### PR TITLE
Bound UI data loading: pagination, caching, graph topN

### DIFF
--- a/packages/ui/app/src/lib/statsCache.ts
+++ b/packages/ui/app/src/lib/statsCache.ts
@@ -1,0 +1,44 @@
+import { apiFetch } from "./api";
+
+export interface MemoryStats {
+  total: number;
+  active: number;
+  superseded: number;
+  byCategory: Record<string, number>;
+  byKind: Record<string, number>;
+}
+
+const TTL_MS = 30_000;
+
+let cached: { data: MemoryStats; expiresAt: number } | null = null;
+let inflight: Promise<MemoryStats> | null = null;
+
+/**
+ * Module-level dedup + TTL cache for /api/memory/stats so the Dashboard and
+ * Memory pages don't double-fetch the (expensive) stats fan-out on simultaneous
+ * mount. Use refresh=true to bust both caches.
+ */
+export async function getStats(refresh = false): Promise<MemoryStats> {
+  if (refresh) {
+    cached = null;
+    inflight = null;
+  }
+  if (cached && cached.expiresAt > Date.now()) return cached.data;
+  if (inflight) return inflight;
+
+  inflight = apiFetch<MemoryStats>(`/api/memory/stats${refresh ? "?refresh=true" : ""}`)
+    .then((data) => {
+      cached = { data, expiresAt: Date.now() + TTL_MS };
+      return data;
+    })
+    .finally(() => {
+      inflight = null;
+    });
+
+  return inflight;
+}
+
+export function clearStatsCache(): void {
+  cached = null;
+  inflight = null;
+}

--- a/packages/ui/app/src/pages/Dashboard.tsx
+++ b/packages/ui/app/src/pages/Dashboard.tsx
@@ -1,16 +1,9 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router";
-import { apiFetch, ApiError } from "../lib/api";
+import { ApiError } from "../lib/api";
+import { getStats, type MemoryStats } from "../lib/statsCache";
 import { CATEGORY_COLORS } from "../lib/format";
 import Badge from "../components/Badge";
-
-interface MemoryStats {
-  total: number;
-  active: number;
-  superseded: number;
-  byCategory: Record<string, number>;
-  byKind: Record<string, number>;
-}
 
 type LoadState<T> = { loading: true } | { loading: false; data: T } | { loading: false; error: string };
 
@@ -51,7 +44,7 @@ export default function Dashboard() {
   const [stats, setStats] = useState<LoadState<MemoryStats>>({ loading: true });
 
   useEffect(() => {
-    apiFetch<MemoryStats>("/api/memory/stats")
+    getStats()
       .then((data) => setStats({ loading: false, data }))
       .catch((e) => {
         const code = e instanceof ApiError ? e.code : undefined;

--- a/packages/ui/app/src/pages/Graph.tsx
+++ b/packages/ui/app/src/pages/Graph.tsx
@@ -31,6 +31,12 @@ interface GraphData {
   nodes: GraphNode[];
   edges: GraphEdge[];
   factCount: number;
+  factsScanned?: number;
+  truncated?: boolean;
+  limit?: number;
+  topN?: number | null;
+  nodesPruned?: number;
+  totalNodes?: number;
 }
 
 interface SharedFact {
@@ -108,7 +114,9 @@ export default function Graph() {
   });
 
   useEffect(() => {
-    apiFetch<GraphData>("/api/memory/graph")
+    // Default cap at top-200 nodes server-side to keep d3-force responsive on
+    // large corpora. Banner below surfaces if the server pruned anything.
+    apiFetch<GraphData>("/api/memory/graph?topN=200")
       .then(setData)
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
@@ -487,6 +495,17 @@ export default function Graph() {
           {data && (
             <p className="text-sm text-zinc-500 mt-1">
               {data.nodes.length} entities · {data.edges.length} connections · {data.factCount} facts
+            </p>
+          )}
+          {data && (data.truncated || (data.nodesPruned ?? 0) > 0) && (
+            <p className="text-xs text-amber-400 mt-1">
+              {data.truncated && `Graph based on first ${data.factsScanned?.toLocaleString() ?? data.factCount} facts (limit ${data.limit?.toLocaleString() ?? "?"}).`}
+              {(data.nodesPruned ?? 0) > 0 && (
+                <>
+                  {data.truncated ? " " : ""}
+                  Showing top {data.nodes.length} of {data.totalNodes?.toLocaleString() ?? "?"} entities by fact count.
+                </>
+              )}
             </p>
           )}
           {loading && <p className="text-sm text-zinc-500 mt-1">Loading graph data…</p>}

--- a/packages/ui/app/src/pages/Memory.tsx
+++ b/packages/ui/app/src/pages/Memory.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { Search, Loader2, Database, ArrowUpDown } from "lucide-react";
 import { apiFetch } from "../lib/api";
+import { getStats, type MemoryStats as Stats } from "../lib/statsCache";
 import FactCard, { type Fact } from "../components/FactCard";
 
 const CATEGORIES = ["infrastructure", "decisions", "observation", "preferences", "projects", "team"];
@@ -13,14 +14,6 @@ const SORT_OPTIONS = [
   { value: "newest", label: "Newest first" },
   { value: "oldest", label: "Oldest first" },
 ];
-
-interface Stats {
-  total: number;
-  active: number;
-  superseded: number;
-  byCategory: Record<string, number>;
-  byKind: Record<string, number>;
-}
 
 interface BrowseResponse {
   results: Fact[];
@@ -56,9 +49,9 @@ export default function Memory() {
   const [stats, setStats] = useState<Stats | null>(null);
   const [error, setError] = useState("");
 
-  // Load stats on mount
+  // Load stats on mount (shared cache → no double fetch with Dashboard)
   useEffect(() => {
-    apiFetch<Stats>("/api/memory/stats").then(setStats).catch(() => {});
+    getStats().then(setStats).catch(() => {});
   }, []);
 
   const buildParams = useCallback(() => {

--- a/packages/ui/app/src/pages/MemoryEntity.tsx
+++ b/packages/ui/app/src/pages/MemoryEntity.tsx
@@ -16,7 +16,15 @@ interface EntityResponse {
   relations: Relation[];
   factCount: number;
   relationCount: number;
+  factsTotal: number | null;
+  relationsTotal: number | null;
+  factsTruncated: boolean;
+  factsNextOffset: string | null;
+  relationsTruncated: boolean;
+  limit: number;
 }
+
+const FACTS_PAGE_SIZE = 50;
 
 export default function MemoryEntity() {
   const { name } = useParams<{ name: string }>();
@@ -24,17 +32,41 @@ export default function MemoryEntity() {
 
   const [data, setData] = useState<EntityResponse | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState("");
 
   useEffect(() => {
     if (!name) return;
     setLoading(true);
     setError("");
-    apiFetch<EntityResponse>(`/api/memory/entities/${encodeURIComponent(name)}`)
+    apiFetch<EntityResponse>(
+      `/api/memory/entities/${encodeURIComponent(name)}?limit=${FACTS_PAGE_SIZE}`,
+    )
       .then(setData)
       .catch((e) => setError(e instanceof ApiError ? e.message : "Failed to load entity"))
       .finally(() => setLoading(false));
   }, [name]);
+
+  const loadMoreFacts = async () => {
+    if (!data || !data.factsNextOffset || !name) return;
+    setLoadingMore(true);
+    try {
+      const more = await apiFetch<EntityResponse>(
+        `/api/memory/entities/${encodeURIComponent(name)}?limit=${FACTS_PAGE_SIZE}&offset=${encodeURIComponent(data.factsNextOffset)}`,
+      );
+      setData({
+        ...data,
+        facts: [...data.facts, ...more.facts],
+        factCount: data.facts.length + more.facts.length,
+        factsTruncated: more.factsTruncated,
+        factsNextOffset: more.factsNextOffset,
+      });
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "Failed to load more facts");
+    } finally {
+      setLoadingMore(false);
+    }
+  };
 
   if (loading) {
     return (
@@ -70,7 +102,13 @@ export default function MemoryEntity() {
           </button>
           <h2 className="text-2xl font-bold">{data.entity}</h2>
           <span className="text-sm text-zinc-500">
-            {data.factCount} facts · {data.relationCount} relations
+            {data.factsTotal !== null && data.factsTotal !== data.factCount
+              ? `${data.factCount} of ${data.factsTotal} facts`
+              : `${data.factCount} facts`}
+            {" · "}
+            {data.relationsTotal !== null && data.relationsTotal !== data.relationCount
+              ? `${data.relationCount} of ${data.relationsTotal} relations`
+              : `${data.relationCount} relations`}
           </span>
         </div>
         <Link
@@ -86,6 +124,11 @@ export default function MemoryEntity() {
         <div className="mb-8">
           <h3 className="text-sm font-semibold text-zinc-400 uppercase tracking-wider mb-3">
             Relations
+            {data.relationsTruncated && (
+              <span className="ml-2 text-xs font-normal text-amber-400 normal-case tracking-normal">
+                (showing first {data.relations.length} — more exist)
+              </span>
+            )}
           </h3>
           <div className="rounded-lg border border-zinc-800 bg-zinc-900 divide-y divide-zinc-800">
             {data.relations.map((r, i) => (
@@ -132,6 +175,16 @@ export default function MemoryEntity() {
                 onClick={() => navigate(`/memory/${fact.id}`)}
               />
             ))}
+            {data.factsTruncated && (
+              <button
+                onClick={loadMoreFacts}
+                disabled={loadingMore}
+                className="w-full mt-3 py-2 text-sm rounded-md border border-zinc-800 bg-zinc-900 hover:bg-zinc-800 text-zinc-300 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+              >
+                {loadingMore && <Loader2 size={14} className="animate-spin" />}
+                {loadingMore ? "Loading…" : `Load more (${data.factsTotal ? data.factsTotal - data.facts.length : "more"})`}
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/packages/ui/src/routes/memory.ts
+++ b/packages/ui/src/routes/memory.ts
@@ -13,6 +13,40 @@ function formatPoint(p: QdrantPoint) {
   return { id: p.id, score: p.score ?? null, ...p.payload };
 }
 
+// --- Query helpers ---
+
+function parseLimit(raw: string | undefined, def: number, max: number): number {
+  const n = parseInt(raw || String(def), 10);
+  if (!Number.isFinite(n) || n <= 0) return def;
+  return Math.min(n, max);
+}
+
+function parseTopN(raw: string | undefined, max: number): number | null {
+  if (!raw) return null;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return Math.min(n, max);
+}
+
+// --- TTL cache (module-scope, per-process) ---
+
+interface CacheEntry<T> { value: T; expiresAt: number; }
+const cache = new Map<string, CacheEntry<unknown>>();
+
+function cacheGet<T>(key: string): T | null {
+  const hit = cache.get(key);
+  if (!hit) return null;
+  if (hit.expiresAt < Date.now()) { cache.delete(key); return null; }
+  return hit.value as T;
+}
+
+function cacheSet<T>(key: string, value: T, ttlMs: number): void {
+  cache.set(key, { value, expiresAt: Date.now() + ttlMs });
+}
+
+const STATS_TTL_MS = 30_000;
+const GRAPH_TTL_MS = 60_000;
+
 // GET /api/memory/search?q=...&category=...&entity=...&domain=...&kind=...&limit=...
 memoryRoutes.get("/search", async (c) => {
   const q = c.req.query("q");
@@ -174,27 +208,39 @@ memoryRoutes.post("/facts", async (c) => {
   return c.json({ ok: true, id }, 201);
 });
 
-// GET /api/memory/entities/:name
+// GET /api/memory/entities/:name?limit=&offset=&relationsLimit=
 memoryRoutes.get("/entities/:name", async (c) => {
   const name = c.req.param("name").toLowerCase();
   const qdrant = createQdrantClient();
 
-  const filter = buildFilter({ entity: name });
-  const { points } = await qdrant.scroll(filter, 50);
+  const limit = parseLimit(c.req.query("limit"), 50, 200);
+  const offset = c.req.query("offset") || undefined;
+  const relationsLimit = parseLimit(c.req.query("relationsLimit"), 50, 200);
 
-  const fromFilter = { must: [
+  const filter = buildFilter({ entity: name });
+  const fromFilter: QdrantFilter = { must: [
     { is_null: { key: "superseded_by" } },
     { key: "from_entity", match: { value: name } },
   ]};
-  const toFilter = { must: [
+  const toFilter: QdrantFilter = { must: [
     { is_null: { key: "superseded_by" } },
     { key: "to_entity", match: { value: name } },
   ]};
 
-  const [fromRels, toRels] = await Promise.all([
-    qdrant.scroll(fromFilter, 50),
-    qdrant.scroll(toFilter, 50),
+  const safeCount = async (f: QdrantFilter) => {
+    try { return await qdrant.count(f); } catch { return null; }
+  };
+
+  const [scroll, fromRels, toRels, factsTotal, fromTotal, toTotal] = await Promise.all([
+    qdrant.scroll(filter, limit, offset),
+    qdrant.scroll(fromFilter, relationsLimit),
+    qdrant.scroll(toFilter, relationsLimit),
+    safeCount(filter),
+    safeCount(fromFilter),
+    safeCount(toFilter),
   ]);
+
+  const { points, nextOffset } = scroll;
 
   const relations = [
     ...fromRels.points.map((p) => ({
@@ -205,19 +251,37 @@ memoryRoutes.get("/entities/:name", async (c) => {
     })),
   ];
 
+  const fromTrunc = fromRels.nextOffset !== null;
+  const toTrunc = toRels.nextOffset !== null;
+  const relationsTotal =
+    fromTotal !== null && toTotal !== null ? fromTotal + toTotal : null;
+
   return c.json({
-    entity: name, facts: points.map(formatPoint), relations,
-    factCount: points.length, relationCount: relations.length,
+    entity: name,
+    facts: points.map(formatPoint),
+    relations,
+    factCount: points.length,
+    relationCount: relations.length,
+    factsTotal,
+    relationsTotal,
+    factsTruncated: nextOffset !== null,
+    factsNextOffset: nextOffset,
+    relationsTruncated: fromTrunc || toTrunc,
+    limit,
+    relationsLimit,
   });
 });
 
-// GET /api/memory/shared?a=...&b=...
+// GET /api/memory/shared?a=...&b=...&limit=&offset=
 memoryRoutes.get("/shared", async (c) => {
   const a = c.req.query("a")?.toLowerCase();
   const b = c.req.query("b")?.toLowerCase();
   if (!a || !b) return c.json({ error: "Missing 'a' and 'b' entity parameters" }, 400);
 
   const qdrant = createQdrantClient();
+  const limit = parseLimit(c.req.query("limit"), 50, 200);
+  const offset = c.req.query("offset") || undefined;
+
   const filter: QdrantFilter = {
     must: [
       { is_null: { key: "superseded_by" } },
@@ -225,21 +289,36 @@ memoryRoutes.get("/shared", async (c) => {
       { key: "entities", match: { value: b } },
     ],
   };
-  const { points } = await qdrant.scroll(filter, 50);
 
-  return c.json({ entityA: a, entityB: b, facts: points.map(formatPoint), count: points.length });
+  const [scroll, total] = await Promise.all([
+    qdrant.scroll(filter, limit, offset),
+    qdrant.count(filter).catch(() => null as number | null),
+  ]);
+
+  return c.json({
+    entityA: a,
+    entityB: b,
+    facts: scroll.points.map(formatPoint),
+    count: scroll.points.length,
+    total,
+    truncated: scroll.nextOffset !== null,
+    nextOffset: scroll.nextOffset,
+    limit,
+  });
 });
 
-// GET /api/memory/relations?entity=...&type=...&direction=...
+// GET /api/memory/relations?entity=...&type=...&direction=...&limit=
 memoryRoutes.get("/relations", async (c) => {
   const entity = c.req.query("entity")?.toLowerCase();
   const relationType = c.req.query("type");
   const direction = c.req.query("direction") || "both";
+  const limit = parseLimit(c.req.query("limit"), 50, 200);
 
   if (!entity) return c.json({ error: "Missing 'entity' parameter" }, 400);
 
   const qdrant = createQdrantClient();
   const results: QdrantPoint[] = [];
+  let truncated = false;
 
   if (direction === "from" || direction === "both") {
     const must: Array<Record<string, unknown>> = [
@@ -247,8 +326,9 @@ memoryRoutes.get("/relations", async (c) => {
       { key: "from_entity", match: { value: entity } },
     ];
     if (relationType) must.push({ key: "relation_type", match: { value: relationType } });
-    const { points } = await qdrant.scroll({ must } as QdrantFilter, 50);
+    const { points, nextOffset } = await qdrant.scroll({ must } as QdrantFilter, limit);
     results.push(...points);
+    if (nextOffset !== null) truncated = true;
   }
 
   if (direction === "to" || direction === "both") {
@@ -257,8 +337,9 @@ memoryRoutes.get("/relations", async (c) => {
       { key: "to_entity", match: { value: entity } },
     ];
     if (relationType) must.push({ key: "relation_type", match: { value: relationType } });
-    const { points } = await qdrant.scroll({ must } as QdrantFilter, 50);
+    const { points, nextOffset } = await qdrant.scroll({ must } as QdrantFilter, limit);
     results.push(...points);
+    if (nextOffset !== null) truncated = true;
   }
 
   const seen = new Set<string>();
@@ -273,13 +354,24 @@ memoryRoutes.get("/relations", async (c) => {
       id: p.id, from: p.payload.from_entity, type: p.payload.relation_type, to: p.payload.to_entity, content: p.payload.content,
     })),
     count: unique.length,
+    truncated,
+    limit,
   });
 });
 
-// GET /api/memory/graph
+// GET /api/memory/graph?limit=&topN=&refresh=
 memoryRoutes.get("/graph", async (c) => {
-  const qdrant = createQdrantClient();
+  const limit = parseLimit(c.req.query("limit"), 2000, 5000);
+  const topN = parseTopN(c.req.query("topN"), 1000);
+  const refresh = c.req.query("refresh") === "true";
 
+  const cacheKey = `graph:limit=${limit}:topN=${topN ?? ""}`;
+  if (!refresh) {
+    const hit = cacheGet<unknown>(cacheKey);
+    if (hit) return c.json(hit);
+  }
+
+  const qdrant = createQdrantClient();
   const allFacts: QdrantPoint[] = [];
   let offset: string | null = null;
   const filter = buildFilter({});
@@ -287,7 +379,10 @@ memoryRoutes.get("/graph", async (c) => {
     const { points, nextOffset } = await qdrant.scroll(filter, 100, offset);
     allFacts.push(...points);
     offset = nextOffset;
-  } while (offset && allFacts.length < 2000);
+  } while (offset && allFacts.length < limit);
+
+  const truncated = offset !== null;
+  const factsScanned = allFacts.length;
 
   const entityStats = new Map<string, { factCount: number; categories: Set<string> }>();
   const edgeMap = new Map<string, { source: string; target: string; weight: number; type: string }>();
@@ -324,19 +419,48 @@ memoryRoutes.get("/graph", async (c) => {
     }
   }
 
-  const nodes = Array.from(entityStats.entries()).map(([id, stat]) => ({
+  let nodes = Array.from(entityStats.entries()).map(([id, stat]) => ({
     id, label: id, factCount: stat.factCount,
     categories: Array.from(stat.categories),
     primaryCategory: Array.from(stat.categories).sort((a, b) => a.localeCompare(b))[0] ?? "infrastructure",
   }));
 
-  return c.json({ nodes, edges: Array.from(edgeMap.values()), factCount: allFacts.length });
+  let edges = Array.from(edgeMap.values());
+  const totalNodes = nodes.length;
+  let nodesPruned = 0;
+
+  if (topN !== null && nodes.length > topN) {
+    nodes = [...nodes].sort((a, b) => b.factCount - a.factCount).slice(0, topN);
+    const keep = new Set(nodes.map((n) => n.id));
+    edges = edges.filter((e) => keep.has(e.source) && keep.has(e.target));
+    nodesPruned = totalNodes - nodes.length;
+  }
+
+  const payload = {
+    nodes,
+    edges,
+    factCount: factsScanned,
+    factsScanned,
+    truncated,
+    limit,
+    topN,
+    nodesPruned,
+    totalNodes,
+  };
+  cacheSet(cacheKey, payload, GRAPH_TTL_MS);
+  return c.json(payload);
 });
 
-// GET /api/memory/stats
+// GET /api/memory/stats?refresh=
 memoryRoutes.get("/stats", async (c) => {
+  const refresh = c.req.query("refresh") === "true";
+  const cacheKey = "stats";
+  if (!refresh) {
+    const hit = cacheGet<unknown>(cacheKey);
+    if (hit) return c.json(hit);
+  }
+
   const qdrant = createQdrantClient();
-  const info = await qdrant.collectionInfo();
 
   // Safe count — returns 0 if filter field lacks a payload index
   const safeCount = async (filter?: QdrantFilter) => {
@@ -344,24 +468,25 @@ memoryRoutes.get("/stats", async (c) => {
   };
 
   const categories = ["infrastructure", "decisions", "observation", "preferences", "projects", "team"];
-  const categoryCounts: Record<string, number> = {};
-  await Promise.all(categories.map(async (cat) => {
-    categoryCounts[cat] = await safeCount(buildFilter({ category: cat }));
-  }));
-
   const kinds = ["fact", "summary", "distilled", "relation"];
-  const kindCounts: Record<string, number> = {};
-  await Promise.all(kinds.map(async (k) => {
-    kindCounts[k] = await safeCount(buildFilter({ kind: k }));
-  }));
 
-  const allCount = await safeCount({ must: [] });
+  // All counts in one Promise.all instead of three sequential awaits.
+  const [info, catCounts, kindCounts, allCount] = await Promise.all([
+    qdrant.collectionInfo(),
+    Promise.all(categories.map(async (cat) => [cat, await safeCount(buildFilter({ category: cat }))] as const)),
+    Promise.all(kinds.map(async (k) => [k, await safeCount(buildFilter({ kind: k }))] as const)),
+    safeCount({ must: [] }),
+  ]);
 
-  return c.json({
-    total: info.points_count, active: allCount,
+  const payload = {
+    total: info.points_count,
+    active: allCount,
     superseded: info.points_count - allCount,
-    byCategory: categoryCounts, byKind: kindCounts,
-  });
+    byCategory: Object.fromEntries(catCounts),
+    byKind: Object.fromEntries(kindCounts),
+  };
+  cacheSet(cacheKey, payload, STATS_TTL_MS);
+  return c.json(payload);
 });
 
 async function hashContent(content: string): Promise<string> {


### PR DESCRIPTION
## Summary

Closes #6. Bounds the bikky UI's data loading so it scales past a few thousand facts without silent truncation, redundant fan-out, or graph jank.

### Tier A — Truncation honesty + cursor pagination
- `/entities/:name`: `?limit` (cap 200), `?offset`. Returns `factsTotal` / `relationsTotal` (via `count`), `factsTruncated`, `factsNextOffset`, `relationsTruncated`.
- `/shared`: `?limit` (cap 200), `?offset`. Returns `total`, `truncated`, `nextOffset`.
- `/relations`: `?limit` (cap 200) per direction. Returns `truncated`.
- `MemoryEntity` page: shows "X of Y facts/relations" when totals are known, "Load more" for facts, "more exist" hint when relations cap hit.

### Tier B — Stats cache + dedup
- `/stats`: module-level TTL cache (30s) with `?refresh=true` to bust. Single `Promise.all` over collectionInfo + categories + kinds + active.
- `app/src/lib/statsCache.ts` (new): client-side TTL cache + in-flight promise dedup. Dashboard and Memory share one fetch on simultaneous mount.

### Tier C — Graph survives 10k+ facts
- `/graph`: `?limit` (cap 5000), `?topN` (cap 1000) for server-side prune by `factCount`, `?refresh=true` to bust the 60s TTL cache. Returns `factsScanned`, `truncated`, `nodesPruned`, `totalNodes`.
- `Graph` page: defaults to `?topN=200`; banner surfaces when server reports truncation or pruning.

## Verification

```
$ npm run typecheck && npm run build      # root: clean
$ cd packages/ui && npm run build         # tsc + vite: clean (293.63 kB / 91.97 kB gz)
$ node --test 'dist/**/*.test.js'         # 231/233 pass; 2 failures pre-existing (prompts.test.js / render.test.js, taxonomy export missing — see backlog)
```

## Backwards compatibility

All new query params have safe defaults that preserve prior request shapes. Response shapes are additive — existing fields (`facts`, `relations`, `nodes`, `edges`, `factCount`, etc.) are unchanged. The Graph page now defaults `topN=200`, which changes rendered output for large corpora but the new banner makes pruning visible.

## Out of scope (logged in agent00 task backlog)

- Migrate UI to shared `QdrantClient` from PR #5 (`src/lib/qdrant-client.ts`).
- HTTP `Cache-Control`/`ETag` headers on read endpoints.
- Browse list virtualisation.
- Graph filter UI controls (date / category / topN slider).
- Search load-more cap-honesty banner.
