### PR TITLE
feat: add daemon capture ontology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# bikky
+<p align="center">
+  <img src="assets/bikky-tp.png" alt="bikky logo" width="180" />
+</p>
 
-**Shared persistent memory for AI coding agents.**
+<h1 align="center">bikky</h1>
 
-bikky gives your team's AI agents (GitHub Copilot, Claude Code) long-term memory that persists across sessions and is shared across team members. What one engineer's agent learns today, every agent on the team knows tomorrow.
+<p align="center"><b>Shared persistent memory for AI coding agents.</b></p>
+
+bikky gives your team's AI agents (GitHub Copilot, Claude Code, Cursor, Codex, and other MCP clients) long-term memory that persists across sessions and is shared across team members. It helps software factories become queryable organizations: what one engineer's agent learns today, every agent on the team knows tomorrow through a closed-loop memory system.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/bikky-dev/bikky/main/docs/diagrams/team-memory.svg" alt="Team memory — facts flow from individual sessions into a shared, self-curating knowledge store" width="720" />
@@ -49,7 +53,7 @@ echo '{ "qdrant_url": "https://…:6333", "qdrant_api_key": "…" }' > ~/.bikky/
 export QDRANT_URL="https://…:6333" QDRANT_API_KEY="…"
 ```
 
-Restart your editor — 12 memory tools appear automatically.
+Restart your editor — memory tools appear automatically.
 
 > 📖 Full configuration reference (providers, models, daemon settings): **[docs/configuration.md](docs/configuration.md)**
 >
@@ -65,9 +69,9 @@ Restart your editor — 12 memory tools appear automatically.
 
 **MCP Server** — tools your agent calls directly:
 
-`memory_store` · `memory_recall` · `memory_entity` · `memory_relations` · `memory_forget` · `memory_verify` · `memory_session_summary` · `memory_distill` · `memory_heartbeat` · `memory_review` · `configure_credentials` · `verify_connection`
+`memory_store` · `memory_recall` · `memory_entity` · `memory_relations` · `memory_forget` · `memory_verify` · `memory_heartbeat` · `memory_review` · `configure_credentials` · `verify_connection`
 
-**Daemon** — background process that passively watches session logs, extracts facts via LLM, infers entity relationships, and runs the consolidation pipeline (distillation, contradiction detection, staleness scanning).
+**Daemon** — background process that passively watches session logs, extracts ontology-v2 facts, writes lightweight session indexes, captures coherent episode summaries, updates current-state workstream summaries, infers entity relationships, and runs the consolidation pipeline. Lifecycle memory is daemon-owned so agents do not need to remember summary/distillation tool calls.
 
 ---
 
@@ -76,6 +80,7 @@ Restart your editor — 12 memory tools appear automatically.
 Raw fact accumulation creates noise. bikky keeps the knowledge store clean automatically:
 
 - **Deduplication** — content hash + vector similarity merges near-identical facts
+- **Ontology scope fields** — optional `workspace_id`, repo, workstream, and episode metadata make recall more precise
 - **Confidence decay** — old facts lose weight and surface for review
 - **Contradiction detection** — conflicting facts are resolved, not silently stacked
 - **Distillation** — recurring patterns across sessions consolidate into higher-level insights
@@ -92,7 +97,7 @@ Raw fact accumulation creates noise. bikky keeps the knowledge store clean autom
 
 ## Web UI
 
-[`bikky-ui`](packages/ui) is a local dashboard for browsing and managing your team's memory — facts, entities, and the relationship graph.
+[`bikky-ui`](packages/ui) is a local dashboard for browsing and managing your team's memory — facts, entities, quality metrics, aggregate impact insights, and the relationship graph.
 
 ```bash
 npx bikky-ui          # one-shot — no install needed
@@ -125,7 +130,10 @@ bikky mcp       # start MCP server (stdio) — used by editors
 bikky setup     # interactive setup wizard
 bikky status    # check memory system health
 bikky install   # write MCP config for Copilot + Claude Code
+bikky templates # print config snippets for Copilot, Claude Code, Cursor, and Codex
 ```
+
+See **[docs/integrations.md](docs/integrations.md)** for copy-paste MCP templates.
 
 ## License
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,10 @@ Config lives at `~/.bikky/config.json`. Resolution order: **defaults → config 
 | `qdrant_api_key` | `QDRANT_API_KEY` | *none — must be set* | Qdrant API key from cluster dashboard |
 | `collection` | `BIKKY_COLLECTION` | `bikky` | Collection name. Change only if running multiple instances |
 
+## Ontology scope fields
+
+Bikky's ontology includes optional scope payload fields such as `workspace_id`, `repo`, `branch`, `task_key`, `workstream_key`, and `episode_id`. These fields can be supplied through MCP calls or daemon-generated records where available; task 243 does not add workspace, redaction, or telemetry configuration sections.
+
 ## Embedding & LLM providers
 
 Both `embedding.provider` and `llm.provider` accept exactly one of three values:
@@ -119,14 +123,38 @@ Both `embedding.provider` and `llm.provider` accept exactly one of three values:
 
 ## Daemon settings
 
+The daemon owns memory lifecycle work: it extracts ontology-v2 facts, writes lightweight session indexes, captures coherent episode summaries, and distills longer-lived patterns when consolidation is enabled.
+
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `daemon.tick_interval_sec` | `5` | Seconds between daemon loop ticks |
 | `daemon.extract_every_sec` | `300` | Seconds between extraction runs |
-| `daemon.extract_min_events` | `5` | Minimum session events before triggering extraction |
-| `daemon.consolidation_enabled` | `true` | Auto-distill session summaries into patterns |
+| `daemon.extract_min_events` | `10` | Minimum session events before triggering extraction |
+| `daemon.consolidation_enabled` | `true` | Auto-distill daemon-generated session summaries into patterns |
 | `daemon.relation_inference_enabled` | `true` | Infer entity relationships via LLM |
 | `daemon.staleness_threshold_days` | `30` | Days before a fact is flagged as stale |
+
+## Memory ontology
+
+New daemon captures use ontology v2:
+
+```text
+workspace -> domain -> repo/project/surface -> workstream -> episode -> memory objects
+```
+
+`domain` is an activity/knowledge profile, not a work/personal flag. The initial canonical domains are:
+
+| Domain | Purpose |
+|--------|---------|
+| `software_engineering` | Default for coding-agent captures: repos, code, infrastructure, releases, incidents |
+| `product_strategy` | Roadmap, positioning, experiments, customer insight, product decisions |
+| `business_operations` | Company processes, vendors, compliance, obligations, recurring workflows |
+| `research` | Source-backed investigation, hypotheses, contradictions, synthesis |
+| `personal_productivity` | Individual goals, routines, preferences, projects, habits |
+
+For `software_engineering`, canonical categories are `codebase`, `infrastructure`, `operations`, `decisions`, `product_domain`, `projects`, `people`, `preferences`, and `observations`.
+
+`kind` stays small (`fact`, `summary`, `distilled`, `relation`, `telemetry`). More specific shape lives in `memory_subtype`, such as `codebase_map`, `architecture_decision`, `episode`, `workstream`, or `failure_mode`.
 
 ## Watcher settings
 
@@ -136,3 +164,7 @@ Both `embedding.provider` and `llm.provider` accept exactly one of three values:
 | `watchers.copilot.path` | `~/.copilot/session-state` | Path to Copilot session directory |
 | `watchers.claude.enabled` | `false` | Watch Claude Code project logs |
 | `watchers.claude.path` | `~/.claude/projects` | Path to Claude Code projects directory |
+
+## Agent integration templates
+
+Run `bikky templates` to print all MCP client snippets, or `bikky templates cursor` / `bikky templates codex` for one target. See [docs/integrations.md](integrations.md).

--- a/src/daemon/capture-policy.test.ts
+++ b/src/daemon/capture-policy.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  CAPTURE_BUDGETS,
+  CAPTURE_KIND_SUBTYPES,
+  CAPTURE_POLICY_VERSION,
+  CAPTURE_TRIGGERS,
+  DEFAULT_CAPTURE_CONTEXT,
+  PROMPT_VERSIONS,
+  QUALITY_THRESHOLDS,
+  promptVersionForSubtype,
+  subtypeForCategory,
+} from "./capture-policy.js";
+
+describe("daemon/capture-policy", () => {
+  it("uses ontology v2 and software_engineering defaults", () => {
+    assert.strictEqual(CAPTURE_POLICY_VERSION, "capture-policy-v2");
+    assert.strictEqual(DEFAULT_CAPTURE_CONTEXT.domain, "software_engineering");
+    assert.strictEqual(DEFAULT_CAPTURE_CONTEXT.source, "daemon");
+    assert.strictEqual(DEFAULT_CAPTURE_CONTEXT.reviewStatus, "candidate");
+  });
+
+  it("keeps fact extraction cadence aligned with config defaults", () => {
+    assert.strictEqual(CAPTURE_TRIGGERS.factExtraction.minEvents, 10);
+    assert.strictEqual(CAPTURE_TRIGGERS.factExtraction.cooldownSeconds, 300);
+    assert.ok(CAPTURE_TRIGGERS.factExtraction.maxEventsPerBatch > CAPTURE_TRIGGERS.factExtraction.minEvents);
+  });
+
+  it("defines bounded budgets for every first-slice object", () => {
+    assert.ok(CAPTURE_BUDGETS.fact.maxFactsPerBatch > 0);
+    assert.ok(CAPTURE_BUDGETS.episodeSummary.targetWords[0] < CAPTURE_BUDGETS.episodeSummary.targetWords[1]);
+    assert.ok(CAPTURE_BUDGETS.workstreamSummary.targetWords[0] < CAPTURE_BUDGETS.workstreamSummary.targetWords[1]);
+    assert.ok(CAPTURE_BUDGETS.distilled.maxSourceRefs > 0);
+  });
+
+  it("maps each capture kind to approved subtypes", () => {
+    assert.ok(CAPTURE_KIND_SUBTYPES.fact?.includes("codebase_map"));
+    assert.ok(CAPTURE_KIND_SUBTYPES.summary?.includes("episode"));
+    assert.ok(CAPTURE_KIND_SUBTYPES.distilled?.includes("convention"));
+  });
+
+  it("maps categories to deterministic default fact subtypes", () => {
+    assert.strictEqual(subtypeForCategory("codebase"), "codebase_map");
+    assert.strictEqual(subtypeForCategory("infrastructure"), "infra_topology");
+    assert.strictEqual(subtypeForCategory("people"), "ownership");
+    assert.strictEqual(subtypeForCategory("preferences"), "preference");
+  });
+
+  it("selects prompt versions by subtype lifecycle", () => {
+    assert.strictEqual(promptVersionForSubtype("codebase_map"), PROMPT_VERSIONS.factExtraction);
+    assert.strictEqual(promptVersionForSubtype("session_index"), PROMPT_VERSIONS.sessionIndex);
+    assert.strictEqual(promptVersionForSubtype("episode"), PROMPT_VERSIONS.episodeSummary);
+    assert.strictEqual(promptVersionForSubtype("workstream"), PROMPT_VERSIONS.workstreamSummary);
+    assert.strictEqual(promptVersionForSubtype("convention"), PROMPT_VERSIONS.distillation);
+  });
+
+  it("sets quality thresholds that reject weak daemon memories", () => {
+    assert.ok(QUALITY_THRESHOLDS.minFactConfidence > 0.5);
+    assert.ok(QUALITY_THRESHOLDS.minFactQualityScore > 0.5);
+    assert.strictEqual(QUALITY_THRESHOLDS.rejectStatusOnlyFacts, true);
+  });
+});

--- a/src/daemon/capture-policy.ts
+++ b/src/daemon/capture-policy.ts
@@ -1,0 +1,149 @@
+/**
+ * Daemon-owned capture policy for ontology v2.
+ *
+ * These constants define when Bikky should capture memory, how large each
+ * generated object should be, and which prompt/capture versions are stored on
+ * payloads for later audits and prompt evolution.
+ */
+
+import type { Category, Kind, MemorySubtype } from "../mcp/taxonomy.js";
+import { DEFAULT_DOMAIN } from "../mcp/taxonomy.js";
+
+export const CAPTURE_POLICY_VERSION = "capture-policy-v2";
+
+export const PROMPT_VERSIONS = {
+  factExtraction: "fact-extraction-v2",
+  sessionIndex: "session-index-v1",
+  episodeSummary: "episode-summary-v1",
+  workstreamSummary: "workstream-summary-v1",
+  distillation: "distillation-v1",
+} as const;
+
+export const CAPTURE_TRIGGERS = {
+  factExtraction: {
+    minEvents: 10,
+    minUsefulCharacters: 280,
+    maxEventsPerBatch: 120,
+    cooldownSeconds: 300,
+  },
+  episodeSummary: {
+    minEvents: 12,
+    minUsefulCharacters: 600,
+    maxEventsPerEpisode: 80,
+    idleGapMinutes: 20,
+    forceCheckpointEvents: 140,
+  },
+  sessionIndex: {
+    minEvents: 1,
+    forceCheckpointEvents: 140,
+    maxRecentEpisodeRefs: 12,
+  },
+  workstreamSummary: {
+    minEpisodeCount: 1,
+    minConfidence: 0.65,
+    maxEpisodesPerUpdate: 8,
+  },
+  distillation: {
+    minSourceSummaries: 5,
+    maxSourceSummaries: 20,
+    lookbackDays: 14,
+  },
+} as const;
+
+export const CAPTURE_BUDGETS = {
+  fact: {
+    maxFactsPerBatch: 6,
+    targetWords: [12, 45],
+    maxEntities: 8,
+  },
+  episodeSummary: {
+    targetWords: [90, 180],
+    maxTasks: 8,
+    maxDecisions: 8,
+    maxOpenQuestions: 6,
+  },
+  sessionIndex: {
+    targetWords: [30, 80],
+    maxEpisodeRefs: 12,
+  },
+  workstreamSummary: {
+    targetWords: [120, 240],
+    maxCurrentDecisions: 8,
+    maxNextSteps: 8,
+    maxBlockers: 6,
+  },
+  distilled: {
+    targetWords: [60, 160],
+    maxSourceRefs: 12,
+  },
+} as const;
+
+export const QUALITY_THRESHOLDS = {
+  minFactConfidence: 0.55,
+  minFactQualityScore: 0.6,
+  minImportanceForLowConfidenceFact: 0.75,
+  rejectStatusOnlyFacts: true,
+  rejectDuplicatedTranscriptNarration: true,
+} as const;
+
+export const CAPTURE_KIND_SUBTYPES = {
+  fact: [
+    "codebase_map",
+    "architecture_decision",
+    "infra_topology",
+    "access_pattern",
+    "deployment_procedure",
+    "operational_procedure",
+    "domain_rule",
+    "troubleshooting_gotcha",
+    "preference",
+    "ownership",
+  ],
+  summary: ["session_index", "episode", "workstream"],
+  distilled: [
+    "runbook_candidate",
+    "failure_mode",
+    "convention",
+    "architecture_pattern",
+    "product_insight",
+  ],
+} as const satisfies Partial<Record<Kind, readonly MemorySubtype[]>>;
+
+export const FACT_CATEGORY_TO_SUBTYPE: Record<Category, MemorySubtype> = {
+  codebase: "codebase_map",
+  infrastructure: "infra_topology",
+  operations: "operational_procedure",
+  decisions: "architecture_decision",
+  product_domain: "domain_rule",
+  projects: "codebase_map",
+  people: "ownership",
+  preferences: "preference",
+  observations: "troubleshooting_gotcha",
+};
+
+export const DEFAULT_CAPTURE_CONTEXT = {
+  domain: DEFAULT_DOMAIN,
+  source: "daemon",
+  reviewStatus: "candidate",
+  volatility: "medium",
+} as const;
+
+export function promptVersionForSubtype(subtype: MemorySubtype): string {
+  if (subtype === "session_index") return PROMPT_VERSIONS.sessionIndex;
+  if (subtype === "episode") return PROMPT_VERSIONS.episodeSummary;
+  if (subtype === "workstream") return PROMPT_VERSIONS.workstreamSummary;
+  if (
+    subtype === "runbook_candidate" ||
+    subtype === "failure_mode" ||
+    subtype === "convention" ||
+    subtype === "architecture_pattern" ||
+    subtype === "product_insight"
+  ) {
+    return PROMPT_VERSIONS.distillation;
+  }
+  return PROMPT_VERSIONS.factExtraction;
+}
+
+export function subtypeForCategory(category: Category): MemorySubtype {
+  return FACT_CATEGORY_TO_SUBTYPE[category];
+}

--- a/src/daemon/episode-summary.test.ts
+++ b/src/daemon/episode-summary.test.ts
@@ -1,0 +1,125 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildEpisodeSummaryFilter,
+  buildEpisodeSummaryMessages,
+  buildEpisodeSummaryPayload,
+  parseEpisodeSummaryDraft,
+  segmentTranscriptIntoEpisodes,
+} from "./episode-summary.js";
+
+interface WorkspaceScope { workspaceId?: string; actorId?: string; includeLegacy?: boolean }
+
+const defaultScope: WorkspaceScope = {
+  workspaceId: "default",
+  includeLegacy: true,
+};
+
+describe("daemon/episode-summary", () => {
+  it("segments two unrelated user tasks in one session into two episodes", () => {
+    const transcript = `[USER] Implement ontology v2 in src/mcp/taxonomy.ts and add tests.
+
+[ASSISTANT] Updated src/mcp/taxonomy.ts with software_engineering domains and memory_subtype validation. Ran npm test for taxonomy.
+
+[USER] Now fix the UI smoke tests in packages/ui/tests/smoke.spec.ts.
+
+[ASSISTANT] Updated packages/ui/tests/smoke.spec.ts to cover browse filters and ran npm run test:e2e.`;
+
+    const segments = segmentTranscriptIntoEpisodes({
+      sessionId: "uuid:test-session",
+      transcript,
+      eventCount: 14,
+    });
+
+    assert.equal(segments.length, 2);
+    assert.match(segments[0].episode_id, /^uuid:test-session:episode:/);
+    assert.match(segments[0].transcript, /ontology v2/);
+    assert.match(segments[1].transcript, /UI smoke tests/);
+  });
+
+  it("does not create episodes for small irrelevant batches", () => {
+    const segments = segmentTranscriptIntoEpisodes({
+      sessionId: "uuid:test-session",
+      transcript: "[USER] ok\n\n[ASSISTANT] done",
+      eventCount: 2,
+    });
+    assert.deepEqual(segments, []);
+  });
+
+  it("builds episode summary prompts", () => {
+    const messages = buildEpisodeSummaryMessages({
+      transcript: "[USER] update src/daemon/extraction.ts",
+    });
+    assert.match(messages[0].content, /one coherent work episode/);
+    assert.match(messages[1].content, /workstream_key/);
+  });
+
+  it("parses episode summary drafts", () => {
+    const draft = parseEpisodeSummaryDraft(`\`\`\`json
+{
+  "content": "Implemented ontology v2 extraction for src/daemon/extraction.ts.",
+  "tasks_completed": ["ontology extraction"],
+  "decisions_made": ["Use memory_subtype on daemon facts"],
+  "open_questions": ["wire workstream summaries"],
+  "entities": ["Bikky", "src/daemon/extraction.ts"],
+  "workstream_key": "243-bikky-data-capture-policy",
+  "importance": 0.9
+}
+\`\`\``);
+
+    assert.equal(draft.content, "Implemented ontology v2 extraction for src/daemon/extraction.ts.");
+    assert.deepEqual(draft.entities, ["bikky", "src/daemon/extraction.ts"]);
+    assert.equal(draft.workstream_key, "243-bikky-data-capture-policy");
+  });
+
+  it("builds episode filters scoped to workspace and subtype", () => {
+    const filter = buildEpisodeSummaryFilter("episode-1", defaultScope);
+    assert.ok((filter.must as unknown[]).some((condition) =>
+      JSON.stringify(condition) === JSON.stringify({ key: "memory_subtype", match: { value: "episode" } }),
+    ));
+    assert.deepEqual(filter.should, [
+      { key: "workspace_id", match: { value: "default" } },
+      { is_empty: { key: "workspace_id" } },
+    ]);
+  });
+
+  it("omits workspace filters when no workspace is supplied", () => {
+    const filter = buildEpisodeSummaryFilter("episode-1", {});
+    assert.equal(filter.should, undefined);
+    assert.equal((filter.must as unknown[]).some((condition) =>
+      JSON.stringify(condition).includes("workspace_id"),
+    ), false);
+  });
+
+  it("builds ontology-v2 episode payloads", () => {
+    const { payload } = buildEpisodeSummaryPayload({
+      draft: {
+        content: "Implemented daemon episode summaries for src/daemon/episode-summary.ts.",
+        tasks_completed: ["episode summaries"],
+        decisions_made: ["Use episode summaries instead of one evolving session summary"],
+        open_questions: ["workstream updater"],
+        entities: ["bikky", "src/daemon/episode-summary.ts"],
+        workstream_key: "243-bikky-data-capture-policy",
+        importance: 0.85,
+      },
+      segment: {
+        episode_id: "episode-1",
+        ordinal: 0,
+        transcript: "[USER] implement episodes",
+        event_count: 8,
+      },
+      sessionId: "uuid:test-session",
+      scope: { workspaceId: "team-a", actorId: "agent-1", includeLegacy: false },
+      now: "2026-04-25T12:00:00.000Z",
+      redactionOptions: { enabled: true, redactPii: true },
+    });
+
+    assert.equal(payload.kind, "summary");
+    assert.equal(payload.memory_subtype, "episode");
+    assert.equal(payload.domain, "software_engineering");
+    assert.equal(payload.episode_id, "episode-1");
+    assert.equal(payload.workstream_key, "243-bikky-data-capture-policy");
+    assert.equal((payload.metadata as Record<string, string>).summary_subtype, "episode");
+  });
+});

--- a/src/daemon/episode-summary.ts
+++ b/src/daemon/episode-summary.ts
@@ -1,0 +1,341 @@
+/**
+ * Episode summaries.
+ *
+ * A session can contain multiple unrelated tasks. Episodes are coherent task
+ * segments inside the session and are the summary unit that feeds durable
+ * workstream memory.
+ */
+import { createHash, randomUUID } from "node:crypto";
+
+import type { BikkyConfig } from "../config.js";
+import { chatCompletion } from "../llm/index.js";
+import { normalizeEntities } from "../mcp/taxonomy.js";
+import {
+  CAPTURE_BUDGETS,
+  CAPTURE_POLICY_VERSION,
+  CAPTURE_TRIGGERS,
+  DEFAULT_CAPTURE_CONTEXT,
+  PROMPT_VERSIONS,
+} from "./capture-policy.js";
+import * as qdrant from "./qdrant.js";
+import type { QdrantPayload } from "./qdrant.js";
+
+export interface WorkspaceScope {
+  workspaceId?: string;
+  actorId?: string;
+  includeLegacy?: boolean;
+}
+
+export interface RedactionSummary {
+  redacted: boolean;
+  summary: string;
+  matches: Array<{ type: string; count: number }>;
+}
+
+const noRedaction = (): RedactionSummary => ({ redacted: false, summary: "none", matches: [] });
+const passthroughText = (text: string, _options?: { enabled: boolean; redactPii: boolean }): { text: string; redacted: boolean; summary: string; matches: Array<{ type: string; count: number }> } => ({
+  text,
+  ...noRedaction(),
+});
+const combinePassThrough = (): RedactionSummary => noRedaction();
+
+export interface EpisodeSegment {
+  episode_id: string;
+  ordinal: number;
+  transcript: string;
+  event_count: number;
+  workstream_key?: string | null;
+}
+
+export interface EpisodeSummaryDraft {
+  content: string;
+  tasks_completed: string[];
+  decisions_made: string[];
+  open_questions: string[];
+  entities: string[];
+  workstream_key?: string | null;
+  importance: number;
+}
+
+export interface EpisodeSummaryPayloadResult {
+  payload: Record<string, unknown>;
+  redaction: RedactionSummary;
+}
+
+export interface EpisodeSummaryWriteResult {
+  action: "stored" | "updated" | "skipped";
+  factId?: string;
+  episodeId?: string;
+  workstreamKey?: string | null;
+  reason?: string;
+}
+
+const DEFAULT_EPISODE_IMPORTANCE = 0.75;
+
+const contentHash = (text: string): string =>
+  createHash("sha256").update(`episode:${text}`).digest("hex");
+
+const stableHash = (text: string): string =>
+  createHash("sha256").update(text).digest("hex").slice(0, 12);
+
+const stripJsonFence = (raw: string): string =>
+  raw.trim().replace(/^```(?:json)?\s*\n?/, "").replace(/\n?```\s*$/, "").trim();
+
+const normalizeStringArray = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter(Boolean))];
+};
+
+const clampImportance = (value: unknown): number => {
+  if (typeof value !== "number" || Number.isNaN(value)) return DEFAULT_EPISODE_IMPORTANCE;
+  return Math.min(1, Math.max(0.5, value));
+};
+
+const likelyUsefulEpisode = (text: string): boolean => {
+  const trimmed = text.trim();
+  if (trimmed.length >= CAPTURE_TRIGGERS.episodeSummary.minUsefulCharacters) return true;
+  return Boolean(
+    /\b(?:decide|decided|implement|implemented|update|updated|fix|fixed|root cause|because|prefer|use|run|ran|command|error|fails|passes)\b/i.test(trimmed) &&
+    /(?:`[^`]+`|(?:[\w.-]+\/)+[\w./-]+|\b(?:npm|git|gh|docker|kubectl|make|python|go|cargo|curl)\b|#\d+)/i.test(trimmed),
+  );
+};
+
+export const segmentTranscriptIntoEpisodes = (input: {
+  sessionId: string;
+  transcript: string;
+  eventCount: number;
+}): EpisodeSegment[] => {
+  const transcript = input.transcript.trim();
+  if (!transcript) return [];
+
+  const chunks: string[] = [];
+  let current: string[] = [];
+  for (const block of transcript.split(/\n{2,}/)) {
+    if (/^\[USER\]/.test(block) && current.length > 0) {
+      chunks.push(current.join("\n\n").trim());
+      current = [];
+    }
+    current.push(block);
+  }
+  if (current.length > 0) chunks.push(current.join("\n\n").trim());
+
+  const candidateChunks = chunks.length > 0 ? chunks : [transcript];
+  const eventCountPerChunk = Math.max(1, Math.round(input.eventCount / candidateChunks.length));
+
+  return candidateChunks
+    .map((chunk, index) => ({ chunk, index }))
+    .filter(({ chunk }) => likelyUsefulEpisode(chunk))
+    .map(({ chunk, index }) => ({
+      episode_id: `${input.sessionId}:episode:${stableHash(`${input.sessionId}:${index}:${chunk}`)}`,
+      ordinal: index,
+      transcript: chunk,
+      event_count: eventCountPerChunk,
+    }));
+};
+
+export const buildEpisodeSummaryMessages = (input: {
+  transcript: string;
+}): Array<{ role: "system" | "user"; content: string }> => [
+  {
+    role: "system",
+    content:
+      "You are Bikky's background memory daemon. Summarize one coherent work episode, not the whole session. " +
+      "Preserve durable current state: task goal, files/surfaces touched, important commands, decisions, failures, validation, and open follow-ups. " +
+      "Do not include chat narration. Output only valid JSON.",
+  },
+  {
+    role: "user",
+    content: `Summarize this episode as durable memory for a future coding agent.
+
+## Episode transcript
+${input.transcript}
+
+## Output JSON shape
+{
+  "content": "${CAPTURE_BUDGETS.episodeSummary.targetWords[0]}-${CAPTURE_BUDGETS.episodeSummary.targetWords[1]} words, self-contained current-state summary",
+  "tasks_completed": ["short task or milestone labels"],
+  "decisions_made": ["decision with rationale if present"],
+  "open_questions": ["blockers or follow-ups if present"],
+  "entities": ["lowercase key repos/services/files/tools"],
+  "workstream_key": "stable task/project key when explicit, otherwise null",
+  "importance": 0.75
+}
+
+Return only the JSON object.`,
+  },
+];
+
+export const parseEpisodeSummaryDraft = (raw: string): EpisodeSummaryDraft => {
+  const parsed = JSON.parse(stripJsonFence(raw)) as Record<string, unknown>;
+  const contentValue = parsed.content ?? parsed.summary;
+  if (typeof contentValue !== "string" || !contentValue.trim()) {
+    throw new Error("Episode summary response missing non-empty content");
+  }
+
+  return {
+    content: contentValue.trim(),
+    tasks_completed: normalizeStringArray(parsed.tasks_completed ?? parsed.tasks),
+    decisions_made: normalizeStringArray(parsed.decisions_made ?? parsed.decisions),
+    open_questions: normalizeStringArray(parsed.open_questions ?? parsed.follow_ups),
+    entities: normalizeEntities(normalizeStringArray(parsed.entities)),
+    workstream_key: typeof parsed.workstream_key === "string" && parsed.workstream_key.trim()
+      ? parsed.workstream_key.trim()
+      : null,
+    importance: clampImportance(parsed.importance),
+  };
+};
+
+export const buildEpisodeSummaryFilter = (
+  episodeId: string,
+  scope: WorkspaceScope,
+): Record<string, unknown> => {
+  const must: Record<string, unknown>[] = [
+    { key: "episode_id", match: { value: episodeId } },
+    { key: "kind", match: { value: "summary" } },
+    { key: "memory_subtype", match: { value: "episode" } },
+    { is_null: { key: "superseded_by" } },
+  ];
+  const filter: Record<string, unknown> = { must };
+  if (scope.workspaceId && scope.includeLegacy) {
+    filter["should"] = [
+      { key: "workspace_id", match: { value: scope.workspaceId } },
+      { is_empty: { key: "workspace_id" } },
+    ];
+  } else if (scope.workspaceId) {
+    must.push({ key: "workspace_id", match: { value: scope.workspaceId } });
+  }
+  return filter;
+};
+
+export const buildEpisodeSummaryPayload = (input: {
+  draft: EpisodeSummaryDraft;
+  segment: EpisodeSegment;
+  sessionId: string;
+  scope: WorkspaceScope;
+  now: string;
+  existing?: { id: string; payload?: Partial<QdrantPayload> } | null;
+  redactionOptions: { enabled: boolean; redactPii: boolean };
+}): EpisodeSummaryPayloadResult => {
+  const redactedContent = passthroughText(input.draft.content, input.redactionOptions);
+  const redactedTasks = input.draft.tasks_completed.map((task) => passthroughText(task, input.redactionOptions));
+  const redactedDecisions = input.draft.decisions_made.map((decision) => passthroughText(decision, input.redactionOptions));
+  const redactedOpenQuestions = input.draft.open_questions.map((question) => passthroughText(question, input.redactionOptions));
+  const redactedEntities = input.draft.entities.map((entity) => passthroughText(entity, input.redactionOptions));
+  const redaction = combinePassThrough();
+  const existingPayload = input.existing?.payload ?? {};
+  const workstreamKey = input.draft.workstream_key ?? input.segment.workstream_key ?? null;
+
+  const payload: Record<string, unknown> = {
+    ...existingPayload,
+    content: redactedContent.text,
+    category: "projects",
+    domain: DEFAULT_CAPTURE_CONTEXT.domain,
+    kind: "summary",
+    memory_subtype: "episode",
+    layer: "episode",
+    ...(input.scope.workspaceId ? { workspace_id: input.scope.workspaceId } : {}),
+    ...(input.scope.actorId ? { actor_id: input.scope.actorId } : {}),
+    entities: redactedEntities.map((entity) => entity.text.toLowerCase()),
+    source: "system",
+    confidence: 1.0,
+    importance: input.draft.importance,
+    content_hash: contentHash(redactedContent.text),
+    reinforcement_count: existingPayload.reinforcement_count ?? 1,
+    last_reinforced_at: existingPayload.last_reinforced_at ?? input.now,
+    superseded_by: null,
+    superseded_at: null,
+    created_at: existingPayload.created_at ?? input.now,
+    updated_at: input.now,
+    session_id: input.sessionId,
+    episode_id: input.segment.episode_id,
+    ...(workstreamKey ? { workstream_key: workstreamKey } : {}),
+    prompt_version: PROMPT_VERSIONS.episodeSummary,
+    capture_policy_version: CAPTURE_POLICY_VERSION,
+    review_status: DEFAULT_CAPTURE_CONTEXT.reviewStatus,
+    tasks_completed: redactedTasks.map((task) => task.text),
+    decisions_made: redactedDecisions.map((decision) => decision.text),
+    open_questions: redactedOpenQuestions.map((question) => question.text),
+    metadata: {
+      ...(existingPayload.metadata ?? {}),
+      summary_source: "daemon",
+      summary_subtype: "episode",
+      summarized_from_session: input.sessionId,
+      episode_id: input.segment.episode_id,
+      episode_event_count: String(input.segment.event_count),
+      summary_updated_at: input.now,
+    },
+  };
+
+  if (redaction.redacted) {
+    payload["redaction"] = redaction;
+  }
+
+  return { payload, redaction };
+};
+
+const summarizeEpisodeTranscript = async (transcript: string): Promise<EpisodeSummaryDraft> => {
+  const result = await chatCompletion({
+    messages: buildEpisodeSummaryMessages({ transcript }),
+    temperature: 0.2,
+    max_tokens: 1500,
+    response_format: { type: "json_object" },
+  });
+  if (!result) throw new Error("Episode summary LLM returned null");
+  return parseEpisodeSummaryDraft(result);
+};
+
+const findExistingEpisodeSummary = async (
+  episodeId: string,
+  scope: WorkspaceScope,
+): Promise<{ id: string; payload?: Partial<QdrantPayload> } | null> => {
+  const result = await qdrant.qdrantRequest("POST", `/collections/${qdrant.collection}/points/scroll`, {
+    filter: buildEpisodeSummaryFilter(episodeId, scope),
+    limit: 1,
+    with_payload: true,
+  }) as { result?: { points?: Array<{ id: string; payload?: Partial<QdrantPayload> }> } };
+
+  return result.result?.points?.[0] ?? null;
+};
+
+export const updateEpisodeSummary = async (input: {
+  segment: EpisodeSegment;
+  sessionId: string;
+  scope: WorkspaceScope;
+  config: BikkyConfig;
+}): Promise<EpisodeSummaryWriteResult> => {
+  if (!input.segment.transcript.trim()) {
+    return { action: "skipped", reason: "empty_transcript", episodeId: input.segment.episode_id };
+  }
+
+  const existing = await findExistingEpisodeSummary(input.segment.episode_id, input.scope);
+  const draft = await summarizeEpisodeTranscript(input.segment.transcript);
+  const now = new Date().toISOString();
+  const { payload } = buildEpisodeSummaryPayload({
+    draft,
+    segment: input.segment,
+    sessionId: input.sessionId,
+    scope: input.scope,
+    now,
+    existing,
+    redactionOptions: {
+      enabled: false,
+      redactPii: false,
+    },
+  });
+  const vector = await qdrant.embed(String(payload.content));
+  const factId = existing?.id ?? randomUUID();
+
+  await qdrant.qdrantRequest("PUT", `/collections/${qdrant.collection}/points`, {
+    points: [{ id: factId, vector, payload }],
+  });
+
+  return {
+    action: existing ? "updated" : "stored",
+    factId,
+    episodeId: input.segment.episode_id,
+    workstreamKey: draft.workstream_key ?? input.segment.workstream_key ?? null,
+  };
+};

--- a/src/daemon/extraction.test.ts
+++ b/src/daemon/extraction.test.ts
@@ -1,0 +1,125 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  DEFAULT_EXTRACTION_PROMPT,
+  factQualitySignals,
+  isHighQualityExtractedFact,
+  normalizeExtractedFact,
+  type ExtractedFact,
+} from "./extraction.js";
+
+describe("daemon/extraction prompt", () => {
+  it("describes ontology v2 fields and avoids legacy domain wording", () => {
+    assert.ok(DEFAULT_EXTRACTION_PROMPT.includes("software_engineering"));
+    assert.ok(DEFAULT_EXTRACTION_PROMPT.includes("memory_subtype"));
+    assert.ok(DEFAULT_EXTRACTION_PROMPT.includes("codebase_map"));
+    assert.ok(!DEFAULT_EXTRACTION_PROMPT.includes("work or personal"));
+    assert.ok(!DEFAULT_EXTRACTION_PROMPT.includes("Telegram"));
+    assert.ok(!DEFAULT_EXTRACTION_PROMPT.includes("WhatsApp"));
+  });
+});
+
+describe("normalizeExtractedFact", () => {
+  it("uses canonical category names and assigns subtype metadata", () => {
+    const fact = normalizeExtractedFact({
+      content: "The root test suite uses Node's built-in test runner; run npm test before opening PRs.",
+      category: "people",
+      entities: ["Node", "npm-test"],
+      confidence: 0.9,
+      importance: 0.8,
+      quality_score: 0.8,
+    });
+
+    assert.ok(fact);
+    assert.strictEqual(fact.category, "people");
+    assert.strictEqual(fact.memory_subtype, "ownership");
+    assert.deepStrictEqual(fact.entities, ["node", "npm-test"]);
+  });
+
+  it("accepts short durable preferences without padding", () => {
+    const fact = normalizeExtractedFact({
+      content: "Prefer Node's built-in test runner for daemon unit tests.",
+      category: "preferences",
+      memory_subtype: "preference",
+      entities: ["node-test-runner"],
+      confidence: 0.9,
+      importance: 0.7,
+      quality_score: 0.7,
+    });
+
+    assert.ok(fact);
+    assert.strictEqual(fact.memory_subtype, "preference");
+  });
+
+  it("rejects skinny status-only memories", () => {
+    const fact = normalizeExtractedFact({
+      content: "The tests were fixed and now pass.",
+      category: "observations",
+      entities: [],
+      confidence: 0.9,
+      importance: 0.6,
+      quality_score: 0.8,
+    });
+
+    assert.strictEqual(fact, null);
+  });
+
+  it("falls back from invalid subtype to the category default", () => {
+    const fact = normalizeExtractedFact({
+      content: "If Qdrant order_by fails, create a datetime payload index for the sorted field before retrying.",
+      category: "operations",
+      memory_subtype: "episode",
+      entities: ["qdrant", "order_by"],
+      confidence: 0.9,
+      importance: 0.8,
+      quality_score: 0.8,
+    });
+
+    assert.ok(fact);
+    assert.strictEqual(fact.memory_subtype, "operational_procedure");
+  });
+});
+
+describe("isHighQualityExtractedFact", () => {
+  function makeFact(overrides: Partial<ExtractedFact> = {}): ExtractedFact {
+    return {
+      content: "The UI smoke tests live in packages/ui/tests/smoke.spec.ts and run with npm run test:e2e.",
+      category: "codebase",
+      memory_subtype: "codebase_map",
+      entities: ["packages/ui", "playwright"],
+      confidence: 0.9,
+      importance: 0.7,
+      quality_score: 0.8,
+      ...overrides,
+    };
+  }
+
+  it("accepts facts with durable anchors", () => {
+    assert.strictEqual(isHighQualityExtractedFact(makeFact()), true);
+    const signals = factQualitySignals(makeFact());
+    assert.strictEqual(signals.hasDurableAnchor, true);
+    assert.strictEqual(signals.isStatusOnly, false);
+  });
+
+  it("rejects low-confidence, low-importance weak facts", () => {
+    assert.strictEqual(isHighQualityExtractedFact(makeFact({
+      content: "There may be something useful about the project.",
+      entities: [],
+      confidence: 0.4,
+      importance: 0.4,
+      quality_score: 0.9,
+    })), false);
+  });
+
+  it("requires either an anchor or short-useful subtype", () => {
+    assert.strictEqual(isHighQualityExtractedFact(makeFact({
+      content: "The project has a couple of things to remember for later reference.",
+      entities: [],
+      memory_subtype: "codebase_map",
+      confidence: 0.9,
+      importance: 0.8,
+      quality_score: 0.9,
+    })), false);
+  });
+});

--- a/src/daemon/extraction.ts
+++ b/src/daemon/extraction.ts
@@ -18,6 +18,21 @@ import * as qdrant from "./qdrant.js";
 import { chatCompletion } from "../llm/index.js";
 import { detectContradiction } from "./consolidation.js";
 import type { LogFn, StoreFact } from "./qdrant.js";
+import {
+  normalizeCategory,
+  normalizeEntities,
+  normalizeMemorySubtype,
+  validateMemorySubtype,
+} from "../mcp/taxonomy.js";
+import {
+  CAPTURE_POLICY_VERSION,
+  CAPTURE_TRIGGERS,
+  DEFAULT_CAPTURE_CONTEXT,
+  QUALITY_THRESHOLDS,
+  promptVersionForSubtype,
+  subtypeForCategory,
+} from "./capture-policy.js";
+import { shouldSummarizeEvents, updateSessionSummary } from "./session-summary.js";
 
 // ── Module state ─────────────────────────────────────────────────────────────
 
@@ -36,78 +51,65 @@ const EXTRACTABLE_TYPES = new Set([
   "session.compaction_complete",
 ]);
 
-const DEFAULT_EXTRACTION_PROMPT = `You are a knowledge extraction agent for software engineers. Extract ENGINEERING REFERENCES — durable facts that help an engineer navigate codebases, understand infrastructure, run operations, and make decisions.
+export const DEFAULT_EXTRACTION_PROMPT = `You are Bikky's memory extraction agent for open-source coding agents. Extract durable, reusable facts that help a future agent continue work without rereading the whole transcript.
 
-## Quality Gate (apply to EVERY candidate fact)
-A fact must pass AT LEAST ONE of these tests or it is noise — skip it:
-1. GREPPABLE — contains a file path, service name, config key, CLI flag, or symbol an engineer could search for
-2. RUNNABLE — contains a command, URL, port, or procedure that could be executed
-3. NAVIGABLE — tells you where to look for something specific (which repo, which module, which config)
-4. DECISIVE — records a choice with enough rationale that a future engineer won't re-debate it
+## Core rule
+Extract fewer, sharper memories. A candidate fact must be independently useful after the session is gone.
 
-## 7 Reference Types (extract ONLY these)
+## Quality gate
+Every fact must pass at least one gate:
+1. GREPPABLE: names a file path, package, symbol, config key, CLI flag, issue/PR, service, or API a future agent can search for.
+2. RUNNABLE: contains a command, URL, setting, port, or procedure that can be executed or checked.
+3. NAVIGABLE: tells a future agent where to look and what that location means.
+4. DECISIVE: records a durable decision, rationale, constraint, convention, preference, or ownership rule.
+5. DIAGNOSTIC: captures a repeatable failure mode, root cause, or troubleshooting gotcha.
 
-### 1. Codebase Map — "where does X live?"
-File paths, entry points, module ownership, call chains.
-GOOD: "Alert extraction logic is in src/enrichers/bank-account-enricher.ts, called by the DM pipeline handler (src/pipeline/dm-handler.ts), not the group handler"
-BAD: "The code was updated to fix extraction" (no path, no specifics)
+## Ontology
+- domain is the activity profile. For coding-agent captures use "software_engineering".
+- category is subject matter: codebase | infrastructure | operations | decisions | product_domain | projects | people | preferences | observations.
+- kind is object shape. For this prompt, emit only kind="fact".
+- memory_subtype must be one of:
+  codebase_map | architecture_decision | infra_topology | access_pattern | deployment_procedure | operational_procedure | domain_rule | troubleshooting_gotcha | preference | ownership.
 
-### 2. Architecture Decision — "why was X chosen?"
-Choice + alternatives considered + rationale + constraints.
-GOOD: "Chose Portkey over direct Bedrock calls for LLM routing — gives per-model fallback chains and spend tracking without vendor lock-in. Decided in PR #847"
-BAD: "We use Portkey for LLM" (no rationale, no context)
+## Examples
+GOOD:
+- "The UI smoke tests live in packages/ui/tests/smoke.spec.ts and run through npm run test:e2e with mocked /api/memory/* responses."
+- "Use workspace_id as the tenancy/access boundary; domain is reserved for activity profile such as software_engineering."
+- "If Qdrant order_by fails with a missing index error, create a datetime payload index for the sorted field before retrying."
+- "Prefer Node's built-in test runner for root tests; do not add Jest just for daemon unit tests."
 
-### 3. Infrastructure Topology — "what connects to what?"
-Endpoints, ports, resource IDs, service connections, cluster names, regions.
-GOOD: "ClickHouse in lloyds cluster accessed via port-forward: kubectl port-forward svc/clickhouse 9000:9000 --context arn:aws:eks:eu-west-2:871829501674:cluster/lloyds"
-BAD: "ClickHouse is running" (no actionable detail)
-
-### 4. Access & Credentials — "how do I authenticate?"
-Where secrets live, IAM roles, auth patterns, permission gotchas.
-GOOD: "saber IAM user blocked by EnforceMFA for ECR/S3 — use --profile mfa. EC2 instance role agent00-cortex-ec2 has ECR pull+push scoped to arn:aws:ecr:ap-southeast-2:871829501674:repository/agent00-cortex"
-BAD: "AWS credentials are configured" (useless)
-
-### 5. Deployment & Shipping — "how do I release X?"
-Build, release, CI/CD pipelines, verification steps.
-GOOD: "EC2 cortex deploys via SSM: download repo tarball from GitHub API (needs saber-zrelli-private token) → build on EC2 (native amd64) → push to ECR → docker compose pull && up -d. SSM executionTimeout must be ≥600s"
-BAD: "The deployment was successful" (not reusable)
-
-### 6. Operational Procedure — "how do I do X on a live system?"
-kubectl recipes, patching commands, rollout procedures, scaling ops, cleanup, troubleshooting.
-GOOD: "To roll TG bot images across lloyds fleet: kubectl get deploy -l app=tg-bot --context lloyds-ctx, then patch each with image update. Wait 30s between batches to avoid message loss"
-BAD: "Bot images were updated" (no procedure)
-
-### 7. Business Logic Rule — "what are the domain rules?"
-Data flow semantics, edge cases that affect code, domain-specific constraints.
-GOOD: "SA bank accounts (Capitec branch 470010, TymeBank 678910, FNB 250655) are frequently misclassified as AU BSBs because branch codes are 6 digits. Recovery script stage 1b re-extracts with ZA country tagging"
-BAD: "Bank accounts are extracted" (no specifics)
-
-## What to ALWAYS SKIP
-- Session narration: "the user asked to fix X, then we looked at Y" — that's a log, not a reference
-- Meta-observations about tools: "bikky handles extraction" / "the agent used kubectl" — obvious from context
-- Debugging state: "test 67 fails" / "got a 404" — transient unless it reveals a PERMANENT quirk
-- Vague summaries: "WhatsApp bot was updated" — which bot? which update? which PR?
-- Opinions without rationale: "Nova Lite is good" — good for what? compared to what?
-- Anything you can't add specifics to: if you can't name a file, service, command, or decision — skip it
+BAD:
+- "The tests were fixed." (status only)
+- "We reviewed the code." (session narration)
+- "The deployment succeeded." (transient and not reusable)
+- "The agent used npm." (tool narration)
+- "There was an error." (no root cause or reusable detail)
 
 ## Output format
-{"facts": [
+Return strict JSON:
+{"facts":[
   {
-    "content": "EC2 cortex has no git installed — deploys download repo tarball via GitHub API (curl -sL -H 'Authorization: token $TOKEN' https://api.github.com/repos/OWNER/REPO/tarball/main) then build locally on EC2",
-    "category": "infrastructure",
-    "entities": ["ec2", "ecr", "github-api"],
-    "confidence": 0.9,
-    "importance": 0.8
+    "content":"One self-contained durable fact.",
+    "category":"codebase",
+    "memory_subtype":"codebase_map",
+    "entities":["repo-or-tool","specific-module"],
+    "confidence":0.9,
+    "importance":0.7,
+    "quality_score":0.8,
+    "confidence_reason":"Explicitly stated in the transcript.",
+    "repo":"optional/repo-or-package",
+    "branch":"optional-branch",
+    "task_key":"optional issue/PR/task key",
+    "workstream_key":"optional stable workstream key"
   }
 ]}
 
-- Category: infrastructure | decisions | observation | preferences | projects | team
-- Entities: lowercase identifiers (service names, tools, repos — things you'd grep for)
-- Confidence 0.0-1.0: 0.9 for explicit statements, 0.6 for inferences
-- Importance 0.0-1.0: 0.7+ for architecture/infra/access/ops, 0.5-0.7 for decisions/business rules
+Scoring:
+- confidence: 0.9 explicit, 0.7 strong inference, 0.55 weak but useful inference.
+- importance: 0.8+ for decisions, infra, procedures, access, recurring failures; 0.6+ for useful codebase maps/preferences.
+- quality_score: 0.8+ passes multiple gates, 0.6+ passes one strong gate, below 0.6 should usually be omitted.
 
-Prefer fewer, higher-quality facts over many weak ones. 3 good references beat 10 vague observations.
-If nothing passes the quality gate, return: {"facts": []}`;
+If nothing passes the quality gate, return {"facts":[]}.`;
 
 // ── JSON-file state persistence ──────────────────────────────────────────────
 
@@ -331,13 +333,143 @@ const buildTranscript = (events: ParsedEvent[]): string => {
 
 // ── LLM extraction ──────────────────────────────────────────────────────────
 
-interface ExtractedFact {
+export interface ExtractedFact {
   content: string;
   category: string;
+  memory_subtype?: string | null;
   entities: string[];
   confidence: number;
   importance: number;
+  quality_score?: number | null;
+  confidence_reason?: string | null;
+  repo?: string | null;
+  branch?: string | null;
+  task_key?: string | null;
+  workstream_key?: string | null;
 }
+
+export interface FactQualitySignals {
+  wordCount: number;
+  hasDurableAnchor: boolean;
+  isStatusOnly: boolean;
+  isShortUseful: boolean;
+  computedQualityScore: number;
+}
+
+const clamp01 = (value: number): number => Math.max(0, Math.min(1, value));
+
+const textWordCount = (text: string): number => text.trim().split(/\s+/).filter(Boolean).length;
+
+const hasDurableAnchor = (content: string, entities: string[]): boolean => {
+  const text = content.trim();
+  return Boolean(
+    /(?:^|\s)(?:[\w.-]+\/)+[\w./-]+/.test(text) ||
+    /`[^`]+`/.test(text) ||
+    /\b(?:npm|pnpm|yarn|node|git|gh|docker|kubectl|make|go|python|pip|cargo|terraform|aws|curl)\b/.test(text) ||
+    /https?:\/\/\S+/.test(text) ||
+    /\b[A-Z][A-Z0-9_]{2,}\b/.test(text) ||
+    /\b[\w.-]+\.(?:ts|tsx|js|jsx|mjs|cjs|py|go|rs|java|kt|rb|php|json|ya?ml|toml|md|sql|sh)\b/.test(text) ||
+    /\b(?:issue|pr|pull request)\s*#?\d+\b/i.test(text) ||
+    entities.length >= 2,
+  );
+};
+
+const isStatusOnlyContent = (content: string, entities: string[]): boolean => {
+  const lower = content.trim().toLowerCase();
+  if (hasDurableAnchor(content, entities)) return false;
+  if (textWordCount(content) > 16) return false;
+  return /\b(done|fixed|updated|implemented|reviewed|tested|works|passed|failed|succeeded|completed|started|looked|changed|deployed)\b/.test(lower);
+};
+
+export const factQualitySignals = (fact: ExtractedFact): FactQualitySignals => {
+  const content = fact.content.trim();
+  const entities = normalizeEntities(fact.entities ?? []);
+  const subtype = normalizeMemorySubtype("fact", fact.memory_subtype) ?? subtypeForCategory(normalizeCategory(fact.category));
+  const wordCount = textWordCount(content);
+  const durableAnchor = hasDurableAnchor(content, entities);
+  const statusOnly = isStatusOnlyContent(content, entities);
+  const isPreferenceLike = subtype === "preference" || subtype === "ownership" || subtype === "domain_rule";
+  const isDecisionLike = subtype === "architecture_decision" || subtype === "troubleshooting_gotcha";
+  const shortUseful = wordCount >= 7 && wordCount <= 22 && (isPreferenceLike || isDecisionLike) && (entities.length > 0 || durableAnchor);
+
+  let score = 0.25;
+  if (wordCount >= 8) score += 0.1;
+  if (wordCount >= 14) score += 0.1;
+  if (durableAnchor) score += 0.25;
+  if (isPreferenceLike || isDecisionLike) score += 0.15;
+  if ((fact.confidence ?? 0) >= 0.75) score += 0.1;
+  if ((fact.importance ?? 0) >= 0.7) score += 0.1;
+  if (statusOnly) score -= 0.4;
+
+  return {
+    wordCount,
+    hasDurableAnchor: durableAnchor,
+    isStatusOnly: statusOnly,
+    isShortUseful: shortUseful,
+    computedQualityScore: Math.round(clamp01(score) * 100) / 100,
+  };
+};
+
+export const normalizeExtractedFact = (raw: Record<string, unknown>): ExtractedFact | null => {
+  if (!raw.content || typeof raw.content !== "string") return null;
+
+  const category = normalizeCategory(typeof raw.category === "string" ? raw.category : "observations");
+  const requestedSubtype = typeof raw.memory_subtype === "string" ? raw.memory_subtype : null;
+  let memorySubtype = requestedSubtype ? normalizeMemorySubtype("fact", requestedSubtype) : null;
+  if (!memorySubtype) {
+    memorySubtype = subtypeForCategory(category);
+  }
+
+  try {
+    validateMemorySubtype("fact", memorySubtype);
+  } catch {
+    memorySubtype = subtypeForCategory(category);
+  }
+
+  const confidence = typeof raw.confidence === "number" ? clamp01(raw.confidence) : 0.7;
+  const importance = typeof raw.importance === "number" ? clamp01(raw.importance) : 0.5;
+  const qualityScore = typeof raw.quality_score === "number" ? clamp01(raw.quality_score) : null;
+  const entities = Array.isArray(raw.entities)
+    ? normalizeEntities(raw.entities.map((entity) => String(entity)))
+    : [];
+
+  const fact: ExtractedFact = {
+    content: raw.content.trim(),
+    category,
+    memory_subtype: memorySubtype,
+    entities,
+    confidence,
+    importance,
+    quality_score: qualityScore,
+    confidence_reason: typeof raw.confidence_reason === "string" ? raw.confidence_reason.trim() : null,
+    repo: typeof raw.repo === "string" ? raw.repo.trim() : null,
+    branch: typeof raw.branch === "string" ? raw.branch.trim() : null,
+    task_key: typeof raw.task_key === "string" ? raw.task_key.trim() : null,
+    workstream_key: typeof raw.workstream_key === "string" ? raw.workstream_key.trim() : null,
+  };
+
+  return isHighQualityExtractedFact(fact) ? fact : null;
+};
+
+export const isHighQualityExtractedFact = (fact: ExtractedFact): boolean => {
+  const content = fact.content.trim();
+  if (content.length < 30) return false;
+
+  const signals = factQualitySignals(fact);
+  if (QUALITY_THRESHOLDS.rejectStatusOnlyFacts && signals.isStatusOnly) return false;
+
+  const confidence = fact.confidence ?? 0.7;
+  const importance = fact.importance ?? 0.5;
+  if (confidence < QUALITY_THRESHOLDS.minFactConfidence && importance < QUALITY_THRESHOLDS.minImportanceForLowConfidenceFact) {
+    return false;
+  }
+
+  const qualityScore = fact.quality_score ?? signals.computedQualityScore;
+  if (qualityScore < QUALITY_THRESHOLDS.minFactQualityScore && !signals.isShortUseful) return false;
+  if (!signals.hasDurableAnchor && !signals.isShortUseful) return false;
+
+  return true;
+};
 
 /**
  * Call the LLM to extract facts from a conversation transcript.
@@ -392,21 +524,16 @@ const extractFacts = async (transcript: string, config?: BikkyConfig): Promise<E
     }
 
     return (parsed as Array<Record<string, unknown>>)
-      .filter(f => f.content && typeof f.content === "string" && f.category)
-      .map(f => ({
-        content: f.content as string,
-        category: f.category as string,
-        entities: Array.isArray(f.entities) ? (f.entities as string[]).map(e => String(e).toLowerCase()) : [],
-        confidence: typeof f.confidence === "number" ? f.confidence : 0.7,
-        importance: typeof f.importance === "number" ? f.importance : 0.5,
-      }))
-      .filter(f => {
-        if (f.importance < 0.5) {
-          logFn("DEBUG", `Extraction: dropping low-importance fact (${f.importance}): "${f.content.slice(0, 80)}…"`);
-          return false;
+      .map((raw) => {
+        const fact = normalizeExtractedFact(raw);
+        if (!fact) {
+          const content = typeof raw.content === "string" ? raw.content : JSON.stringify(raw).slice(0, 120);
+          logFn("DEBUG", `Extraction: dropping low-quality fact candidate: "${content.slice(0, 80)}…"`);
+          return null;
         }
-        return true;
-      });
+        return fact;
+      })
+      .filter((fact): fact is ExtractedFact => fact !== null);
   } catch (e) {
     logFn("WARN", `Extraction LLM parse error: ${(e as Error).message} — raw: ${result.slice(0, 200)}`);
     return [];
@@ -432,15 +559,21 @@ const storeFacts = async (
     return 0;
   }
 
-  const baseMeta: Record<string, string> = { extracted_from_session: sessionId };
-
+  const baseMeta: Record<string, string | number | boolean | null> = {
+    extracted_from_session: sessionId,
+    capture_policy_version: CAPTURE_POLICY_VERSION,
+  };
   let stored = 0;
 
   for (const fact of facts) {
     const hash = contentHash(fact.content);
+    const sanitizedFact: ExtractedFact = {
+      ...fact,
+      entities: fact.entities.map((entity) => entity.toLowerCase()),
+    };
 
     try {
-      const dedup = await qdrant.dedupCheck(fact.content, hash);
+      const dedup = await qdrant.dedupCheck(sanitizedFact.content, hash);
 
       if (dedup.action === "skip") {
         // Reinforce existing fact
@@ -453,7 +586,7 @@ const storeFacts = async (
       // Run contradiction detection for non-trivial facts
       if (config && (fact.confidence ?? 0.5) >= 0.5) {
         try {
-          const contradiction = await detectContradiction(fact, config);
+          const contradiction = await detectContradiction(sanitizedFact, config);
           if (contradiction.contradiction && contradiction.existingId) {
             logFn("INFO", `Extraction: contradiction detected for "${fact.content.slice(0, 60)}..." vs ${contradiction.existingId}: ${contradiction.reason}`);
             // Log contradiction instead of writing to inbox
@@ -463,15 +596,30 @@ const storeFacts = async (
         }
       }
 
+      const subtype = validateMemorySubtype("fact", sanitizedFact.memory_subtype)
+        ?? subtypeForCategory(normalizeCategory(sanitizedFact.category));
+
       const storePayload: StoreFact = {
-        content: fact.content,
-        category: fact.category,
-        entities: fact.entities,
+        content: sanitizedFact.content,
+        category: sanitizedFact.category,
+        domain: DEFAULT_CAPTURE_CONTEXT.domain,
+        memory_subtype: subtype,
+        entities: sanitizedFact.entities,
         source: "daemon",
         kind: "fact",
         confidence: fact.confidence,
         importance: fact.importance,
         content_hash: hash,
+        prompt_version: promptVersionForSubtype(subtype),
+        capture_policy_version: CAPTURE_POLICY_VERSION,
+        quality_score: fact.quality_score ?? factQualitySignals(fact).computedQualityScore,
+        confidence_reason: fact.confidence_reason,
+        review_status: DEFAULT_CAPTURE_CONTEXT.reviewStatus,
+        volatility: DEFAULT_CAPTURE_CONTEXT.volatility,
+        repo: fact.repo,
+        branch: fact.branch,
+        task_key: fact.task_key,
+        workstream_key: fact.workstream_key,
         metadata: baseMeta,
       };
 
@@ -489,6 +637,24 @@ const storeFacts = async (
   }
 
   return stored;
+};
+
+const updateSummaryForTranscript = async (
+  sessionId: string,
+  transcript: string,
+  eventCount: number,
+  config?: BikkyConfig,
+): Promise<void> => {
+  try {
+    const result = await updateSessionSummary({ sessionId, transcript, eventCount, config });
+    if (result.action === "stored" || result.action === "updated") {
+      logFn("INFO", `Summary: ${result.action} session summary ${result.factId} for ${sessionId}`);
+    } else {
+      logFn("DEBUG", `Summary: skipped for ${sessionId} (${result.reason})`);
+    }
+  } catch (e) {
+    logFn("WARN", `Summary: failed for ${sessionId}: ${(e as Error).message}`);
+  }
 };
 
 // ── Tick entry point ─────────────────────────────────────────────────────────
@@ -517,7 +683,7 @@ export const tick = async (config: BikkyConfig): Promise<void> => {
   if (now - lastTickAt < intervalMs) return;
   lastTickAt = now;
 
-  const minEvents = config.daemon.extract_min_events || 5;
+  const minEvents = config.daemon.extract_min_events || CAPTURE_TRIGGERS.factExtraction.minEvents;
 
   try {
     // Extract from ALL active Copilot sessions with events.jsonl
@@ -563,7 +729,9 @@ const extractForUuid = async (
   // Read new events
   const { events, newOffset, totalLines } = await readNewEvents(eventsPath, state.byte_offset);
 
-  if (events.length < minEvents) {
+  const shouldSummarize = shouldSummarizeEvents(events, minEvents);
+
+  if (events.length < minEvents && !shouldSummarize) {
     // Still update offset to avoid re-scanning non-extractable events
     if (newOffset > state.byte_offset) {
       state.byte_offset = newOffset;
@@ -580,12 +748,17 @@ const extractForUuid = async (
   for (let i = 0; i < chunks.length; i++) {
     const transcript = buildTranscript(chunks[i]!);
     logFn("DEBUG", `Extraction: UUID ${uuid.slice(0, 8)} — chunk ${i + 1}/${chunks.length}, ${chunks[i]!.length} events, ${transcript.length} chars`);
-    const facts = await extractFacts(transcript, config);
 
-    if (facts.length > 0) {
-      const stored = await storeFacts(facts, stateKey, config);
-      totalFacts += stored;
+    if (events.length >= minEvents) {
+      const facts = await extractFacts(transcript, config);
+
+      if (facts.length > 0) {
+        const stored = await storeFacts(facts, stateKey, config);
+        totalFacts += stored;
+      }
     }
+
+    await updateSummaryForTranscript(stateKey, transcript, chunks[i]!.length, config);
   }
 
   if (totalFacts > 0) {

--- a/src/daemon/qdrant.ts
+++ b/src/daemon/qdrant.ts
@@ -11,6 +11,16 @@ import { loadConfig } from "../config.js";
 import { embed, initEmbedding, getEmbeddingConfig } from "../llm/index.js";
 import type { InitEmbeddingInput } from "../llm/index.js";
 import { QdrantClient, type QdrantLogLevel } from "../lib/qdrant-client.js";
+import {
+  DEFAULT_DOMAIN,
+  QDRANT_INDEXES,
+  categoryForMemorySubtype,
+  layerForMemorySubtype,
+  normalizeCategory,
+  normalizeDomain,
+  normalizeKind,
+  validateMemorySubtype,
+} from "../mcp/taxonomy.js";
 
 // ---------------------------------------------------------------------------
 // Types (local)
@@ -23,6 +33,10 @@ export interface QdrantPayload {
   category: string;
   domain: string;
   kind: string;
+  layer?: string | null;
+  memory_subtype?: string | null;
+  workspace_id?: string;
+  actor_id?: string;
   entities: string[];
   source: string;
   confidence: number;
@@ -34,7 +48,26 @@ export interface QdrantPayload {
   superseded_at: string | null;
   created_at: string;
   updated_at: string;
-  metadata: Record<string, string>;
+  metadata: Record<string, string | number | boolean | null>;
+  episode_id?: string | null;
+  workstream_key?: string | null;
+  task_key?: string | null;
+  repo?: string | null;
+  branch?: string | null;
+  surface?: string | null;
+  issue_id?: string | null;
+  pr_id?: string | null;
+  source_event_ids?: string[];
+  source_fact_ids?: string[];
+  source_episode_ids?: string[];
+  prompt_version?: string | null;
+  capture_policy_version?: string | null;
+  review_status?: string | null;
+  volatility?: string | null;
+  valid_from?: string | null;
+  expires_at?: string | null;
+  quality_score?: number | null;
+  confidence_reason?: string | null;
   from_entity?: string;
   relation_type?: string;
   to_entity?: string;
@@ -45,12 +78,35 @@ export interface StoreFact {
   category: string;
   domain?: string;
   kind?: string;
+  layer?: string | null;
+  memory_subtype?: string | null;
   entities: string[];
   source?: string;
   confidence?: number;
   importance?: number;
   content_hash: string;
-  metadata?: Record<string, string>;
+  workspace_id?: string;
+  actor_id?: string;
+  metadata?: Record<string, string | number | boolean | null>;
+  episode_id?: string | null;
+  workstream_key?: string | null;
+  task_key?: string | null;
+  repo?: string | null;
+  branch?: string | null;
+  surface?: string | null;
+  issue_id?: string | null;
+  pr_id?: string | null;
+  source_event_ids?: string[];
+  source_fact_ids?: string[];
+  source_episode_ids?: string[];
+  prompt_version?: string | null;
+  capture_policy_version?: string | null;
+  review_status?: string | null;
+  volatility?: string | null;
+  valid_from?: string | null;
+  expires_at?: string | null;
+  quality_score?: number | null;
+  confidence_reason?: string | null;
   relation?: { from: string; type: string; to: string } | null;
 }
 
@@ -81,6 +137,7 @@ export interface QdrantSearchFilters {
   since?: string;
   domain?: string;
   source?: string;
+  workspaceId?: string;
 }
 
 export interface QdrantScrollFilters {
@@ -163,6 +220,16 @@ const init = (): boolean => {
 
 const isReady = (): boolean => !!(qdrantUrl && qdrantApiKey && client);
 
+const ensureCollection = async (): Promise<void> => {
+  if (!client) {
+    throw new Error("Qdrant client not initialized — call init() first");
+  }
+  const embCfg = getEmbeddingConfig();
+  await client.ensureCollection(embCfg.dimensions, QDRANT_INDEXES);
+  logFn("INFO", `Qdrant collection '${collection}' ready (${QDRANT_INDEXES.length} indexes)`);
+};
+
+
 // ---------------------------------------------------------------------------
 // HTTP requests
 // ---------------------------------------------------------------------------
@@ -205,6 +272,9 @@ const searchFacts = async (
   }
   if (filters.source) {
     must.push({ key: "source", match: { value: filters.source } });
+  }
+  if (filters.workspaceId) {
+    must.push({ key: "workspace_id", match: { value: filters.workspaceId } });
   }
 
   const result = await qdrantRequest("POST", `/collections/${collection}/points/search`, {
@@ -251,7 +321,6 @@ const scrollFacts = async (
   if (filters.domain) {
     must.push({ key: "domain", match: { value: filters.domain } });
   }
-
   const result = await qdrantRequest("POST", `/collections/${collection}/points/scroll`, {
     filter: { must },
     limit,
@@ -274,16 +343,26 @@ const scrollFacts = async (
 // ---------------------------------------------------------------------------
 
 const storeFact = async (fact: StoreFact): Promise<string> => {
+  const normalizedKind = normalizeKind(fact.kind);
+  const normalizedSubtype = validateMemorySubtype(normalizedKind, fact.memory_subtype);
+  const normalizedCategory = normalizedSubtype
+    ? categoryForMemorySubtype(normalizedSubtype) ?? normalizeCategory(fact.category)
+    : normalizeCategory(fact.category);
+  const normalizedDomain = normalizeDomain(fact.domain ?? DEFAULT_DOMAIN);
+  const normalizedLayer = fact.layer ?? (normalizedSubtype ? layerForMemorySubtype(normalizedSubtype) : null);
   const vector = await embed(fact.content);
   const now = new Date().toISOString();
   const id = randomUUID();
-
   const payload: QdrantPayload = {
     content: fact.content,
-    category: fact.category,
-    domain: fact.domain || "work",
-    kind: fact.kind || "fact",
-    entities: fact.entities || [],
+    category: normalizedCategory,
+    domain: normalizedDomain,
+    kind: normalizedKind,
+    ...(normalizedLayer ? { layer: normalizedLayer } : {}),
+    ...(normalizedSubtype ? { memory_subtype: normalizedSubtype } : {}),
+    ...(fact.workspace_id ? { workspace_id: fact.workspace_id } : {}),
+    ...(fact.actor_id ? { actor_id: fact.actor_id } : {}),
+    entities: (fact.entities || []).map((entity) => entity.toLowerCase()),
     source: fact.source || "daemon",
     confidence: fact.confidence ?? 0.7,
     importance: fact.importance ?? 0.5,
@@ -295,8 +374,26 @@ const storeFact = async (fact: StoreFact): Promise<string> => {
     created_at: now,
     updated_at: now,
     metadata: fact.metadata || {},
+    ...(fact.episode_id ? { episode_id: fact.episode_id } : {}),
+    ...(fact.workstream_key ? { workstream_key: fact.workstream_key } : {}),
+    ...(fact.task_key ? { task_key: fact.task_key } : {}),
+    ...(fact.repo ? { repo: fact.repo } : {}),
+    ...(fact.branch ? { branch: fact.branch } : {}),
+    ...(fact.surface ? { surface: fact.surface } : {}),
+    ...(fact.issue_id ? { issue_id: fact.issue_id } : {}),
+    ...(fact.pr_id ? { pr_id: fact.pr_id } : {}),
+    ...(fact.source_event_ids ? { source_event_ids: fact.source_event_ids } : {}),
+    ...(fact.source_fact_ids ? { source_fact_ids: fact.source_fact_ids } : {}),
+    ...(fact.source_episode_ids ? { source_episode_ids: fact.source_episode_ids } : {}),
+    ...(fact.prompt_version ? { prompt_version: fact.prompt_version } : {}),
+    ...(fact.capture_policy_version ? { capture_policy_version: fact.capture_policy_version } : {}),
+    ...(fact.review_status ? { review_status: fact.review_status } : {}),
+    ...(fact.volatility ? { volatility: fact.volatility } : {}),
+    ...(fact.valid_from ? { valid_from: fact.valid_from } : {}),
+    ...(fact.expires_at ? { expires_at: fact.expires_at } : {}),
+    ...(fact.quality_score != null ? { quality_score: fact.quality_score } : {}),
+    ...(fact.confidence_reason ? { confidence_reason: fact.confidence_reason } : {}),
   };
-
   // Add relation fields if present
   if (fact.relation) {
     payload.from_entity = fact.relation.from;
@@ -308,7 +405,7 @@ const storeFact = async (fact: StoreFact): Promise<string> => {
     points: [{ id, vector, payload }],
   });
 
-  logFn("DEBUG", `Qdrant: stored fact ${id} [${fact.category}] ${fact.content.slice(0, 60)}`);
+  logFn("DEBUG", `Qdrant: stored fact ${id} [${normalizedCategory}] ${fact.content.slice(0, 60)}`);
   return id;
 };
 
@@ -342,16 +439,17 @@ const dedupCheck = async (
   content: string,
   contentHashVal: string,
   { exactThreshold = 0.92, supersedeThreshold = 0.80 }: DedupThresholds = {},
+  workspaceId?: string,
 ): Promise<DedupResult> => {
   // First: hash-based exact check (fast, no embedding)
   try {
+    const must: Record<string, unknown>[] = [
+      { key: "content_hash", match: { value: contentHashVal } },
+      { is_null: { key: "superseded_by" } },
+    ];
+    if (workspaceId) must.push({ key: "workspace_id", match: { value: workspaceId } });
     const hashResult = await qdrantRequest("POST", `/collections/${collection}/points/scroll`, {
-      filter: {
-        must: [
-          { key: "content_hash", match: { value: contentHashVal } },
-          { is_null: { key: "superseded_by" } },
-        ],
-      },
+      filter: { must },
       limit: 1,
       with_payload: true,
     }) as { result?: { points?: Array<{ id: string; payload?: Partial<QdrantPayload> }> } };
@@ -373,11 +471,11 @@ const dedupCheck = async (
   // Second: vector similarity check
   try {
     const vector = await embed(content);
+    const must: Record<string, unknown>[] = [{ is_null: { key: "superseded_by" } }];
+    if (workspaceId) must.push({ key: "workspace_id", match: { value: workspaceId } });
     const searchResult = await qdrantRequest("POST", `/collections/${collection}/points/search`, {
       vector,
-      filter: {
-        must: [{ is_null: { key: "superseded_by" } }],
-      },
+      filter: { must },
       limit: 1,
       with_payload: true,
     }) as { result?: Array<{ id: string; score: number; payload?: Partial<QdrantPayload> }> };
@@ -418,6 +516,7 @@ const dedupCheck = async (
 export {
   init,
   isReady,
+  ensureCollection,
   setLogger,
   setEmbeddingConfig,
   qdrantRequest,

--- a/src/daemon/session-index.test.ts
+++ b/src/daemon/session-index.test.ts
@@ -1,0 +1,71 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildSessionIndexDraft,
+  buildSessionIndexFilter,
+  buildSessionIndexPayload,
+} from "./session-index.js";
+
+interface WorkspaceScope { workspaceId?: string; actorId?: string; includeLegacy?: boolean }
+
+const defaultScope: WorkspaceScope = {
+  workspaceId: "default",
+  includeLegacy: true,
+};
+
+describe("daemon/session-index", () => {
+  it("builds one low-priority index from multiple episode results", () => {
+    const draft = buildSessionIndexDraft({
+      sessionId: "uuid:test-session",
+      eventCount: 20,
+      episodeResults: [
+        { action: "stored", factId: "fact-1", episodeId: "episode-1", workstreamKey: "task-a" },
+        { action: "stored", factId: "fact-2", episodeId: "episode-2", workstreamKey: "task-b" },
+      ],
+    });
+
+    assert.deepEqual(draft.episode_ids, ["episode-1", "episode-2"]);
+    assert.deepEqual(draft.workstream_keys, ["task-a", "task-b"]);
+    assert.equal(draft.importance, 0.35);
+  });
+
+  it("filters by session_index subtype", () => {
+    const filter = buildSessionIndexFilter("uuid:test-session", defaultScope);
+    assert.ok((filter.must as unknown[]).some((condition) =>
+      JSON.stringify(condition) === JSON.stringify({ key: "memory_subtype", match: { value: "session_index" } }),
+    ));
+  });
+
+  it("omits workspace filters when no workspace is supplied", () => {
+    const filter = buildSessionIndexFilter("uuid:test-session", {});
+    assert.equal(filter.should, undefined);
+    assert.equal((filter.must as unknown[]).some((condition) =>
+      JSON.stringify(condition).includes("workspace_id"),
+    ), false);
+  });
+
+  it("builds ontology-v2 session index payloads", () => {
+    const draft = buildSessionIndexDraft({
+      sessionId: "uuid:test-session",
+      eventCount: 12,
+      episodeResults: [
+        { action: "stored", factId: "fact-1", episodeId: "episode-1", workstreamKey: "task-a" },
+      ],
+    });
+    const { payload } = buildSessionIndexPayload({
+      draft,
+      sessionId: "uuid:test-session",
+      scope: { workspaceId: "team-a", actorId: "agent-1", includeLegacy: false },
+      now: "2026-04-25T12:00:00.000Z",
+      eventCount: 12,
+      redactionOptions: { enabled: true, redactPii: true },
+    });
+
+    assert.equal(payload.kind, "summary");
+    assert.equal(payload.memory_subtype, "session_index");
+    assert.equal(payload.domain, "software_engineering");
+    assert.deepEqual(payload.source_episode_ids, ["episode-1"]);
+    assert.equal((payload.metadata as Record<string, string>).workstream_keys, "task-a");
+  });
+});

--- a/src/daemon/session-index.ts
+++ b/src/daemon/session-index.ts
@@ -1,0 +1,202 @@
+/**
+ * Lightweight session indexes.
+ *
+ * Session indexes are routing/audit records. They are not the durable project
+ * memory boundary; episode and workstream summaries carry continuity.
+ */
+import { createHash, randomUUID } from "node:crypto";
+
+import type { BikkyConfig } from "../config.js";
+import { CAPTURE_POLICY_VERSION, DEFAULT_CAPTURE_CONTEXT, PROMPT_VERSIONS } from "./capture-policy.js";
+import type { EpisodeSummaryWriteResult } from "./episode-summary.js";
+import * as qdrant from "./qdrant.js";
+import type { QdrantPayload } from "./qdrant.js";
+
+export interface WorkspaceScope {
+  workspaceId?: string;
+  actorId?: string;
+  includeLegacy?: boolean;
+}
+
+export interface RedactionSummary {
+  redacted: boolean;
+  summary: string;
+  matches: Array<{ type: string; count: number }>;
+}
+
+const noRedaction = (): RedactionSummary => ({ redacted: false, summary: "none", matches: [] });
+const passthroughText = (text: string, _options?: { enabled: boolean; redactPii: boolean }): { text: string; redacted: boolean; summary: string; matches: Array<{ type: string; count: number }> } => ({
+  text,
+  ...noRedaction(),
+});
+const combinePassThrough = (): RedactionSummary => noRedaction();
+
+export interface SessionIndexDraft {
+  content: string;
+  episode_ids: string[];
+  workstream_keys: string[];
+  entities: string[];
+  importance: number;
+}
+
+export interface SessionIndexPayloadResult {
+  payload: Record<string, unknown>;
+  redaction: RedactionSummary;
+}
+
+const contentHash = (text: string): string =>
+  createHash("sha256").update(`session-index:${text}`).digest("hex");
+
+export const buildSessionIndexDraft = (input: {
+  sessionId: string;
+  eventCount: number;
+  episodeResults: EpisodeSummaryWriteResult[];
+}): SessionIndexDraft => {
+  const episodeIds = input.episodeResults
+    .map((result) => result.episodeId)
+    .filter((episodeId): episodeId is string => Boolean(episodeId));
+  const workstreamKeys = [...new Set(input.episodeResults
+    .map((result) => result.workstreamKey)
+    .filter((key): key is string => Boolean(key)))];
+
+  return {
+    content: `Session ${input.sessionId} captured ${episodeIds.length} episode(s) from ${input.eventCount} event(s).`,
+    episode_ids: episodeIds,
+    workstream_keys: workstreamKeys,
+    entities: ["bikky", "session-index", ...workstreamKeys],
+    importance: 0.35,
+  };
+};
+
+export const buildSessionIndexFilter = (
+  sessionId: string,
+  scope: WorkspaceScope,
+): Record<string, unknown> => {
+  const must: Record<string, unknown>[] = [
+    { key: "session_id", match: { value: sessionId } },
+    { key: "kind", match: { value: "summary" } },
+    { key: "memory_subtype", match: { value: "session_index" } },
+    { is_null: { key: "superseded_by" } },
+  ];
+  const filter: Record<string, unknown> = { must };
+  if (scope.workspaceId && scope.includeLegacy) {
+    filter["should"] = [
+      { key: "workspace_id", match: { value: scope.workspaceId } },
+      { is_empty: { key: "workspace_id" } },
+    ];
+  } else if (scope.workspaceId) {
+    must.push({ key: "workspace_id", match: { value: scope.workspaceId } });
+  }
+  return filter;
+};
+
+export const buildSessionIndexPayload = (input: {
+  draft: SessionIndexDraft;
+  sessionId: string;
+  scope: WorkspaceScope;
+  now: string;
+  existing?: { id: string; payload?: Partial<QdrantPayload> } | null;
+  eventCount: number;
+  redactionOptions: { enabled: boolean; redactPii: boolean };
+}): SessionIndexPayloadResult => {
+  const redactedContent = passthroughText(input.draft.content, input.redactionOptions);
+  const redactedEntities = input.draft.entities.map((entity) => passthroughText(entity, input.redactionOptions));
+  const redaction = combinePassThrough();
+  const existingPayload = input.existing?.payload ?? {};
+
+  const payload: Record<string, unknown> = {
+    ...existingPayload,
+    content: redactedContent.text,
+    category: "projects",
+    domain: DEFAULT_CAPTURE_CONTEXT.domain,
+    kind: "summary",
+    memory_subtype: "session_index",
+    layer: "episode",
+    ...(input.scope.workspaceId ? { workspace_id: input.scope.workspaceId } : {}),
+    ...(input.scope.actorId ? { actor_id: input.scope.actorId } : {}),
+    entities: redactedEntities.map((entity) => entity.text.toLowerCase()),
+    source: "system",
+    confidence: 1.0,
+    importance: input.draft.importance,
+    content_hash: contentHash(redactedContent.text),
+    reinforcement_count: existingPayload.reinforcement_count ?? 1,
+    last_reinforced_at: existingPayload.last_reinforced_at ?? input.now,
+    superseded_by: null,
+    superseded_at: null,
+    created_at: existingPayload.created_at ?? input.now,
+    updated_at: input.now,
+    session_id: input.sessionId,
+    source_episode_ids: input.draft.episode_ids,
+    prompt_version: PROMPT_VERSIONS.sessionIndex,
+    capture_policy_version: CAPTURE_POLICY_VERSION,
+    review_status: DEFAULT_CAPTURE_CONTEXT.reviewStatus,
+    metadata: {
+      ...(existingPayload.metadata ?? {}),
+      summary_source: "daemon",
+      summary_subtype: "session_index",
+      summarized_from_session: input.sessionId,
+      summary_event_count: String(input.eventCount),
+      episode_ids: input.draft.episode_ids.join(","),
+      workstream_keys: input.draft.workstream_keys.join(","),
+      summary_updated_at: input.now,
+    },
+  };
+
+  if (redaction.redacted) {
+    payload["redaction"] = redaction;
+  }
+
+  return { payload, redaction };
+};
+
+const findExistingSessionIndex = async (
+  sessionId: string,
+  scope: WorkspaceScope,
+): Promise<{ id: string; payload?: Partial<QdrantPayload> } | null> => {
+  const result = await qdrant.qdrantRequest("POST", `/collections/${qdrant.collection}/points/scroll`, {
+    filter: buildSessionIndexFilter(sessionId, scope),
+    limit: 1,
+    with_payload: true,
+  }) as { result?: { points?: Array<{ id: string; payload?: Partial<QdrantPayload> }> } };
+
+  return result.result?.points?.[0] ?? null;
+};
+
+export const updateSessionIndex = async (input: {
+  sessionId: string;
+  eventCount: number;
+  episodeResults: EpisodeSummaryWriteResult[];
+  scope: WorkspaceScope;
+  config: BikkyConfig;
+}): Promise<{ action: "stored" | "updated" | "skipped"; factId?: string; reason?: string }> => {
+  if (input.episodeResults.length === 0) {
+    return { action: "skipped", reason: "no_episode_results" };
+  }
+  const existing = await findExistingSessionIndex(input.sessionId, input.scope);
+  const draft = buildSessionIndexDraft({
+    sessionId: input.sessionId,
+    eventCount: input.eventCount,
+    episodeResults: input.episodeResults,
+  });
+  const now = new Date().toISOString();
+  const { payload } = buildSessionIndexPayload({
+    draft,
+    sessionId: input.sessionId,
+    scope: input.scope,
+    now,
+    existing,
+    eventCount: input.eventCount,
+    redactionOptions: {
+      enabled: false,
+      redactPii: false,
+    },
+  });
+  const vector = await qdrant.embed(String(payload.content));
+  const factId = existing?.id ?? randomUUID();
+
+  await qdrant.qdrantRequest("PUT", `/collections/${qdrant.collection}/points`, {
+    points: [{ id: factId, vector, payload }],
+  });
+
+  return { action: existing ? "updated" : "stored", factId };
+};

--- a/src/daemon/session-summary.test.ts
+++ b/src/daemon/session-summary.test.ts
@@ -1,0 +1,191 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildSessionSummaryFilter,
+  buildSessionSummaryMessages,
+  buildSessionSummaryPayload,
+  hasCompactionSummary,
+  parseSessionSummaryDraft,
+  shouldSummarizeEvents,
+} from "./session-summary.js";
+
+interface WorkspaceScope { workspaceId?: string; actorId?: string; includeLegacy?: boolean }
+
+const defaultScope: WorkspaceScope = {
+  workspaceId: "default",
+  includeLegacy: true,
+};
+
+describe("daemon/session-summary", () => {
+  describe("shouldSummarizeEvents", () => {
+    it("summarizes when the normal extraction threshold is met", () => {
+      const events = Array.from({ length: 5 }, (_, index) => ({
+        type: "assistant.message",
+        content: `event ${index}`,
+      }));
+      assert.equal(shouldSummarizeEvents(events, 5), true);
+    });
+
+    it("summarizes compaction summaries even below the extraction threshold", () => {
+      const events = [{ type: "session.compaction_complete", content: "Session summary content" }];
+      assert.equal(hasCompactionSummary(events), true);
+      assert.equal(shouldSummarizeEvents(events, 5), true);
+    });
+
+    it("skips small non-compaction batches", () => {
+      const events = [{ type: "assistant.message", content: "short update" }];
+      assert.equal(shouldSummarizeEvents(events, 5), false);
+    });
+  });
+
+  describe("buildSessionSummaryMessages", () => {
+    it("instructs the daemon to produce self-contained lifecycle summaries", () => {
+      const messages = buildSessionSummaryMessages({
+        existingSummary: "Existing context",
+        transcript: "[USER] add daemon summaries",
+      });
+
+      assert.equal(messages[0].role, "system");
+      assert.match(messages[0].content, /background memory daemon/);
+      assert.match(messages[0].content, /routing\/audit/);
+      assert.match(messages[0].content, /Bare status like 'tests passed'/);
+      assert.match(messages[1].content, /Existing context/);
+      assert.match(messages[1].content, /self-contained summary/);
+    });
+  });
+
+  describe("parseSessionSummaryDraft", () => {
+    it("parses fenced JSON and normalizes arrays", () => {
+      const draft = parseSessionSummaryDraft(`\`\`\`json
+{
+  "summary": "Implemented daemon-owned summaries for issue #14.",
+  "tasks": ["issue-14", "issue-14", "daemon summaries"],
+  "decisions": ["Daemon owns lifecycle memory"],
+  "entities": ["Bikky", "src/daemon/session-summary.ts"],
+  "importance": 0.95
+}
+\`\`\``);
+
+      assert.equal(draft.content, "Implemented daemon-owned summaries for issue #14.");
+      assert.deepEqual(draft.tasks_completed, ["issue-14", "daemon summaries"]);
+      assert.deepEqual(draft.decisions_made, ["Daemon owns lifecycle memory"]);
+      assert.deepEqual(draft.entities, ["bikky", "src/daemon/session-summary.ts"]);
+      assert.equal(draft.importance, 0.95);
+    });
+
+    it("rejects empty summaries", () => {
+      assert.throws(
+        () => parseSessionSummaryDraft(JSON.stringify({ content: "   " })),
+        /missing non-empty content/,
+      );
+    });
+  });
+
+  describe("buildSessionSummaryFilter", () => {
+    it("includes legacy summaries for default workspace scopes", () => {
+      const filter = buildSessionSummaryFilter("uuid:test-session", defaultScope);
+      const should = filter.should as unknown[];
+
+      assert.deepEqual((filter.must as unknown[]).slice(0, 3), [
+        { key: "session_id", match: { value: "uuid:test-session" } },
+        { key: "kind", match: { value: "summary" } },
+        { key: "memory_subtype", match: { value: "session_index" } },
+      ]);
+      assert.deepEqual((filter.must as unknown[]).slice(3, 4), [
+        { is_null: { key: "superseded_by" } },
+      ]);
+      assert.deepEqual(should, [
+        { key: "workspace_id", match: { value: "default" } },
+        { is_empty: { key: "workspace_id" } },
+      ]);
+    });
+
+    it("requires workspace match when legacy inclusion is disabled", () => {
+      const filter = buildSessionSummaryFilter("uuid:test-session", {
+        workspaceId: "team-a",
+        actorId: "agent-1",
+        includeLegacy: false,
+      });
+
+      assert.equal(filter.should, undefined);
+      assert.ok((filter.must as unknown[]).some((condition) =>
+        JSON.stringify(condition) === JSON.stringify({ key: "workspace_id", match: { value: "team-a" } }),
+      ));
+    });
+  });
+
+  describe("buildSessionSummaryPayload", () => {
+    it("builds raw system summary payloads with optional workspace metadata", () => {
+      const { payload, redaction } = buildSessionSummaryPayload({
+        draft: {
+          content: "Configured service with password=supersecretvalue during daemon summary work.",
+          tasks_completed: ["issue #14"],
+          decisions_made: ["Daemon owns summaries"],
+          entities: ["bikky", "daemon"],
+          importance: 0.9,
+        },
+        sessionId: "uuid:test-session",
+        scope: { workspaceId: "team-a", actorId: "agent-1", includeLegacy: false },
+        now: "2026-04-25T11:00:00.000Z",
+        eventCount: 7,
+        redactionOptions: { enabled: true, redactPii: true },
+      });
+
+      assert.equal(payload.category, "projects");
+      assert.equal(payload.domain, "software_engineering");
+      assert.equal(payload.kind, "summary");
+      assert.equal(payload.memory_subtype, "session_index");
+      assert.equal(payload.source, "system");
+      assert.equal(payload.workspace_id, "team-a");
+      assert.equal(payload.actor_id, "agent-1");
+      assert.equal(payload.session_id, "uuid:test-session");
+      assert.match(String(payload.content), /password=supersecretvalue/);
+      assert.deepEqual(payload.tasks_completed, ["issue #14"]);
+      assert.deepEqual(payload.decisions_made, ["Daemon owns summaries"]);
+      assert.deepEqual(payload.entities, ["bikky", "daemon"]);
+      assert.equal((payload.metadata as Record<string, string>).summary_source, "daemon");
+      assert.equal((payload.metadata as Record<string, string>).summary_subtype, "session_index");
+      assert.equal((payload.metadata as Record<string, string>).summary_event_count, "7");
+      assert.equal(redaction.redacted, false);
+    });
+
+    it("preserves existing created_at and fact counters on update", () => {
+      const { payload } = buildSessionSummaryPayload({
+        draft: {
+          content: "Updated summary",
+          tasks_completed: [],
+          decisions_made: [],
+          entities: [],
+          importance: 0.8,
+        },
+        sessionId: "uuid:test-session",
+        scope: defaultScope,
+        now: "2026-04-25T11:00:00.000Z",
+        existing: {
+          id: "existing-id",
+          payload: {
+            content: "Old summary",
+            category: "projects",
+            entities: [],
+            confidence: 1,
+            content_hash: "old",
+            reinforcement_count: 3,
+            last_reinforced_at: "2026-04-25T10:00:00.000Z",
+            superseded_by: null,
+            superseded_at: null,
+            created_at: "2026-04-25T10:00:00.000Z",
+            updated_at: "2026-04-25T10:00:00.000Z",
+          },
+        },
+        eventCount: 3,
+        redactionOptions: { enabled: true, redactPii: true },
+      });
+
+      assert.equal(payload.created_at, "2026-04-25T10:00:00.000Z");
+      assert.equal(payload.updated_at, "2026-04-25T11:00:00.000Z");
+      assert.equal(payload.reinforcement_count, 3);
+      assert.equal(payload.last_reinforced_at, "2026-04-25T10:00:00.000Z");
+    });
+  });
+});

--- a/src/daemon/session-summary.ts
+++ b/src/daemon/session-summary.ts
@@ -1,0 +1,298 @@
+/**
+ * Compatibility wrapper for daemon-owned summaries.
+ *
+ * Sessions are routing/audit boundaries. Durable continuity is captured as
+ * episode summaries and workstream summaries; this module keeps the old
+ * updateSessionSummary entry point while writing session_index + episode data.
+ */
+import { createHash } from "node:crypto";
+
+import type { BikkyConfig } from "../config.js";
+import { loadConfig } from "../config.js";
+import { chatCompletion } from "../llm/index.js";
+import { DEFAULT_CAPTURE_CONTEXT, CAPTURE_POLICY_VERSION, PROMPT_VERSIONS } from "./capture-policy.js";
+import { segmentTranscriptIntoEpisodes, updateEpisodeSummary } from "./episode-summary.js";
+import { buildSessionIndexFilter, updateSessionIndex } from "./session-index.js";
+import { updateWorkstreamSummaries } from "./workstream-summary.js";
+import * as qdrant from "./qdrant.js";
+import type { QdrantPayload } from "./qdrant.js";
+
+export interface WorkspaceScope {
+  workspaceId?: string;
+  actorId?: string;
+  includeLegacy?: boolean;
+}
+
+export interface RedactionSummary {
+  redacted: boolean;
+  summary: string;
+  matches: Array<{ type: string; count: number }>;
+}
+
+const noRedaction = (): RedactionSummary => ({ redacted: false, summary: "none", matches: [] });
+const passthroughText = (text: string, _options?: { enabled: boolean; redactPii: boolean }): { text: string; redacted: boolean; summary: string; matches: Array<{ type: string; count: number }> } => ({
+  text,
+  ...noRedaction(),
+});
+const combinePassThrough = (): RedactionSummary => noRedaction();
+
+export interface SummaryEvent {
+  type: string;
+  content?: string;
+}
+
+export interface SessionSummaryDraft {
+  content: string;
+  tasks_completed: string[];
+  decisions_made: string[];
+  entities: string[];
+  importance: number;
+}
+
+export interface ExistingSummary {
+  id: string;
+  payload?: Partial<QdrantPayload>;
+}
+
+export interface SessionSummaryPayloadResult {
+  payload: Record<string, unknown>;
+  redaction: RedactionSummary;
+}
+
+export interface SessionSummaryUpdateResult {
+  action: "stored" | "updated" | "skipped";
+  factId?: string;
+  reason?: string;
+}
+
+const DEFAULT_SUMMARY_IMPORTANCE = 0.8;
+
+const contentHash = (text: string): string =>
+  createHash("sha256").update(`summary:${text}`).digest("hex");
+
+const stripJsonFence = (raw: string): string =>
+  raw.trim().replace(/^```(?:json)?\s*\n?/, "").replace(/\n?```\s*$/, "").trim();
+
+const normalizeStringArray = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter(Boolean))];
+};
+
+const normalizeEntityArray = (value: unknown): string[] =>
+  normalizeStringArray(value).map((entity) => entity.toLowerCase());
+
+const clampImportance = (value: unknown): number => {
+  if (typeof value !== "number" || Number.isNaN(value)) return DEFAULT_SUMMARY_IMPORTANCE;
+  return Math.min(1, Math.max(0.5, value));
+};
+
+export const hasCompactionSummary = (events: SummaryEvent[]): boolean =>
+  events.some((event) => event.type === "session.compaction_complete" && Boolean(event.content?.trim()));
+
+export const shouldSummarizeEvents = (events: SummaryEvent[], minEvents: number): boolean =>
+  events.length >= minEvents || hasCompactionSummary(events);
+
+export const buildSessionSummaryMessages = (input: {
+  transcript: string;
+  existingSummary?: string | null;
+}): Array<{ role: "system" | "user"; content: string }> => [
+  {
+    role: "system",
+    content:
+      "You are Bikky's background memory daemon. Maintain a lightweight session index for routing/audit only; do not treat the session as the durable project boundary. " +
+      "Preserve task/project context, important files, commands, decisions, failures, fixes, validation results, and open follow-ups. " +
+      "Bare status like 'tests passed' is only useful if tied to the branch/task/scope it validates. Output only valid JSON.",
+  },
+  {
+    role: "user",
+    content: `Update the existing session index with the new transcript. If there is no existing index, create one.
+
+## Existing summary
+${input.existingSummary?.trim() || "(none)"}
+
+## New transcript
+${input.transcript}
+
+## Output JSON shape
+{
+  "content": "2-5 sentence self-contained summary. It must make sense without the surrounding transcript.",
+  "tasks_completed": ["short task or milestone labels"],
+  "decisions_made": ["decision with rationale if present"],
+  "entities": ["lowercase key repos/services/files/tools"],
+  "importance": 0.5
+}
+
+Return only the JSON object.`,
+  },
+];
+
+export const parseSessionSummaryDraft = (raw: string): SessionSummaryDraft => {
+  const cleaned = stripJsonFence(raw);
+  const parsed = JSON.parse(cleaned) as Record<string, unknown>;
+  const contentValue = parsed.content ?? parsed.summary;
+  if (typeof contentValue !== "string" || !contentValue.trim()) {
+    throw new Error("Session summary response missing non-empty content");
+  }
+
+  return {
+    content: contentValue.trim(),
+    tasks_completed: normalizeStringArray(parsed.tasks_completed ?? parsed.tasks),
+    decisions_made: normalizeStringArray(parsed.decisions_made ?? parsed.decisions),
+    entities: normalizeEntityArray(parsed.entities),
+    importance: clampImportance(parsed.importance),
+  };
+};
+
+export const buildSessionSummaryFilter = (
+  sessionId: string,
+  scope: WorkspaceScope,
+): Record<string, unknown> => {
+  return buildSessionIndexFilter(sessionId, scope);
+};
+
+export const buildSessionSummaryPayload = (input: {
+  draft: SessionSummaryDraft;
+  sessionId: string;
+  scope: WorkspaceScope;
+  now: string;
+  existing?: ExistingSummary | null;
+  eventCount: number;
+  redactionOptions: { enabled: boolean; redactPii: boolean };
+}): SessionSummaryPayloadResult => {
+  const redactedContent = passthroughText(input.draft.content, input.redactionOptions);
+  const redactedTasks = input.draft.tasks_completed.map((task) => passthroughText(task, input.redactionOptions));
+  const redactedDecisions = input.draft.decisions_made.map((decision) => passthroughText(decision, input.redactionOptions));
+  const redactedEntities = input.draft.entities.map((entity) => passthroughText(entity, input.redactionOptions));
+  const redaction = combinePassThrough();
+  const existingPayload = input.existing?.payload ?? {};
+
+  const payload: Record<string, unknown> = {
+    ...existingPayload,
+    content: redactedContent.text,
+    category: "projects",
+    domain: DEFAULT_CAPTURE_CONTEXT.domain,
+    kind: "summary",
+    memory_subtype: "session_index",
+    layer: "episode",
+    ...(input.scope.workspaceId ? { workspace_id: input.scope.workspaceId } : {}),
+    ...(input.scope.actorId ? { actor_id: input.scope.actorId } : {}),
+    entities: redactedEntities.map((entity) => entity.text.toLowerCase()),
+    source: "system",
+    confidence: 1.0,
+    importance: input.draft.importance,
+    content_hash: contentHash(redactedContent.text),
+    reinforcement_count: existingPayload.reinforcement_count ?? 1,
+    last_reinforced_at: existingPayload.last_reinforced_at ?? input.now,
+    superseded_by: null,
+    superseded_at: null,
+    created_at: existingPayload.created_at ?? input.now,
+    updated_at: input.now,
+    session_id: input.sessionId,
+    prompt_version: PROMPT_VERSIONS.sessionIndex,
+    capture_policy_version: CAPTURE_POLICY_VERSION,
+    review_status: DEFAULT_CAPTURE_CONTEXT.reviewStatus,
+    tasks_completed: redactedTasks.map((task) => task.text),
+    decisions_made: redactedDecisions.map((decision) => decision.text),
+    metadata: {
+      ...(existingPayload.metadata ?? {}),
+      summarized_from_session: input.sessionId,
+      summary_source: "daemon",
+      summary_subtype: "session_index",
+      summary_event_count: String(input.eventCount),
+      summary_updated_at: input.now,
+    },
+  };
+
+  if (redaction.redacted) {
+    payload["redaction"] = redaction;
+  }
+
+  return { payload, redaction };
+};
+
+const redactionOptions = (_config: BikkyConfig): { enabled: boolean; redactPii: boolean } => ({
+  enabled: false,
+  redactPii: false,
+});
+
+const summarizeTranscript = async (input: {
+  transcript: string;
+  existingSummary?: string | null;
+}): Promise<SessionSummaryDraft> => {
+  const result = await chatCompletion({
+    messages: buildSessionSummaryMessages(input),
+    temperature: 0.2,
+    max_tokens: 1500,
+    response_format: { type: "json_object" },
+  });
+  if (!result) throw new Error("Session summary LLM returned null");
+  return parseSessionSummaryDraft(result);
+};
+
+const findExistingSummary = async (
+  sessionId: string,
+  scope: WorkspaceScope,
+): Promise<ExistingSummary | null> => {
+  const result = await qdrant.qdrantRequest("POST", `/collections/${qdrant.collection}/points/scroll`, {
+    filter: buildSessionSummaryFilter(sessionId, scope),
+    limit: 1,
+    with_payload: true,
+  }) as { result?: { points?: ExistingSummary[] } };
+
+  return result.result?.points?.[0] ?? null;
+};
+
+export const updateSessionSummary = async (input: {
+  sessionId: string;
+  transcript: string;
+  eventCount: number;
+  config?: BikkyConfig;
+}): Promise<SessionSummaryUpdateResult> => {
+  if (!input.transcript.trim()) {
+    return { action: "skipped", reason: "empty_transcript" };
+  }
+  if (!qdrant.isReady()) {
+    return { action: "skipped", reason: "qdrant_not_ready" };
+  }
+
+  const config = input.config ?? loadConfig();
+  const scope: WorkspaceScope = {};
+  const segments = segmentTranscriptIntoEpisodes({
+    sessionId: input.sessionId,
+    transcript: input.transcript,
+    eventCount: input.eventCount,
+  });
+  if (segments.length === 0) {
+    return { action: "skipped", reason: "no_episode_segments" };
+  }
+
+  const episodeResults = [];
+  for (const segment of segments) {
+    const result = await updateEpisodeSummary({ segment, sessionId: input.sessionId, scope, config });
+    if (result.action === "stored" || result.action === "updated") {
+      episodeResults.push(result);
+    }
+  }
+
+  if (episodeResults.length === 0) {
+    return { action: "skipped", reason: "no_episode_summaries" };
+  }
+
+  const indexResult = await updateSessionIndex({
+    sessionId: input.sessionId,
+    eventCount: input.eventCount,
+    episodeResults,
+    scope,
+    config,
+  });
+  await updateWorkstreamSummaries({ episodeResults, scope, config });
+
+  return {
+    action: indexResult.action,
+    factId: indexResult.factId,
+    reason: indexResult.reason,
+  };
+};

--- a/src/daemon/workstream-summary.test.ts
+++ b/src/daemon/workstream-summary.test.ts
@@ -1,0 +1,115 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildWorkstreamEpisodeFilter,
+  buildWorkstreamSummaryFilter,
+  buildWorkstreamSummaryMessages,
+  buildWorkstreamSummaryPayload,
+  groupEpisodeResultsByWorkstream,
+  parseWorkstreamSummaryDraft,
+} from "./workstream-summary.js";
+
+interface WorkspaceScope { workspaceId?: string; actorId?: string; includeLegacy?: boolean }
+
+const defaultScope: WorkspaceScope = {
+  workspaceId: "default",
+  includeLegacy: true,
+};
+
+describe("daemon/workstream-summary", () => {
+  it("groups only explicit workstream keys and leaves ambiguous episodes unassigned", () => {
+    const grouped = groupEpisodeResultsByWorkstream([
+      { action: "stored", factId: "fact-1", episodeId: "episode-1", workstreamKey: "task-a" },
+      { action: "stored", factId: "fact-2", episodeId: "episode-2", workstreamKey: null },
+      { action: "updated", factId: "fact-3", episodeId: "episode-3", workstreamKey: "task-a" },
+      { action: "stored", factId: "fact-4", episodeId: "episode-4", workstreamKey: "task-b" },
+    ]);
+
+    assert.equal(grouped.size, 2);
+    assert.equal(grouped.get("task-a")?.length, 2);
+    assert.equal(grouped.get("task-b")?.length, 1);
+    assert.equal(grouped.has(""), false);
+  });
+
+  it("prompts for current-state workstream summaries instead of diary chronology", () => {
+    const messages = buildWorkstreamSummaryMessages({
+      workstreamKey: "task-a",
+      existingSummary: "Old state",
+      episodeSummaries: ["Implemented ontology v2.", "Added tests."],
+    });
+
+    assert.match(messages[0].content, /current-state workstream summary/);
+    assert.match(messages[0].content, /Do not append a diary/);
+    assert.match(messages[1].content, /task-a/);
+  });
+
+  it("parses workstream summary drafts", () => {
+    const draft = parseWorkstreamSummaryDraft(`\`\`\`json
+{
+  "content": "Ontology v2 is implemented and extraction is being hardened.",
+  "current_decisions": ["Use domain for activity profile"],
+  "next_steps": ["Run full validation"],
+  "blockers": ["None"],
+  "entities": ["Bikky", "Qdrant"],
+  "importance": 0.9
+}
+\`\`\``);
+
+    assert.equal(draft.content, "Ontology v2 is implemented and extraction is being hardened.");
+    assert.deepEqual(draft.current_decisions, ["Use domain for activity profile"]);
+    assert.deepEqual(draft.entities, ["bikky", "qdrant"]);
+  });
+
+  it("builds filters scoped to workstream subtype", () => {
+    const summaryFilter = buildWorkstreamSummaryFilter("task-a", defaultScope);
+    assert.ok((summaryFilter.must as unknown[]).some((condition) =>
+      JSON.stringify(condition) === JSON.stringify({ key: "memory_subtype", match: { value: "workstream" } }),
+    ));
+
+    const episodeFilter = buildWorkstreamEpisodeFilter("task-a", defaultScope);
+    assert.ok((episodeFilter.must as unknown[]).some((condition) =>
+      JSON.stringify(condition) === JSON.stringify({ key: "memory_subtype", match: { value: "episode" } }),
+    ));
+  });
+
+  it("omits workspace filters when no workspace is supplied", () => {
+    const summaryFilter = buildWorkstreamSummaryFilter("task-a", {});
+    const episodeFilter = buildWorkstreamEpisodeFilter("task-a", {});
+    assert.equal(summaryFilter.should, undefined);
+    assert.equal(episodeFilter.should, undefined);
+    assert.equal((summaryFilter.must as unknown[]).some((condition) =>
+      JSON.stringify(condition).includes("workspace_id"),
+    ), false);
+    assert.equal((episodeFilter.must as unknown[]).some((condition) =>
+      JSON.stringify(condition).includes("workspace_id"),
+    ), false);
+  });
+
+  it("builds one current-state payload per workstream", () => {
+    const { payload } = buildWorkstreamSummaryPayload({
+      draft: {
+        content: "Ontology v2 implementation is in validation.",
+        current_decisions: ["Use software_engineering as the default domain"],
+        next_steps: ["Run npm test"],
+        blockers: [],
+        entities: ["bikky"],
+        importance: 0.85,
+      },
+      workstreamKey: "243-bikky-data-capture-policy",
+      scope: { workspaceId: "team-a", actorId: "agent-1", includeLegacy: false },
+      now: "2026-04-25T12:00:00.000Z",
+      sourceEpisodeIds: ["episode-1", "episode-2"],
+      repo: "bikky-dev/bikky",
+      redactionOptions: { enabled: true, redactPii: true },
+    });
+
+    assert.equal(payload.kind, "summary");
+    assert.equal(payload.memory_subtype, "workstream");
+    assert.equal(payload.layer, "workstream");
+    assert.equal(payload.workstream_key, "243-bikky-data-capture-policy");
+    assert.equal(payload.repo, "bikky-dev/bikky");
+    assert.deepEqual(payload.source_episode_ids, ["episode-1", "episode-2"]);
+    assert.equal((payload.metadata as Record<string, string>).summary_subtype, "workstream");
+  });
+});

--- a/src/daemon/workstream-summary.ts
+++ b/src/daemon/workstream-summary.ts
@@ -1,0 +1,350 @@
+/**
+ * Workstream summaries.
+ *
+ * Workstream summaries are durable current-state records keyed by
+ * workspace + repo/surface + workstream_key. They are conservative: ambiguous
+ * episodes are not merged.
+ */
+import { createHash, randomUUID } from "node:crypto";
+
+import type { BikkyConfig } from "../config.js";
+import { chatCompletion } from "../llm/index.js";
+import {
+  CAPTURE_BUDGETS,
+  CAPTURE_POLICY_VERSION,
+  CAPTURE_TRIGGERS,
+  DEFAULT_CAPTURE_CONTEXT,
+  PROMPT_VERSIONS,
+} from "./capture-policy.js";
+import type { EpisodeSummaryWriteResult } from "./episode-summary.js";
+import * as qdrant from "./qdrant.js";
+import type { QdrantPayload } from "./qdrant.js";
+
+export interface WorkspaceScope {
+  workspaceId?: string;
+  actorId?: string;
+  includeLegacy?: boolean;
+}
+
+export interface RedactionSummary {
+  redacted: boolean;
+  summary: string;
+  matches: Array<{ type: string; count: number }>;
+}
+
+const noRedaction = (): RedactionSummary => ({ redacted: false, summary: "none", matches: [] });
+const passthroughText = (text: string, _options?: { enabled: boolean; redactPii: boolean }): { text: string; redacted: boolean; summary: string; matches: Array<{ type: string; count: number }> } => ({
+  text,
+  ...noRedaction(),
+});
+const combinePassThrough = (): RedactionSummary => noRedaction();
+
+export interface WorkstreamSummaryDraft {
+  content: string;
+  current_decisions: string[];
+  next_steps: string[];
+  blockers: string[];
+  entities: string[];
+  importance: number;
+}
+
+export interface WorkstreamSummaryPayloadResult {
+  payload: Record<string, unknown>;
+  redaction: RedactionSummary;
+}
+
+export interface WorkstreamUpdateResult {
+  action: "stored" | "updated" | "skipped";
+  factId?: string;
+  workstreamKey?: string;
+  reason?: string;
+}
+
+const contentHash = (text: string): string =>
+  createHash("sha256").update(`workstream:${text}`).digest("hex");
+
+const stripJsonFence = (raw: string): string =>
+  raw.trim().replace(/^```(?:json)?\s*\n?/, "").replace(/\n?```\s*$/, "").trim();
+
+const normalizeStringArray = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter(Boolean))];
+};
+
+const clampImportance = (value: unknown): number => {
+  if (typeof value !== "number" || Number.isNaN(value)) return 0.8;
+  return Math.min(1, Math.max(0.5, value));
+};
+
+export const groupEpisodeResultsByWorkstream = (
+  episodeResults: EpisodeSummaryWriteResult[],
+): Map<string, EpisodeSummaryWriteResult[]> => {
+  const grouped = new Map<string, EpisodeSummaryWriteResult[]>();
+  for (const result of episodeResults) {
+    const key = result.workstreamKey?.trim();
+    if (!key || !result.episodeId) continue;
+    const existing = grouped.get(key) ?? [];
+    existing.push(result);
+    grouped.set(key, existing);
+  }
+  return grouped;
+};
+
+export const buildWorkstreamSummaryMessages = (input: {
+  workstreamKey: string;
+  existingSummary?: string | null;
+  episodeSummaries: string[];
+}): Array<{ role: "system" | "user"; content: string }> => [
+  {
+    role: "system",
+    content:
+      "You are Bikky's background memory daemon. Maintain one current-state workstream summary. " +
+      "Do not append a diary or timeline; synthesize the latest durable state, decisions, blockers, and next steps. " +
+      "If an episode is unrelated or ambiguous, ignore it. Output only valid JSON.",
+  },
+  {
+    role: "user",
+    content: `Update the current-state summary for workstream "${input.workstreamKey}".
+
+## Existing workstream summary
+${input.existingSummary?.trim() || "(none)"}
+
+## New episode summaries
+${input.episodeSummaries.map((summary, index) => `${index + 1}. ${summary}`).join("\n\n")}
+
+## Output JSON shape
+{
+  "content": "${CAPTURE_BUDGETS.workstreamSummary.targetWords[0]}-${CAPTURE_BUDGETS.workstreamSummary.targetWords[1]} words, current state only",
+  "current_decisions": ["durable decisions and rationale"],
+  "next_steps": ["specific next actions"],
+  "blockers": ["active blockers or risks"],
+  "entities": ["lowercase key repos/services/files/tools"],
+  "importance": 0.8
+}
+
+Return only the JSON object.`,
+  },
+];
+
+export const parseWorkstreamSummaryDraft = (raw: string): WorkstreamSummaryDraft => {
+  const parsed = JSON.parse(stripJsonFence(raw)) as Record<string, unknown>;
+  const contentValue = parsed.content ?? parsed.summary;
+  if (typeof contentValue !== "string" || !contentValue.trim()) {
+    throw new Error("Workstream summary response missing non-empty content");
+  }
+
+  return {
+    content: contentValue.trim(),
+    current_decisions: normalizeStringArray(parsed.current_decisions ?? parsed.decisions),
+    next_steps: normalizeStringArray(parsed.next_steps ?? parsed.follow_ups),
+    blockers: normalizeStringArray(parsed.blockers ?? parsed.risks),
+    entities: normalizeStringArray(parsed.entities).map((entity) => entity.toLowerCase()),
+    importance: clampImportance(parsed.importance),
+  };
+};
+
+export const buildWorkstreamSummaryFilter = (
+  workstreamKey: string,
+  scope: WorkspaceScope,
+  repo?: string | null,
+): Record<string, unknown> => {
+  const must: Record<string, unknown>[] = [
+    { key: "workstream_key", match: { value: workstreamKey } },
+    { key: "kind", match: { value: "summary" } },
+    { key: "memory_subtype", match: { value: "workstream" } },
+    { is_null: { key: "superseded_by" } },
+  ];
+  if (repo) {
+    must.push({ key: "repo", match: { value: repo } });
+  }
+  const filter: Record<string, unknown> = { must };
+  if (scope.workspaceId && scope.includeLegacy) {
+    filter["should"] = [
+      { key: "workspace_id", match: { value: scope.workspaceId } },
+      { is_empty: { key: "workspace_id" } },
+    ];
+  } else if (scope.workspaceId) {
+    must.push({ key: "workspace_id", match: { value: scope.workspaceId } });
+  }
+  return filter;
+};
+
+export const buildWorkstreamEpisodeFilter = (
+  workstreamKey: string,
+  scope: WorkspaceScope,
+): Record<string, unknown> => {
+  const must: Record<string, unknown>[] = [
+    { key: "workstream_key", match: { value: workstreamKey } },
+    { key: "kind", match: { value: "summary" } },
+    { key: "memory_subtype", match: { value: "episode" } },
+    { is_null: { key: "superseded_by" } },
+  ];
+  const filter: Record<string, unknown> = { must };
+  if (scope.workspaceId && scope.includeLegacy) {
+    filter["should"] = [
+      { key: "workspace_id", match: { value: scope.workspaceId } },
+      { is_empty: { key: "workspace_id" } },
+    ];
+  } else if (scope.workspaceId) {
+    must.push({ key: "workspace_id", match: { value: scope.workspaceId } });
+  }
+  return filter;
+};
+
+export const buildWorkstreamSummaryPayload = (input: {
+  draft: WorkstreamSummaryDraft;
+  workstreamKey: string;
+  scope: WorkspaceScope;
+  now: string;
+  existing?: { id: string; payload?: Partial<QdrantPayload> } | null;
+  sourceEpisodeIds: string[];
+  repo?: string | null;
+  redactionOptions: { enabled: boolean; redactPii: boolean };
+}): WorkstreamSummaryPayloadResult => {
+  const redactedContent = passthroughText(input.draft.content, input.redactionOptions);
+  const redactedDecisions = input.draft.current_decisions.map((decision) => passthroughText(decision, input.redactionOptions));
+  const redactedNextSteps = input.draft.next_steps.map((step) => passthroughText(step, input.redactionOptions));
+  const redactedBlockers = input.draft.blockers.map((blocker) => passthroughText(blocker, input.redactionOptions));
+  const redactedEntities = input.draft.entities.map((entity) => passthroughText(entity, input.redactionOptions));
+  const redaction = combinePassThrough();
+  const existingPayload = input.existing?.payload ?? {};
+
+  const payload: Record<string, unknown> = {
+    ...existingPayload,
+    content: redactedContent.text,
+    category: "projects",
+    domain: DEFAULT_CAPTURE_CONTEXT.domain,
+    kind: "summary",
+    memory_subtype: "workstream",
+    layer: "workstream",
+    ...(input.scope.workspaceId ? { workspace_id: input.scope.workspaceId } : {}),
+    ...(input.scope.actorId ? { actor_id: input.scope.actorId } : {}),
+    ...(input.repo ? { repo: input.repo } : {}),
+    entities: redactedEntities.map((entity) => entity.text.toLowerCase()),
+    source: "system",
+    confidence: 1.0,
+    importance: input.draft.importance,
+    content_hash: contentHash(redactedContent.text),
+    reinforcement_count: existingPayload.reinforcement_count ?? 1,
+    last_reinforced_at: existingPayload.last_reinforced_at ?? input.now,
+    superseded_by: null,
+    superseded_at: null,
+    created_at: existingPayload.created_at ?? input.now,
+    updated_at: input.now,
+    workstream_key: input.workstreamKey,
+    source_episode_ids: input.sourceEpisodeIds,
+    prompt_version: PROMPT_VERSIONS.workstreamSummary,
+    capture_policy_version: CAPTURE_POLICY_VERSION,
+    review_status: DEFAULT_CAPTURE_CONTEXT.reviewStatus,
+    current_decisions: redactedDecisions.map((decision) => decision.text),
+    next_steps: redactedNextSteps.map((step) => step.text),
+    blockers: redactedBlockers.map((blocker) => blocker.text),
+    metadata: {
+      ...(existingPayload.metadata ?? {}),
+      summary_source: "daemon",
+      summary_subtype: "workstream",
+      workstream_key: input.workstreamKey,
+      source_episode_ids: input.sourceEpisodeIds.join(","),
+      summary_updated_at: input.now,
+    },
+  };
+
+  if (redaction.redacted) {
+    payload["redaction"] = redaction;
+  }
+
+  return { payload, redaction };
+};
+
+const findExistingWorkstreamSummary = async (
+  workstreamKey: string,
+  scope: WorkspaceScope,
+  repo?: string | null,
+): Promise<{ id: string; payload?: Partial<QdrantPayload> } | null> => {
+  const result = await qdrant.qdrantRequest("POST", `/collections/${qdrant.collection}/points/scroll`, {
+    filter: buildWorkstreamSummaryFilter(workstreamKey, scope, repo),
+    limit: 1,
+    with_payload: true,
+  }) as { result?: { points?: Array<{ id: string; payload?: Partial<QdrantPayload> }> } };
+  return result.result?.points?.[0] ?? null;
+};
+
+const loadEpisodeSummaries = async (
+  workstreamKey: string,
+  scope: WorkspaceScope,
+): Promise<Array<{ id: string; payload?: Partial<QdrantPayload> }>> => {
+  const result = await qdrant.qdrantRequest("POST", `/collections/${qdrant.collection}/points/scroll`, {
+    filter: buildWorkstreamEpisodeFilter(workstreamKey, scope),
+    limit: CAPTURE_TRIGGERS.workstreamSummary.maxEpisodesPerUpdate,
+    with_payload: true,
+  }) as { result?: { points?: Array<{ id: string; payload?: Partial<QdrantPayload> }> } };
+  return result.result?.points ?? [];
+};
+
+const summarizeWorkstream = async (input: {
+  workstreamKey: string;
+  existingSummary?: string | null;
+  episodeSummaries: string[];
+}): Promise<WorkstreamSummaryDraft> => {
+  const result = await chatCompletion({
+    messages: buildWorkstreamSummaryMessages(input),
+    temperature: 0.2,
+    max_tokens: 1800,
+    response_format: { type: "json_object" },
+  });
+  if (!result) throw new Error("Workstream summary LLM returned null");
+  return parseWorkstreamSummaryDraft(result);
+};
+
+export const updateWorkstreamSummaries = async (input: {
+  episodeResults: EpisodeSummaryWriteResult[];
+  scope: WorkspaceScope;
+  config: BikkyConfig;
+}): Promise<WorkstreamUpdateResult[]> => {
+  const grouped = groupEpisodeResultsByWorkstream(input.episodeResults);
+  if (grouped.size === 0) return [{ action: "skipped", reason: "no_workstream_keys" }];
+
+  const results: WorkstreamUpdateResult[] = [];
+  for (const [workstreamKey] of grouped) {
+    const episodes = await loadEpisodeSummaries(workstreamKey, input.scope);
+    const episodeSummaries = episodes
+      .map((episode) => episode.payload?.content)
+      .filter((content): content is string => Boolean(content?.trim()));
+    if (episodeSummaries.length < CAPTURE_TRIGGERS.workstreamSummary.minEpisodeCount) {
+      results.push({ action: "skipped", reason: "not_enough_episodes", workstreamKey });
+      continue;
+    }
+
+    const existing = await findExistingWorkstreamSummary(workstreamKey, input.scope, null);
+    const draft = await summarizeWorkstream({
+      workstreamKey,
+      existingSummary: existing?.payload?.content ?? null,
+      episodeSummaries,
+    });
+    const now = new Date().toISOString();
+    const { payload } = buildWorkstreamSummaryPayload({
+      draft,
+      workstreamKey,
+      scope: input.scope,
+      now,
+      existing,
+      sourceEpisodeIds: episodes.map((episode) => episode.payload?.episode_id ?? episode.id).filter(Boolean) as string[],
+      repo: null,
+      redactionOptions: {
+        enabled: false,
+        redactPii: false,
+      },
+    });
+    const vector = await qdrant.embed(String(payload.content));
+    const factId = existing?.id ?? randomUUID();
+    await qdrant.qdrantRequest("PUT", `/collections/${qdrant.collection}/points`, {
+      points: [{ id: factId, vector, payload }],
+    });
+    results.push({ action: existing ? "updated" : "stored", factId, workstreamKey });
+  }
+
+  return results;
+};

--- a/src/mcp/helpers.test.ts
+++ b/src/mcp/helpers.test.ts
@@ -16,6 +16,7 @@ import {
   isStale,
   buildFilter,
   formatFact,
+  MEMORY_RECALL_EXCLUDED_KINDS,
 } from "./helpers.js";
 import type { FactPayload, QdrantPoint } from "./types.js";
 
@@ -417,11 +418,11 @@ describe("buildFilter", () => {
   });
 
   it("adds domain filter", () => {
-    const result = buildFilter({ domain: "personal" });
+    const result = buildFilter({ domain: "software_engineering" });
     assert.ok(result);
     const domFilter = result.must.find((c) => c.key === "domain");
     assert.ok(domFilter);
-    assert.deepStrictEqual(domFilter.match, { value: "personal" });
+    assert.deepStrictEqual(domFilter.match, { value: "software_engineering" });
   });
 
   it("adds kind filter", () => {
@@ -430,6 +431,40 @@ describe("buildFilter", () => {
     const kindFilter = result.must.find((c) => c.key === "kind");
     assert.ok(kindFilter);
     assert.deepStrictEqual(kindFilter.match, { value: "summary" });
+  });
+
+  it("adds workspace filter", () => {
+    const result = buildFilter({ workspace_id: "platform" });
+    assert.ok(result);
+    const workspaceFilter = result.must.find((c) => c.key === "workspace_id");
+    assert.ok(workspaceFilter);
+    assert.deepStrictEqual(workspaceFilter.match, { value: "platform" });
+  });
+
+  it("can include legacy unscoped workspace facts", () => {
+    const result = buildFilter({ workspace_id: "default", includeLegacyWorkspace: true });
+    assert.ok(result);
+    assert.deepStrictEqual(result.should, [
+      { key: "workspace_id", match: { value: "default" } },
+      { is_empty: { key: "workspace_id" } },
+    ]);
+  });
+
+  it("can exclude telemetry from recall filters", () => {
+    const result = buildFilter({ excludeKinds: ["telemetry"] });
+    assert.ok(result);
+    assert.deepStrictEqual(result.must_not, [
+      { key: "kind", match: { value: "telemetry" } },
+    ]);
+  });
+
+  it("keeps telemetry excluded from memory recall even when kind is requested", () => {
+    const result = buildFilter({ kind: "telemetry", excludeKinds: MEMORY_RECALL_EXCLUDED_KINDS });
+    assert.ok(result);
+    assert.ok(result.must.some((condition) => condition.key === "kind" && condition.match?.value === "telemetry"));
+    assert.deepStrictEqual(result.must_not, [
+      { key: "kind", match: { value: "telemetry" } },
+    ]);
   });
 
   it("adds entity filter (lowercased)", () => {
@@ -487,13 +522,14 @@ describe("buildFilter", () => {
       category: "infrastructure",
       domain: "work",
       kind: "fact",
+      workspace_id: "platform",
       entity: "redis",
       since: "2025-01-01T00:00:00Z",
       metadata: { source: "test" },
     });
     assert.ok(result);
-    // superseded (default) + category + domain + kind + entity + since + metadata
-    assert.strictEqual(result.must.length, 7);
+    // superseded (default) + category + domain + kind + workspace + entity + since + metadata
+    assert.strictEqual(result.must.length, 8);
   });
 });
 
@@ -533,16 +569,28 @@ describe("formatFact", () => {
     assert.ok(formatted.includes("rank: 0.723"));
   });
 
-  it("includes domain when not 'work'", () => {
-    const point = makePoint({}, { domain: "personal" });
+  it("includes domain when not the default domain profile", () => {
+    const point = makePoint({}, { domain: "product_strategy" });
     const formatted = formatFact(point);
-    assert.ok(formatted.includes("domain: personal"));
+    assert.ok(formatted.includes("domain: product_strategy"));
   });
 
-  it("does not include domain when 'work'", () => {
-    const point = makePoint({}, { domain: "work" });
+  it("does not include the default domain profile", () => {
+    const point = makePoint({}, { domain: "software_engineering" });
     const formatted = formatFact(point);
     assert.ok(!formatted.includes("domain:"));
+  });
+
+  it("includes ontology routing fields when present", () => {
+    const point = makePoint({}, {
+      memory_subtype: "episode",
+      workstream_key: "task-123",
+      episode_id: "session-1:0-10",
+    });
+    const formatted = formatFact(point);
+    assert.ok(formatted.includes("subtype: episode"));
+    assert.ok(formatted.includes("workstream: task-123"));
+    assert.ok(formatted.includes("episode: session-1:0-10"));
   });
 
   it("includes kind when not 'fact'", () => {
@@ -577,5 +625,26 @@ describe("formatFact", () => {
     const point = makePoint({}, { verification_count: 2 });
     const formatted = formatFact(point);
     assert.ok(formatted.includes("verified: 2x"));
+  });
+
+  it("includes non-default workspace and redaction metadata", () => {
+    const point = makePoint({}, {
+      workspace_id: "platform",
+      redaction: {
+        redacted: true,
+        summary: "email:1",
+        matches: [{ type: "email", count: 1 }],
+      },
+    });
+    const formatted = formatFact(point);
+    assert.ok(formatted.includes("workspace: platform"));
+    assert.ok(formatted.includes("redacted: email:1"));
+  });
+
+  it("includes feedback counts", () => {
+    const point = makePoint({}, { useful_count: 2, not_useful_count: 1 });
+    const formatted = formatFact(point);
+    assert.ok(formatted.includes("useful: 2x"));
+    assert.ok(formatted.includes("not useful: 1x"));
   });
 });

--- a/src/mcp/helpers.ts
+++ b/src/mcp/helpers.ts
@@ -6,7 +6,7 @@
 
 import crypto from "node:crypto";
 import type { FactPayload, FilterParams, QdrantFilter, QdrantPoint } from "./types.js";
-import { DECAY_HALF_LIFE, DECAY_DEFAULT_HALF_LIFE, STALENESS_DAYS } from "./taxonomy.js";
+import { DEFAULT_DOMAIN, getDecayHalfLife, STALENESS_DAYS } from "./taxonomy.js";
 
 // ---------------------------------------------------------------------------
 // Hashing
@@ -41,8 +41,11 @@ export function lastActivityDate(payload: FactPayload): string | undefined {
  * Categories with null half-life (session_summary, distilled) don't decay.
  */
 export function computeEffectiveConfidence(payload: FactPayload): number {
-  const cat = payload.category;
-  const halfLife = cat in DECAY_HALF_LIFE ? DECAY_HALF_LIFE[cat] : DECAY_DEFAULT_HALF_LIFE;
+  const halfLife = getDecayHalfLife({
+    category: payload.category,
+    domain: payload.domain,
+    kind: payload.kind,
+  });
   if (halfLife === null || halfLife === undefined) return payload.confidence;
   const days = daysSince(lastActivityDate(payload));
   const decayFactor = Math.pow(0.5, days / halfLife);
@@ -87,10 +90,35 @@ export function isStale(payload: FactPayload): boolean {
 // Filter building
 // ---------------------------------------------------------------------------
 
+export const MEMORY_RECALL_EXCLUDED_KINDS = ["telemetry"];
+
 /** Build a Qdrant filter object from optional params. */
 export function buildFilter(params: FilterParams = {}): QdrantFilter | undefined {
-  const { category, domain, kind, entity, since, until, excludeSuperseded = true, metadata } = params;
+  const {
+    category,
+    domain,
+    kind,
+    memory_subtype,
+    workspace_id,
+    includeLegacyWorkspace = false,
+    actor_id,
+    entity,
+    session_id,
+    episode_id,
+    workstream_key,
+    task_key,
+    repo,
+    branch,
+    review_status,
+    since,
+    until,
+    excludeSuperseded = true,
+    excludeKinds = [],
+    metadata,
+  } = params;
   const must: QdrantFilter["must"] = [];
+  const must_not: QdrantFilter["must_not"] = [];
+  const should: QdrantFilter["should"] = [];
 
   if (excludeSuperseded) {
     must.push({ is_null: { key: "superseded_by" } });
@@ -104,8 +132,37 @@ export function buildFilter(params: FilterParams = {}): QdrantFilter | undefined
   if (kind) {
     must.push({ key: "kind", match: { value: kind } });
   }
+  if (memory_subtype) {
+    must.push({ key: "memory_subtype", match: { value: memory_subtype } });
+  }
+  if (workspace_id) {
+    if (includeLegacyWorkspace) {
+      should.push(
+        { key: "workspace_id", match: { value: workspace_id } },
+        { is_empty: { key: "workspace_id" } },
+      );
+    } else {
+      must.push({ key: "workspace_id", match: { value: workspace_id } });
+    }
+  }
+  if (actor_id) {
+    must.push({ key: "actor_id", match: { value: actor_id } });
+  }
   if (entity) {
     must.push({ key: "entities", match: { value: entity.toLowerCase() } });
+  }
+  for (const [key, value] of Object.entries({
+    session_id,
+    episode_id,
+    workstream_key,
+    task_key,
+    repo,
+    branch,
+    review_status,
+  })) {
+    if (value) {
+      must.push({ key, match: { value } });
+    }
   }
   if (since && until) {
     must.push({ key: "created_at", range: { gte: since, lte: until } });
@@ -119,7 +176,16 @@ export function buildFilter(params: FilterParams = {}): QdrantFilter | undefined
       must.push({ key: `metadata.${k}`, match: { value: v } });
     }
   }
-  return must.length > 0 ? { must } : undefined;
+  for (const excludedKind of excludeKinds) {
+    must_not.push({ key: "kind", match: { value: excludedKind } });
+  }
+
+  if (must.length === 0 && should.length === 0 && must_not.length === 0) return undefined;
+  return {
+    must,
+    ...(should.length > 0 ? { should } : {}),
+    ...(must_not.length > 0 ? { must_not } : {}),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -133,8 +199,12 @@ export function formatFact(point: QdrantPoint): string {
   const stale = isStale(p);
   const parts: string[] = [`${stale ? "🕰️ " : ""}[${p.category}] ${p.content}`];
 
-  if (p.domain && p.domain !== "work") parts.push(`domain: ${p.domain}`);
+  if (p.domain && p.domain !== DEFAULT_DOMAIN) parts.push(`domain: ${p.domain}`);
   if (p.kind && p.kind !== "fact") parts.push(`kind: ${p.kind}`);
+  if (p.memory_subtype) parts.push(`subtype: ${p.memory_subtype}`);
+  if (p.workspace_id && p.workspace_id !== "default") parts.push(`workspace: ${p.workspace_id}`);
+  if (p.workstream_key) parts.push(`workstream: ${p.workstream_key}`);
+  if (p.episode_id) parts.push(`episode: ${p.episode_id}`);
   if (p.entities?.length) parts.push(`entities: ${p.entities.join(", ")}`);
   if (effectiveConf < p.confidence) {
     parts.push(`confidence: ${p.confidence} → effective: ${effectiveConf}`);
@@ -143,6 +213,9 @@ export function formatFact(point: QdrantPoint): string {
   }
   if (p.reinforcement_count > 1) parts.push(`reinforced: ${p.reinforcement_count}x`);
   if ((p.verification_count ?? 0) > 0) parts.push(`verified: ${p.verification_count}x`);
+  if ((p.useful_count ?? 0) > 0) parts.push(`useful: ${p.useful_count}x`);
+  if ((p.not_useful_count ?? 0) > 0) parts.push(`not useful: ${p.not_useful_count}x`);
+  if (p.redaction?.redacted) parts.push(`redacted: ${p.redaction.summary}`);
   if (p.metadata && Object.keys(p.metadata).length > 0) {
     const metaPairs = Object.entries(p.metadata).map(([k, v]) => `${k}=${v}`).join(", ");
     parts.push(`metadata: {${metaPairs}}`);

--- a/src/mcp/taxonomy.test.ts
+++ b/src/mcp/taxonomy.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the taxonomy module — classification axes, decay, staleness.
+ * Tests for the Bikky memory ontology.
  */
 
 import { describe, it } from "node:test";
@@ -7,429 +7,228 @@ import assert from "node:assert/strict";
 
 import {
   CATEGORIES,
-  DOMAINS,
-  KINDS,
-  SOURCES,
-  DECAY_HALF_LIFE,
   DECAY_DEFAULT_HALF_LIFE,
-  STALENESS_DAYS,
-  THRESHOLD_DUPLICATE,
-  THRESHOLD_RELATED,
-  QDRANT_INDEXES,
-  SOURCE_MIGRATION,
   DEFAULT_DOMAIN,
   DEFAULT_KIND,
   DEFAULT_SOURCE,
+  DOMAINS,
+  LAYERS,
+  MEMORY_SUBTYPES,
+  QDRANT_INDEXES,
+  SOURCES,
+  STALENESS_DAYS,
+  THRESHOLD_DUPLICATE,
+  THRESHOLD_RELATED,
+  canonicalCategoryValues,
+  canonicalDomainValues,
+  categoryForMemorySubtype,
   categoryValues,
+  defaultMemorySubtypeForKind,
   domainValues,
+  getDecayHalfLife,
   kindValues,
-  sourceValues,
+  layerForMemorySubtype,
+  layerValues,
+  memorySubtypeValues,
+  memorySubtypeValuesForKind,
   normalizeCategory,
   normalizeDomain,
   normalizeKind,
+  normalizeLayer,
+  normalizeMemorySubtype,
   normalizeSource,
-  getDecayHalfLife,
+  sourceValues,
+  validateMemorySubtype,
 } from "./taxonomy.js";
 
-// ---------------------------------------------------------------------------
-// Value arrays
-// ---------------------------------------------------------------------------
-
-describe("categoryValues", () => {
-  it("returns array with expected categories", () => {
-    const vals = categoryValues();
-    assert.ok(Array.isArray(vals));
-    assert.ok(vals.includes("infrastructure"));
-    assert.ok(vals.includes("decisions"));
-    assert.ok(vals.includes("observation"));
-    assert.ok(vals.includes("preferences"));
-    assert.ok(vals.includes("projects"));
-    assert.ok(vals.includes("team"));
+describe("ontology values", () => {
+  it("defines canonical software-engineering categories", () => {
+    const values = canonicalCategoryValues();
+    assert.deepStrictEqual(values, [
+      "codebase",
+      "infrastructure",
+      "operations",
+      "decisions",
+      "product_domain",
+      "projects",
+      "people",
+      "preferences",
+      "observations",
+    ]);
   });
 
-  it("has exactly 6 categories", () => {
-    assert.strictEqual(categoryValues().length, 6);
-  });
-});
-
-describe("domainValues", () => {
-  it("returns array with work and personal", () => {
-    const vals = domainValues();
-    assert.ok(vals.includes("work"));
-    assert.ok(vals.includes("personal"));
+  it("exposes only canonical ontology v2 categories", () => {
+    assert.deepStrictEqual(categoryValues(), canonicalCategoryValues());
+    assert.ok(!categoryValues().includes("observation"));
+    assert.ok(!categoryValues().includes("team"));
   });
 
-  it("has exactly 2 domains", () => {
-    assert.strictEqual(domainValues().length, 2);
-  });
-});
-
-describe("kindValues", () => {
-  it("returns expected kinds", () => {
-    const vals = kindValues();
-    assert.ok(vals.includes("fact"));
-    assert.ok(vals.includes("summary"));
-    assert.ok(vals.includes("distilled"));
-    assert.ok(vals.includes("relation"));
-  });
-
-  it("has exactly 4 kinds", () => {
-    assert.strictEqual(kindValues().length, 4);
-  });
-});
-
-describe("sourceValues", () => {
-  it("returns expected sources", () => {
-    const vals = sourceValues();
-    assert.ok(vals.includes("agent"));
-    assert.ok(vals.includes("daemon"));
-    assert.ok(vals.includes("system"));
-    assert.ok(vals.includes("user"));
-    assert.ok(vals.includes("docs"));
+  it("defines domain profiles rather than work/personal scopes", () => {
+    const values = canonicalDomainValues();
+    assert.deepStrictEqual(values, [
+      "software_engineering",
+      "product_strategy",
+      "business_operations",
+      "research",
+      "personal_productivity",
+    ]);
+    assert.deepStrictEqual(domainValues(), values);
+    assert.ok(!domainValues().includes("work"));
+    assert.ok(!domainValues().includes("personal"));
   });
 
-  it("has exactly 5 sources", () => {
-    assert.strictEqual(sourceValues().length, 5);
+  it("keeps stable kinds, sources, and layers", () => {
+    assert.deepStrictEqual(kindValues(), ["fact", "summary", "distilled", "relation", "telemetry"]);
+    assert.deepStrictEqual(sourceValues(), ["agent", "daemon", "system", "user", "docs"]);
+    assert.deepStrictEqual(layerValues(), [
+      "workspace",
+      "domain",
+      "surface",
+      "workstream",
+      "episode",
+      "memory_object",
+    ]);
   });
-});
 
-// ---------------------------------------------------------------------------
-// Record objects
-// ---------------------------------------------------------------------------
-
-describe("CATEGORIES", () => {
-  it("has description and extractionHint for each category", () => {
+  it("has descriptions and examples where useful", () => {
     for (const [key, def] of Object.entries(CATEGORIES)) {
       assert.ok(def.description, `${key} missing description`);
-      assert.ok(def.extractionHint, `${key} missing extractionHint`);
-      assert.ok(Array.isArray(def.examples), `${key} missing examples`);
-      assert.ok(def.examples.length > 0, `${key} has no examples`);
+      assert.ok(def.examples.length > 0, `${key} missing examples`);
     }
-  });
-
-  it("examples have required fields", () => {
-    for (const [key, def] of Object.entries(CATEGORIES)) {
-      for (const ex of def.examples) {
-        assert.ok(typeof ex.content === "string", `${key} example missing content`);
-        assert.ok(Array.isArray(ex.entities), `${key} example missing entities`);
-        assert.ok(typeof ex.confidence === "number", `${key} example missing confidence`);
-        assert.ok(typeof ex.importance === "number", `${key} example missing importance`);
-      }
-    }
-  });
-});
-
-describe("DOMAINS", () => {
-  it("has description for each domain", () => {
     for (const [key, def] of Object.entries(DOMAINS)) {
       assert.ok(def.description, `${key} missing description`);
+      assert.ok(def.defaultCategories.length > 0, `${key} missing default categories`);
     }
-  });
-});
-
-describe("KINDS", () => {
-  it("has description for each kind", () => {
-    for (const [key, def] of Object.entries(KINDS)) {
+    for (const [key, def] of Object.entries(LAYERS)) {
       assert.ok(def.description, `${key} missing description`);
     }
-  });
-});
-
-describe("SOURCES", () => {
-  it("has description for each source", () => {
     for (const [key, def] of Object.entries(SOURCES)) {
       assert.ok(def.description, `${key} missing description`);
     }
   });
 });
 
-// ---------------------------------------------------------------------------
-// Defaults
-// ---------------------------------------------------------------------------
-
-describe("defaults", () => {
-  it("DEFAULT_DOMAIN is 'work'", () => {
-    assert.strictEqual(DEFAULT_DOMAIN, "work");
-  });
-
-  it("DEFAULT_KIND is 'fact'", () => {
+describe("defaults and thresholds", () => {
+  it("defaults to software_engineering facts from agents", () => {
+    assert.strictEqual(DEFAULT_DOMAIN, "software_engineering");
     assert.strictEqual(DEFAULT_KIND, "fact");
-  });
-
-  it("DEFAULT_SOURCE is 'agent'", () => {
     assert.strictEqual(DEFAULT_SOURCE, "agent");
   });
-});
 
-// ---------------------------------------------------------------------------
-// STALENESS_DAYS
-// ---------------------------------------------------------------------------
-
-describe("STALENESS_DAYS", () => {
-  it("is a positive number", () => {
-    assert.ok(typeof STALENESS_DAYS === "number");
-    assert.ok(STALENESS_DAYS > 0);
-  });
-
-  it("is 30", () => {
+  it("keeps existing staleness and similarity thresholds", () => {
     assert.strictEqual(STALENESS_DAYS, 30);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// DECAY_HALF_LIFE
-// ---------------------------------------------------------------------------
-
-describe("DECAY_HALF_LIFE", () => {
-  it("has entries for major categories", () => {
-    assert.ok("infrastructure" in DECAY_HALF_LIFE);
-    assert.ok("projects" in DECAY_HALF_LIFE);
-    assert.ok("decisions" in DECAY_HALF_LIFE);
-    assert.ok("observation" in DECAY_HALF_LIFE);
-    assert.ok("preferences" in DECAY_HALF_LIFE);
-    assert.ok("team" in DECAY_HALF_LIFE);
-  });
-
-  it("session_summary has null half-life (no decay)", () => {
-    assert.strictEqual(DECAY_HALF_LIFE.session_summary, null);
-  });
-
-  it("distilled has null half-life (no decay)", () => {
-    assert.strictEqual(DECAY_HALF_LIFE.distilled, null);
-  });
-
-  it("all numeric values are positive", () => {
-    for (const [key, val] of Object.entries(DECAY_HALF_LIFE)) {
-      if (val !== null) {
-        assert.ok(val > 0, `${key} has non-positive half-life: ${val}`);
-      }
-    }
-  });
-});
-
-describe("DECAY_DEFAULT_HALF_LIFE", () => {
-  it("is a reasonable positive number", () => {
-    assert.ok(typeof DECAY_DEFAULT_HALF_LIFE === "number");
-    assert.ok(DECAY_DEFAULT_HALF_LIFE > 0);
     assert.strictEqual(DECAY_DEFAULT_HALF_LIFE, 90);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// getDecayHalfLife
-// ---------------------------------------------------------------------------
-
-describe("getDecayHalfLife", () => {
-  it("returns null for summary kind (no decay)", () => {
-    assert.strictEqual(getDecayHalfLife({ kind: "summary" }), null);
-  });
-
-  it("returns null for distilled kind (no decay)", () => {
-    assert.strictEqual(getDecayHalfLife({ kind: "distilled" }), null);
-  });
-
-  it("returns 180 for relation kind", () => {
-    assert.strictEqual(getDecayHalfLife({ kind: "relation" }), 180);
-  });
-
-  it("returns specific value for category+domain combo", () => {
-    assert.strictEqual(getDecayHalfLife({ category: "observation", domain: "work" }), 45);
-    assert.strictEqual(getDecayHalfLife({ category: "observation", domain: "personal" }), 180);
-    assert.strictEqual(getDecayHalfLife({ category: "infrastructure", domain: "work" }), 60);
-  });
-
-  it("returns wildcard category value when domain match not found", () => {
-    assert.strictEqual(getDecayHalfLife({ category: "decisions", domain: "work" }), 120);
-    assert.strictEqual(getDecayHalfLife({ category: "decisions", domain: "personal" }), 120);
-  });
-
-  it("returns default when no match", () => {
-    assert.strictEqual(getDecayHalfLife({ category: "unknown_cat" }), DECAY_DEFAULT_HALF_LIFE);
-  });
-
-  it("returns default with no args", () => {
-    // defaults to category=observation, domain=work → 45
-    assert.strictEqual(getDecayHalfLife(), 45);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Thresholds
-// ---------------------------------------------------------------------------
-
-describe("thresholds", () => {
-  it("THRESHOLD_DUPLICATE is between 0 and 1", () => {
-    assert.ok(THRESHOLD_DUPLICATE > 0 && THRESHOLD_DUPLICATE < 1);
     assert.strictEqual(THRESHOLD_DUPLICATE, 0.92);
-  });
-
-  it("THRESHOLD_RELATED is between 0 and 1", () => {
-    assert.ok(THRESHOLD_RELATED > 0 && THRESHOLD_RELATED < 1);
-    assert.strictEqual(THRESHOLD_RELATED, 0.80);
-  });
-
-  it("THRESHOLD_DUPLICATE > THRESHOLD_RELATED", () => {
+    assert.strictEqual(THRESHOLD_RELATED, 0.8);
     assert.ok(THRESHOLD_DUPLICATE > THRESHOLD_RELATED);
   });
 });
 
-// ---------------------------------------------------------------------------
-// QDRANT_INDEXES
-// ---------------------------------------------------------------------------
-
-describe("QDRANT_INDEXES", () => {
-  it("is a non-empty array", () => {
-    assert.ok(Array.isArray(QDRANT_INDEXES));
-    assert.ok(QDRANT_INDEXES.length > 0);
+describe("memory subtypes", () => {
+  it("defines subtype lists by kind", () => {
+    assert.ok(MEMORY_SUBTYPES.fact.includes("codebase_map"));
+    assert.ok(MEMORY_SUBTYPES.summary.includes("session_index"));
+    assert.ok(MEMORY_SUBTYPES.summary.includes("episode"));
+    assert.ok(MEMORY_SUBTYPES.summary.includes("workstream"));
+    assert.ok(MEMORY_SUBTYPES.distilled.includes("failure_mode"));
+    assert.deepStrictEqual(MEMORY_SUBTYPES.relation, []);
+    assert.ok(MEMORY_SUBTYPES.telemetry.includes("recall_event"));
   });
 
-  it("each index has field_name and field_schema", () => {
-    for (const idx of QDRANT_INDEXES) {
-      assert.ok(typeof idx.field_name === "string");
-      assert.ok(typeof idx.field_schema === "string");
-    }
+  it("validates subtype and kind combinations", () => {
+    assert.strictEqual(normalizeMemorySubtype("fact", "codebase_map"), "codebase_map");
+    assert.strictEqual(normalizeMemorySubtype("summary", "episode"), "episode");
+    assert.strictEqual(normalizeMemorySubtype("fact", "episode"), null);
+    assert.strictEqual(validateMemorySubtype("summary", "episode"), "episode");
+    assert.throws(() => validateMemorySubtype("fact", "episode"), /Invalid memory_subtype/);
   });
 
-  it("includes key payload indexes", () => {
-    const fieldNames = QDRANT_INDEXES.map((i) => i.field_name);
-    assert.ok(fieldNames.includes("category"));
-    assert.ok(fieldNames.includes("domain"));
-    assert.ok(fieldNames.includes("kind"));
-    assert.ok(fieldNames.includes("source"));
-    assert.ok(fieldNames.includes("entities"));
-    assert.ok(fieldNames.includes("content_hash"));
-    assert.ok(fieldNames.includes("superseded_by"));
-  });
-});
-
-// ---------------------------------------------------------------------------
-// SOURCE_MIGRATION
-// ---------------------------------------------------------------------------
-
-describe("SOURCE_MIGRATION", () => {
-  it("maps old source values to new ones", () => {
-    assert.strictEqual(SOURCE_MIGRATION.conversation, "agent");
-    assert.strictEqual(SOURCE_MIGRATION.task, "agent");
-    assert.strictEqual(SOURCE_MIGRATION.observation, "agent");
-    assert.strictEqual(SOURCE_MIGRATION.manual, "user");
-    assert.strictEqual(SOURCE_MIGRATION.cortex, "daemon");
+  it("provides deterministic subtype defaults and category/layer hints", () => {
+    assert.strictEqual(defaultMemorySubtypeForKind("fact"), "codebase_map");
+    assert.strictEqual(defaultMemorySubtypeForKind("relation"), null);
+    assert.strictEqual(categoryForMemorySubtype("architecture_decision"), "decisions");
+    assert.strictEqual(categoryForMemorySubtype("ownership"), "people");
+    assert.strictEqual(layerForMemorySubtype("workstream"), "workstream");
+    assert.strictEqual(layerForMemorySubtype("episode"), "episode");
+    assert.ok(memorySubtypeValues().includes("product_insight"));
+    assert.deepStrictEqual(memorySubtypeValuesForKind("summary"), ["session_index", "episode", "workstream"]);
   });
 });
 
-// ---------------------------------------------------------------------------
-// Normalization functions
-// ---------------------------------------------------------------------------
-
-describe("normalizeCategory", () => {
-  it("returns valid category as-is (lowercase)", () => {
-    assert.strictEqual(normalizeCategory("infrastructure"), "infrastructure");
-    assert.strictEqual(normalizeCategory("decisions"), "decisions");
-    assert.strictEqual(normalizeCategory("team"), "team");
-  });
-
-  it("is case-insensitive", () => {
+describe("normalization", () => {
+  it("normalizes canonical categories and useful descriptive variants", () => {
     assert.strictEqual(normalizeCategory("Infrastructure"), "infrastructure");
-    assert.strictEqual(normalizeCategory("DECISIONS"), "decisions");
-  });
-
-  it("maps 'personal' to 'preferences'", () => {
-    assert.strictEqual(normalizeCategory("personal"), "preferences");
-  });
-
-  it("maps 'session_summary' to 'projects'", () => {
-    assert.strictEqual(normalizeCategory("session_summary"), "projects");
-  });
-
-  it("maps 'distilled' to 'observation'", () => {
-    assert.strictEqual(normalizeCategory("distilled"), "observation");
-  });
-
-  it("maps 'relation' to 'team'", () => {
-    assert.strictEqual(normalizeCategory("relation"), "team");
-  });
-
-  it("fuzzy matches 'infra' to 'infrastructure'", () => {
     assert.strictEqual(normalizeCategory("infra-stuff"), "infrastructure");
+    assert.strictEqual(normalizeCategory("owner"), "people");
+    assert.strictEqual(normalizeCategory("something_random"), "observations");
   });
 
-  it("fuzzy matches 'decision' to 'decisions'", () => {
-    assert.strictEqual(normalizeCategory("a decision"), "decisions");
+  it("normalizes canonical domain profiles only", () => {
+    assert.strictEqual(normalizeDomain("software-engineering"), "software_engineering");
+    assert.strictEqual(normalizeDomain("personal-productivity"), "personal_productivity");
+    assert.strictEqual(normalizeDomain("work"), "software_engineering");
+    assert.strictEqual(normalizeDomain("personal"), "software_engineering");
+    assert.strictEqual(normalizeDomain(undefined), "software_engineering");
+    assert.strictEqual(normalizeDomain("unknown"), "software_engineering");
   });
 
-  it("defaults to 'observation' for unknown", () => {
-    assert.strictEqual(normalizeCategory("something_random"), "observation");
-  });
-});
-
-describe("normalizeDomain", () => {
-  it("returns valid domains as-is", () => {
-    assert.strictEqual(normalizeDomain("work"), "work");
-    assert.strictEqual(normalizeDomain("personal"), "personal");
-  });
-
-  it("defaults to 'work' for undefined", () => {
-    assert.strictEqual(normalizeDomain(undefined), "work");
-  });
-
-  it("defaults to 'work' for unknown values", () => {
-    assert.strictEqual(normalizeDomain("unknown"), "work");
-  });
-
-  it("fuzzy matches 'personal'", () => {
-    assert.strictEqual(normalizeDomain("personal-stuff"), "personal");
-  });
-
-  it("fuzzy matches 'life' and 'home'", () => {
-    assert.strictEqual(normalizeDomain("life"), "personal");
-    assert.strictEqual(normalizeDomain("home"), "personal");
-  });
-});
-
-describe("normalizeKind", () => {
-  it("returns valid kinds as-is", () => {
-    assert.strictEqual(normalizeKind("fact"), "fact");
-    assert.strictEqual(normalizeKind("summary"), "summary");
-    assert.strictEqual(normalizeKind("distilled"), "distilled");
-    assert.strictEqual(normalizeKind("relation"), "relation");
-  });
-
-  it("defaults to 'fact' for undefined", () => {
-    assert.strictEqual(normalizeKind(undefined), "fact");
-  });
-
-  it("defaults to 'fact' for unknown", () => {
-    assert.strictEqual(normalizeKind("unknown"), "fact");
-  });
-
-  it("fuzzy matches partial strings", () => {
+  it("normalizes kind, source, and layer", () => {
     assert.strictEqual(normalizeKind("summarized"), "summary");
     assert.strictEqual(normalizeKind("distillation"), "distilled");
-    assert.strictEqual(normalizeKind("relationship"), "relation");
     assert.strictEqual(normalizeKind("edge"), "relation");
+    assert.strictEqual(normalizeKind("feedback event"), "telemetry");
+    assert.strictEqual(normalizeSource("daemon"), "daemon");
+    assert.strictEqual(normalizeSource("user"), "user");
+    assert.strictEqual(normalizeSource("unknown"), "agent");
+    assert.strictEqual(normalizeLayer("memory-object"), "memory_object");
+    assert.strictEqual(normalizeLayer("bad-layer"), null);
   });
 });
 
-describe("normalizeSource", () => {
-  it("returns valid sources as-is", () => {
-    assert.strictEqual(normalizeSource("agent"), "agent");
-    assert.strictEqual(normalizeSource("cortex"), "daemon");
-    assert.strictEqual(normalizeSource("system"), "system");
-    assert.strictEqual(normalizeSource("user"), "user");
-    assert.strictEqual(normalizeSource("docs"), "docs");
+describe("decay policy", () => {
+  it("uses category + domain profile decay values", () => {
+    assert.strictEqual(getDecayHalfLife({ category: "codebase", domain: "software_engineering" }), 120);
+    assert.strictEqual(getDecayHalfLife({ category: "projects", domain: "software_engineering" }), 45);
+    assert.strictEqual(getDecayHalfLife({ category: "observations", domain: "research" }), 90);
   });
 
-  it("defaults to 'agent' for undefined", () => {
-    assert.strictEqual(normalizeSource(undefined), "agent");
+  it("does not special-case old category/domain inputs", () => {
+    assert.strictEqual(getDecayHalfLife({ category: "observation", domain: "work" }), DECAY_DEFAULT_HALF_LIFE);
+    assert.strictEqual(getDecayHalfLife({ category: "team", domain: "personal" }), DECAY_DEFAULT_HALF_LIFE);
   });
 
-  it("migrates old source values", () => {
-    assert.strictEqual(normalizeSource("conversation"), "agent");
-    assert.strictEqual(normalizeSource("task"), "agent");
-    assert.strictEqual(normalizeSource("observation"), "agent");
-    assert.strictEqual(normalizeSource("manual"), "user");
+  it("does not decay relation or telemetry objects", () => {
+    assert.strictEqual(getDecayHalfLife({ kind: "relation" }), null);
+    assert.strictEqual(getDecayHalfLife({ kind: "telemetry" }), null);
   });
 
-  it("defaults to 'agent' for unknown", () => {
-    assert.strictEqual(normalizeSource("unknown"), "agent");
+  it("falls back to the default half-life for unknown category/profile pairs", () => {
+    assert.strictEqual(getDecayHalfLife({ category: "unknown_cat", domain: "unknown_domain" }), DECAY_DEFAULT_HALF_LIFE);
+  });
+});
+
+describe("QDRANT_INDEXES", () => {
+  it("includes ontology v2 query-critical payload indexes", () => {
+    const indexes = new Map(QDRANT_INDEXES.map((idx) => [idx.field_name, idx.field_schema]));
+    assert.strictEqual(indexes.get("category"), "keyword");
+    assert.strictEqual(indexes.get("domain"), "keyword");
+    assert.strictEqual(indexes.get("kind"), "keyword");
+    assert.strictEqual(indexes.get("memory_subtype"), "keyword");
+    assert.strictEqual(indexes.get("workspace_id"), "keyword");
+    assert.strictEqual(indexes.get("episode_id"), "keyword");
+    assert.strictEqual(indexes.get("workstream_key"), "keyword");
+    assert.strictEqual(indexes.get("task_key"), "keyword");
+    assert.strictEqual(indexes.get("repo"), "keyword");
+    assert.strictEqual(indexes.get("branch"), "keyword");
+    assert.strictEqual(indexes.get("review_status"), "keyword");
+  });
+
+  it("keeps date and lifecycle indexes used by existing filters", () => {
+    const indexes = new Map(QDRANT_INDEXES.map((idx) => [idx.field_name, idx.field_schema]));
+    assert.strictEqual(indexes.get("created_at"), "datetime");
+    assert.strictEqual(indexes.get("updated_at"), "datetime");
+    assert.strictEqual(indexes.get("last_seen_at"), "datetime");
+    assert.strictEqual(indexes.get("superseded"), "bool");
+    assert.strictEqual(indexes.get("verified"), "bool");
   });
 });

--- a/src/mcp/taxonomy.ts
+++ b/src/mcp/taxonomy.ts
@@ -1,246 +1,655 @@
 /**
- * Memory Taxonomy — Single source of truth for all classification axes.
+ * Bikky memory ontology.
  *
- * Four orthogonal axes classify every fact:
- *   category — topic/subject matter (what the fact is about)
- *   domain   — life scope (work vs personal context)
- *   kind     — epistemic type (how the knowledge exists)
- *   source   — provenance (who/what created this fact)
+ * Ontology v2 separates ownership boundaries from semantic meaning:
+ * workspace -> domain -> repo/project/surface -> workstream -> episode -> memory objects.
  */
 
-import type { AxisDef, CategoryDef, QdrantIndex } from "./types.js";
+// ---------------------------------------------------------------------------
+// Categories: subject matter
+// ---------------------------------------------------------------------------
 
-// ─── Category: topic/subject matter ─────────────────────────────────────────
-
-export const CATEGORIES: Record<string, CategoryDef> = {
-  infrastructure: {
-    description: "Services, ports, configs, databases, deployments, environments",
-    extractionHint:
-      "Look for: service names, ports, hosts, connection strings, database engines, cluster details, deployment targets, environment variables, config values",
+export const CATEGORIES = {
+  codebase: {
+    description:
+      "Repository structure, modules, important files, APIs, build/test commands, and code navigation knowledge.",
     examples: [
-      { content: "ClickHouse runs on port 8123 in production clusters", entities: ["clickhouse"], confidence: 0.95, importance: 0.8 },
-      { content: "The dbt project uses ReplacingMergeTree engine for dedup tables", entities: ["dbt", "clickhouse"], confidence: 0.9, importance: 0.7 },
-      { content: "Redis cache is on redis-prod.internal:6379 with 30-min TTL", entities: ["redis"], confidence: 0.9, importance: 0.8 },
+      "The auth middleware lives in src/server/auth.ts.",
+      "Run npm test -- --runInBand for flaky integration tests.",
+    ],
+  },
+  infrastructure: {
+    description:
+      "Cloud, deployment, runtime, secrets, queues, databases, CI/CD, and environment topology.",
+    examples: [
+      "Production uses Qdrant Cloud for vector storage.",
+      "Deployments are promoted through GitHub Actions.",
+    ],
+  },
+  operations: {
+    description:
+      "Runbooks, incident handling, maintenance procedures, debugging steps, and operational gotchas.",
+    examples: [
+      "Restart the worker after changing queue visibility timeout.",
+      "If migrations hang, check the advisory lock table first.",
     ],
   },
   decisions: {
-    description: "Architectural decisions, technology choices, trade-offs, with who decided and why",
-    extractionHint:
-      "Look for: 'decided', 'chose', 'went with', 'instead of', 'because', trade-off discussions, architecture choices, technology selections",
+    description:
+      "Architecture, product, process, and technical decisions with durable rationale.",
     examples: [
-      { content: "Team decided to use JWT for service-to-service auth instead of mTLS", entities: ["auth", "jwt"], confidence: 0.9, importance: 0.85 },
-      { content: "Team chose Qdrant over Pinecone for vector storage due to self-hosting option", entities: ["qdrant", "pinecone"], confidence: 0.95, importance: 0.8 },
+      "Use workspace_id as the access boundary instead of overloading domain.",
+      "Keep telemetry out of normal semantic recall.",
     ],
   },
-  observation: {
-    description: "Errors encountered, quirks, workarounds, debugging findings, gotchas, behavioral patterns",
-    extractionHint:
-      "Look for: error messages, debugging steps, 'turns out', 'the issue was', workarounds, unexpected behavior, gotchas, caveats",
+  product_domain: {
+    description:
+      "Product concepts, business rules, user workflows, domain vocabulary, and market assumptions.",
     examples: [
-      { content: "ClickHouse OPTIMIZE FINAL is slow on large tables — use OPTIMIZE DEDUPLICATE instead", entities: ["clickhouse"], confidence: 0.9, importance: 0.7 },
-      { content: "Node 25 fetch() doesn't support AbortSignal.timeout() in some edge cases", entities: ["node"], confidence: 0.7, importance: 0.5 },
-    ],
-  },
-  preferences: {
-    description: "User/team preferences, working style, conventions, opinions, personal tastes",
-    extractionHint:
-      "Look for: 'prefer', 'like', 'want', 'always use', conventions, style guides, opinions, personal choices, hobbies, interests",
-    examples: [
-      { content: "User prefers dark mode and concise responses under 3 sentences", entities: ["user"], confidence: 0.85, importance: 0.3 },
-      { content: "Code style: kebab-case for file names, camelCase for JS variables", entities: [], confidence: 0.8, importance: 0.4 },
+      "A workstream is the durable continuity unit for long-running tasks.",
+      "Recall quality should be measured by downstream usefulness, not just similarity.",
     ],
   },
   projects: {
-    description: "What's in progress, blocked, completed, project structure, goals, personal endeavors",
-    extractionHint:
-      "Look for: task progress, blockers, completions, branch names, deployment status, milestones, goals, project structure, hobbies, personal projects",
+    description:
+      "Project goals, milestones, current state, open questions, blockers, and active workstreams.",
     examples: [
-      { content: "The memory extraction daemon pipeline is being built", entities: ["bikky", "daemon"], confidence: 0.95, importance: 0.6 },
-      { content: "User is growing tomatoes and herbs in the backyard garden", entities: ["user", "garden"], confidence: 0.85, importance: 0.4 },
+      "The capture-policy RPI is implementing ontology v2 first.",
+      "The UI smoke suite is tracked in bikky-dev/bikky#13.",
     ],
   },
-  team: {
-    description: "People, roles, relationships, organizational structure, contacts",
-    extractionHint:
-      "Look for: names, titles, roles, reporting lines, team membership, expertise areas, contact details, who owns what",
+  people: {
+    description:
+      "Ownership, roles, collaboration patterns, responsibilities, and team preferences.",
     examples: [
-      { content: "Alice is the lead engineer on the platform team", entities: ["alice", "platform"], confidence: 0.95, importance: 0.7 },
-      { content: "Alex handles DevOps and Kubernetes cluster management", entities: ["alex", "devops", "kubernetes"], confidence: 0.9, importance: 0.6 },
+      "Saber prefers concise implementation plans before code changes.",
+      "The platform team owns the deploy workflow.",
     ],
   },
-};
+  preferences: {
+    description:
+      "User, team, or workspace preferences about style, tooling, defaults, and interaction patterns.",
+    examples: [
+      "Prefer Node's built-in test runner for this repo.",
+      "Default new memory captures to software_engineering.",
+    ],
+  },
+  observations: {
+    description:
+      "Validated observations, troubleshooting evidence, behavioral notes, and learned facts that do not fit a narrower category.",
+    examples: [
+      "The current ESLint config is incompatible with ESLint v9.",
+      "The dashboard shows stale facts separately from verified current facts.",
+    ],
+  },
+} as const;
 
-// ─── Domain: life scope ─────────────────────────────────────────────────────
+export type Category = keyof typeof CATEGORIES;
 
-export const DOMAINS: Record<string, AxisDef> = {
-  work: { description: "Engineering, company, professional context" },
-  personal: { description: "Life, hobbies, health, family, personal projects" },
-};
+export const DEFAULT_CATEGORY: Category = "observations";
 
-export const DEFAULT_DOMAIN = "work";
+// ---------------------------------------------------------------------------
+// Domains: activity / knowledge profiles
+// ---------------------------------------------------------------------------
 
-// ─── Kind: epistemic type ───────────────────────────────────────────────────
+export const DOMAINS = {
+  software_engineering: {
+    description:
+      "Coding-agent work: repositories, code changes, architecture, infrastructure, debugging, tests, CI, and developer workflow.",
+    defaultCategories: [
+      "codebase",
+      "infrastructure",
+      "operations",
+      "decisions",
+      "projects",
+      "preferences",
+      "observations",
+    ] as const,
+  },
+  product_strategy: {
+    description:
+      "Product direction, positioning, roadmap tradeoffs, customer problems, metrics, and market learning.",
+    defaultCategories: [
+      "product_domain",
+      "decisions",
+      "projects",
+      "people",
+      "preferences",
+      "observations",
+    ] as const,
+  },
+  business_operations: {
+    description:
+      "Business process, vendors, finance, legal/admin operations, recurring procedures, and ownership.",
+    defaultCategories: [
+      "operations",
+      "decisions",
+      "projects",
+      "people",
+      "preferences",
+      "observations",
+    ] as const,
+  },
+  research: {
+    description:
+      "Research questions, sources, hypotheses, experiment findings, synthesis, and reusable insights.",
+    defaultCategories: [
+      "product_domain",
+      "decisions",
+      "projects",
+      "preferences",
+      "observations",
+    ] as const,
+  },
+  personal_productivity: {
+    description:
+      "Individual productivity, habits, planning preferences, reminders, and personal operating context.",
+    defaultCategories: [
+      "operations",
+      "projects",
+      "people",
+      "preferences",
+      "observations",
+    ] as const,
+  },
+} as const;
 
-export const KINDS: Record<string, AxisDef> = {
-  fact: { description: "Atomic declarative assertion — the default" },
-  summary: { description: "Compressed narrative of a session or time period" },
-  distilled: { description: "Second-order pattern derived from multiple summaries" },
-  relation: { description: "Typed edge between two entities (from → type → to)" },
-};
+export type Domain = keyof typeof DOMAINS;
 
-export const DEFAULT_KIND = "fact";
+export const DEFAULT_DOMAIN: Domain = "software_engineering";
 
-// ─── Source: provenance ─────────────────────────────────────────────────────
+// ---------------------------------------------------------------------------
+// Layers: hierarchy placement
+// ---------------------------------------------------------------------------
 
-export const SOURCES: Record<string, AxisDef> = {
-  agent: { description: "Stored by an agent via MCP memory_store tool" },
-  daemon: { description: "Extracted by the background daemon pipeline" },
-  system: { description: "Generated by system processes (distillation, session summaries)" },
-  user: { description: "Explicitly requested by the user (manual corrections, direct input)" },
-  docs: { description: "Indexed from documentation (knowledge base)" },
-};
+export const LAYERS = {
+  workspace: {
+    description: "Ownership, tenancy, access policy, sharing, redaction, retention, and quotas.",
+  },
+  domain: {
+    description: "Semantic profile that controls vocabulary, prompts, categories, ranking, and capture policy.",
+  },
+  surface: {
+    description: "Concrete operating surface such as a repo, project, package, service, branch, or channel.",
+  },
+  workstream: {
+    description: "Primary durable continuity key for a long-running objective or task.",
+  },
+  episode: {
+    description: "Coherent segment of activity within a session or transcript.",
+  },
+  memory_object: {
+    description: "A fact, summary, distilled learning, relation, or telemetry object.",
+  },
+} as const;
 
-export const DEFAULT_SOURCE = "agent";
+export type Layer = keyof typeof LAYERS;
 
-// ─── Decay configuration ────────────────────────────────────────────────────
+// ---------------------------------------------------------------------------
+// Kinds and subtypes: object shape
+// ---------------------------------------------------------------------------
 
-const FACT_DECAY: Record<string, number> = {
-  "observation.work": 45,
-  "observation.personal": 180,
-  "infrastructure.work": 60,
-  "infrastructure.personal": 180,
-  "decisions.*": 120,
-  "preferences.*": 365,
-  "projects.work": 90,
-  "projects.personal": 180,
-  "team.*": 365,
-};
+export const KINDS = {
+  fact: {
+    description: "Atomic, durable memory that should be retrievable independently.",
+    examples: [
+      "The daemon stores extracted coding-agent observations in Qdrant.",
+      "The UI package uses Vite and Node's built-in test runner.",
+    ],
+  },
+  summary: {
+    description:
+      "Compressed representation of a session index, coherent episode, or current workstream state.",
+    examples: [
+      "Episode summary of a coherent implementation task.",
+      "Current-state summary for a workstream.",
+    ],
+  },
+  distilled: {
+    description:
+      "Pattern, convention, failure mode, or reusable learning synthesized from multiple memories.",
+    examples: [
+      "Prefer explicit workspace filters for scoped team memory.",
+      "Missing Qdrant payload indexes surface as query failures.",
+    ],
+  },
+  relation: {
+    description: "Typed edge between entities; relation_type carries the edge label.",
+    examples: [
+      "bikky -> uses -> qdrant",
+      "workspace_id -> represents -> access boundary",
+    ],
+  },
+  telemetry: {
+    description:
+      "Memory-use, feedback, or outcome metadata used for product quality and operations; excluded from normal semantic recall.",
+    examples: [
+      "A recall event returned three facts for session abc.",
+      "A user marked a fact useful.",
+    ],
+  },
+} as const;
 
-export const DECAY_DEFAULT_HALF_LIFE = 90;
+export type Kind = keyof typeof KINDS;
 
-export function getDecayHalfLife(opts: { kind?: string; category?: string; domain?: string } = {}): number | null {
-  const { kind, category, domain } = opts;
+export const MEMORY_SUBTYPES = {
+  fact: [
+    "codebase_map",
+    "architecture_decision",
+    "infra_topology",
+    "access_pattern",
+    "deployment_procedure",
+    "operational_procedure",
+    "domain_rule",
+    "troubleshooting_gotcha",
+    "preference",
+    "ownership",
+  ],
+  summary: ["session_index", "episode", "workstream"],
+  distilled: [
+    "runbook_candidate",
+    "failure_mode",
+    "convention",
+    "architecture_pattern",
+    "product_insight",
+  ],
+  relation: [],
+  telemetry: ["recall_event", "feedback_event", "outcome_event", "aggregate_rollup"],
+} as const satisfies Record<Kind, readonly string[]>;
 
-  if (kind === "summary" || kind === "distilled") return null;
-  if (kind === "relation") return 180;
+export type MemorySubtype = (typeof MEMORY_SUBTYPES)[Kind][number];
 
-  const key = `${category ?? "observation"}.${domain ?? DEFAULT_DOMAIN}`;
-  const keyVal = FACT_DECAY[key];
-  if (keyVal !== undefined) return keyVal;
+export const DEFAULT_MEMORY_SUBTYPE_BY_KIND = {
+  fact: "codebase_map",
+  summary: "episode",
+  distilled: "convention",
+  relation: null,
+  telemetry: "recall_event",
+} as const satisfies Record<Kind, MemorySubtype | null>;
 
-  const catKey = `${category ?? "observation"}.*`;
-  const catVal = FACT_DECAY[catKey];
-  if (catVal !== undefined) return catVal;
+export const MEMORY_SUBTYPE_DEFAULT_CATEGORY = {
+  codebase_map: "codebase",
+  architecture_decision: "decisions",
+  infra_topology: "infrastructure",
+  access_pattern: "infrastructure",
+  deployment_procedure: "operations",
+  operational_procedure: "operations",
+  domain_rule: "product_domain",
+  troubleshooting_gotcha: "operations",
+  preference: "preferences",
+  ownership: "people",
+  session_index: "projects",
+  episode: "projects",
+  workstream: "projects",
+  runbook_candidate: "operations",
+  failure_mode: "operations",
+  convention: "observations",
+  architecture_pattern: "decisions",
+  product_insight: "product_domain",
+  recall_event: "observations",
+  feedback_event: "observations",
+  outcome_event: "observations",
+  aggregate_rollup: "observations",
+} as const satisfies Record<MemorySubtype, Category>;
 
-  return DECAY_DEFAULT_HALF_LIFE;
-}
+export const MEMORY_SUBTYPE_DEFAULT_LAYER = {
+  codebase_map: "surface",
+  architecture_decision: "surface",
+  infra_topology: "surface",
+  access_pattern: "surface",
+  deployment_procedure: "surface",
+  operational_procedure: "surface",
+  domain_rule: "domain",
+  troubleshooting_gotcha: "surface",
+  preference: "domain",
+  ownership: "surface",
+  session_index: "episode",
+  episode: "episode",
+  workstream: "workstream",
+  runbook_candidate: "workstream",
+  failure_mode: "workstream",
+  convention: "domain",
+  architecture_pattern: "domain",
+  product_insight: "domain",
+  recall_event: "memory_object",
+  feedback_event: "memory_object",
+  outcome_event: "memory_object",
+  aggregate_rollup: "workspace",
+} as const satisfies Record<MemorySubtype, Layer>;
 
-// Legacy flat map for old code paths
-export const DECAY_HALF_LIFE: Record<string, number | null> = {
-  infrastructure: 60,
-  projects: 90,
-  decisions: 120,
-  observation: 45,
-  personal: 365,
-  preferences: 365,
-  team: 365,
-  relation: 180,
-  session_summary: null,
-  distilled: null,
-};
+// ---------------------------------------------------------------------------
+// Provenance
+// ---------------------------------------------------------------------------
 
-// ─── Staleness ──────────────────────────────────────────────────────────────
+export const SOURCES = {
+  agent: {
+    description: "Captured from an interactive agent tool call.",
+  },
+  daemon: {
+    description: "Captured automatically by the local Bikky daemon.",
+  },
+  system: {
+    description: "Generated by Bikky maintenance, migration, or lifecycle code.",
+  },
+  user: {
+    description: "Created or corrected directly by a user.",
+  },
+  docs: {
+    description: "Imported from documentation or explicit source material.",
+  },
+} as const;
 
+export type Source = keyof typeof SOURCES;
+
+export const DEFAULT_KIND: Kind = "fact";
+export const DEFAULT_SOURCE: Source = "agent";
 export const STALENESS_DAYS = 30;
-
-// ─── Similarity thresholds ──────────────────────────────────────────────────
-
+export const DECAY_DEFAULT_HALF_LIFE = 90;
 export const THRESHOLD_DUPLICATE = 0.92;
-export const THRESHOLD_RELATED = 0.80;
+export const THRESHOLD_RELATED = 0.8;
 
-// ─── Qdrant indexes ────────────────────────────────────────────────────────
+// ---------------------------------------------------------------------------
+// Decay policy: half-life in days by category + domain profile
+// ---------------------------------------------------------------------------
 
-export const QDRANT_INDEXES: QdrantIndex[] = [
+export const DECAY_HALF_LIFE: Record<string, number> = {
+  // Software-engineering defaults.
+  "codebase.software_engineering": 120,
+  "infrastructure.software_engineering": 60,
+  "operations.software_engineering": 60,
+  "decisions.software_engineering": 180,
+  "product_domain.software_engineering": 120,
+  "projects.software_engineering": 45,
+  "people.software_engineering": 120,
+  "preferences.software_engineering": 180,
+  "observations.software_engineering": 45,
+
+  // Other domain profiles.
+  "product_domain.product_strategy": 120,
+  "decisions.product_strategy": 180,
+  "projects.product_strategy": 60,
+  "people.product_strategy": 120,
+  "preferences.product_strategy": 180,
+  "observations.product_strategy": 60,
+  "operations.business_operations": 120,
+  "decisions.business_operations": 180,
+  "projects.business_operations": 60,
+  "people.business_operations": 180,
+  "preferences.business_operations": 180,
+  "observations.business_operations": 90,
+  "product_domain.research": 120,
+  "decisions.research": 180,
+  "projects.research": 60,
+  "preferences.research": 180,
+  "observations.research": 90,
+  "operations.personal_productivity": 90,
+  "projects.personal_productivity": 45,
+  "people.personal_productivity": 180,
+  "preferences.personal_productivity": 180,
+  "observations.personal_productivity": 45,
+
+};
+
+// ---------------------------------------------------------------------------
+// Qdrant payload indexes
+// ---------------------------------------------------------------------------
+
+export const QDRANT_INDEXES: Array<{ field_name: string; field_schema: string }> = [
   { field_name: "category", field_schema: "keyword" },
   { field_name: "domain", field_schema: "keyword" },
   { field_name: "kind", field_schema: "keyword" },
+  { field_name: "memory_subtype", field_schema: "keyword" },
   { field_name: "source", field_schema: "keyword" },
-  { field_name: "entities", field_schema: "keyword" },
-  { field_name: "content_hash", field_schema: "keyword" },
-  { field_name: "from_entity", field_schema: "keyword" },
-  { field_name: "to_entity", field_schema: "keyword" },
-  { field_name: "relation_type", field_schema: "keyword" },
-  { field_name: "superseded_by", field_schema: "keyword" },
+  { field_name: "workspace_id", field_schema: "keyword" },
+  { field_name: "actor_id", field_schema: "keyword" },
+  { field_name: "review_status", field_schema: "keyword" },
+  { field_name: "created_at", field_schema: "datetime" },
+  { field_name: "updated_at", field_schema: "datetime" },
+  { field_name: "last_seen_at", field_schema: "datetime" },
+  { field_name: "stale_after", field_schema: "datetime" },
   { field_name: "session_id", field_schema: "keyword" },
-  { field_name: "last_reinforced_at", field_schema: "datetime" },
-  { field_name: "last_verified_at", field_schema: "datetime" },
+  { field_name: "episode_id", field_schema: "keyword" },
+  { field_name: "workstream_key", field_schema: "keyword" },
+  { field_name: "task_key", field_schema: "keyword" },
+  { field_name: "repo", field_schema: "keyword" },
+  { field_name: "branch", field_schema: "keyword" },
+  { field_name: "reviewed", field_schema: "bool" },
+  { field_name: "verified", field_schema: "bool" },
+  { field_name: "superseded", field_schema: "bool" },
+  { field_name: "useful_feedback_count", field_schema: "integer" },
+  { field_name: "not_useful_feedback_count", field_schema: "integer" },
+  { field_name: "recall_count", field_schema: "integer" },
+  { field_name: "last_recalled_at", field_schema: "datetime" },
 ];
 
-// ─── Source value migration (old → new) ─────────────────────────────────────
+// ---------------------------------------------------------------------------
+// Normalization helpers
+// ---------------------------------------------------------------------------
 
-export const SOURCE_MIGRATION: Record<string, string> = {
-  conversation: "agent",
-  task: "agent",
-  observation: "agent",
-  manual: "user",
-  cortex: "daemon",
-};
+type NonEmptyStringArray = [string, ...string[]];
 
-// ─── Normalization helpers ──────────────────────────────────────────────────
-
-export function normalizeCategory(cat: string): string {
-  const lower = String(cat).toLowerCase().trim();
-  if (lower in CATEGORIES) return lower;
-  if (lower === "personal") return "preferences";
-  if (lower === "session_summary") return "projects";
-  if (lower === "distilled") return "observation";
-  if (lower === "relation") return "team";
-  if (lower.includes("infra")) return "infrastructure";
-  if (lower.includes("decision")) return "decisions";
-  if (lower.includes("observ") || lower.includes("error")) return "observation";
-  if (lower.includes("prefer")) return "preferences";
-  if (lower.includes("project")) return "projects";
-  if (lower.includes("team") || lower.includes("people")) return "team";
-  return "observation";
+function normalizeToken(value: string | null | undefined): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
 }
 
-export function normalizeDomain(d: string | undefined): string {
-  if (!d) return DEFAULT_DOMAIN;
-  const lower = String(d).toLowerCase().trim();
-  if (lower in DOMAINS) return lower;
-  if (lower.includes("personal") || lower.includes("life") || lower.includes("home")) return "personal";
+export function normalizeText(text: string): string {
+  return text.trim().replace(/\s+/g, " ");
+}
+
+export function normalizeCategory(category: string | null | undefined): Category {
+  const normalized = normalizeToken(category);
+  if (normalized in CATEGORIES) {
+    return normalized as Category;
+  }
+  if (normalized.includes("infra")) return "infrastructure";
+  if (normalized.includes("decision")) return "decisions";
+  if (normalized.includes("operation") || normalized.includes("runbook")) return "operations";
+  if (normalized.includes("owner") || normalized.includes("people")) return "people";
+  if (normalized.includes("product") || normalized.includes("domain")) return "product_domain";
+  if (normalized.includes("repo") || normalized.includes("code")) return "codebase";
+  return DEFAULT_CATEGORY;
+}
+
+export function normalizeDomain(domain: string | null | undefined): Domain {
+  const normalized = normalizeToken(domain);
+  if (normalized in DOMAINS) {
+    return normalized as Domain;
+  }
   return DEFAULT_DOMAIN;
 }
 
-export function normalizeKind(k: string | undefined): string {
-  if (!k) return DEFAULT_KIND;
-  const lower = String(k).toLowerCase().trim();
-  if (lower in KINDS) return lower;
-  if (lower.includes("summar")) return "summary";
-  if (lower.includes("distil")) return "distilled";
-  if (lower.includes("relat") || lower.includes("edge")) return "relation";
-  return DEFAULT_KIND;
+export function normalizeKind(kind: string | null | undefined): Kind {
+  const normalized = normalizeToken(kind);
+  if (normalized in KINDS) {
+    return normalized as Kind;
+  }
+  if (normalized.includes("summar")) return "summary";
+  if (normalized.includes("distill")) return "distilled";
+  if (normalized.includes("relation") || normalized.includes("edge")) return "relation";
+  if (normalized.includes("telemetry") || normalized.includes("feedback_event")) return "telemetry";
+  return "fact";
 }
 
-export function normalizeSource(s: string | undefined): string {
-  if (!s) return DEFAULT_SOURCE;
-  const lower = String(s).toLowerCase().trim();
-  if (lower in SOURCES) return lower;
-  const migrated = SOURCE_MIGRATION[lower];
-  if (migrated) return migrated;
+export function normalizeSource(source: string | null | undefined): Source {
+  const normalized = normalizeToken(source);
+  if (normalized in SOURCES) {
+    return normalized as Source;
+  }
   return DEFAULT_SOURCE;
 }
 
-// ─── Value arrays for z.enum consumption ────────────────────────────────────
+export function normalizeLayer(layer: string | null | undefined): Layer | null {
+  const normalized = normalizeToken(layer);
+  if (normalized in LAYERS) {
+    return normalized as Layer;
+  }
+  return null;
+}
 
-export const categoryValues = (): [string, ...string[]] =>
-  Object.keys(CATEGORIES) as [string, ...string[]];
+export function normalizeMemorySubtype(
+  kind: string | null | undefined,
+  subtype: string | null | undefined,
+): MemorySubtype | null {
+  const normalizedKind = normalizeKind(kind);
+  const normalizedSubtype = normalizeToken(subtype);
+  if (!normalizedSubtype) return null;
 
-export const domainValues = (): [string, ...string[]] =>
-  Object.keys(DOMAINS) as [string, ...string[]];
+  const allowed = MEMORY_SUBTYPES[normalizedKind] as readonly string[];
+  if (allowed.includes(normalizedSubtype)) {
+    return normalizedSubtype as MemorySubtype;
+  }
+  return null;
+}
 
-export const kindValues = (): [string, ...string[]] =>
-  Object.keys(KINDS) as [string, ...string[]];
+export function validateMemorySubtype(
+  kind: string | null | undefined,
+  subtype: string | null | undefined,
+): MemorySubtype | null {
+  if (!subtype) return null;
+  const normalized = normalizeMemorySubtype(kind, subtype);
+  if (normalized) return normalized;
 
-export const sourceValues = (): [string, ...string[]] =>
-  Object.keys(SOURCES) as [string, ...string[]];
+  const normalizedKind = normalizeKind(kind);
+  const allowed = MEMORY_SUBTYPES[normalizedKind];
+  const allowedText = allowed.length > 0 ? allowed.join(", ") : "none";
+  throw new Error(
+    `Invalid memory_subtype "${subtype}" for kind "${normalizedKind}". Allowed subtypes: ${allowedText}.`,
+  );
+}
+
+export function defaultMemorySubtypeForKind(kind: string | null | undefined): MemorySubtype | null {
+  return DEFAULT_MEMORY_SUBTYPE_BY_KIND[normalizeKind(kind)];
+}
+
+export function categoryForMemorySubtype(subtype: string | null | undefined): Category | null {
+  const normalized = normalizeToken(subtype);
+  if (normalized in MEMORY_SUBTYPE_DEFAULT_CATEGORY) {
+    return MEMORY_SUBTYPE_DEFAULT_CATEGORY[normalized as MemorySubtype];
+  }
+  return null;
+}
+
+export function layerForMemorySubtype(subtype: string | null | undefined): Layer | null {
+  const normalized = normalizeToken(subtype);
+  if (normalized in MEMORY_SUBTYPE_DEFAULT_LAYER) {
+    return MEMORY_SUBTYPE_DEFAULT_LAYER[normalized as MemorySubtype];
+  }
+  return null;
+}
+
+export function normalizeEntities(entities: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const entity of entities) {
+    const normalized = entity.trim().toLowerCase();
+    if (normalized && !seen.has(normalized)) {
+      seen.add(normalized);
+      result.push(normalized);
+    }
+  }
+
+  return result;
+}
+
+export function inferEntities(content: string): string[] {
+  const entities: string[] = [];
+
+  // Backtick code refs
+  const codeRefs = content.match(/`([^`]+)`/g);
+  if (codeRefs) {
+    for (const ref of codeRefs) {
+      entities.push(ref.slice(1, -1));
+    }
+  }
+
+  // Package-like names: qdrant, postgres, react, etc.
+  const techTerms = content.match(
+    /\b(qdrant|postgres|postgresql|redis|docker|kubernetes|k8s|react|typescript|node|python|aws|gcp|azure|github|gitlab|notion|slack)\b/gi,
+  );
+  if (techTerms) {
+    entities.push(...techTerms);
+  }
+
+  return normalizeEntities(entities).slice(0, 10);
+}
+
+export function getDecayHalfLife(input: {
+  category?: string | null;
+  domain?: string | null;
+  kind?: string | null;
+}): number | null {
+  const kind = normalizeKind(input.kind);
+  if (kind === "relation" || kind === "telemetry") return null;
+
+  const rawCategory = normalizeToken(input.category);
+  const rawDomain = normalizeToken(input.domain);
+  const categoryWasProvided = rawCategory.length > 0;
+  const categoryIsKnown =
+    rawCategory in CATEGORIES ||
+    rawCategory.includes("infra") ||
+    rawCategory.includes("decision") ||
+    rawCategory.includes("operation") ||
+    rawCategory.includes("runbook") ||
+    rawCategory.includes("owner") ||
+    rawCategory.includes("people") ||
+    rawCategory.includes("product") ||
+    rawCategory.includes("domain") ||
+    rawCategory.includes("repo") ||
+    rawCategory.includes("code");
+  if (categoryWasProvided && !categoryIsKnown) {
+    return DECAY_DEFAULT_HALF_LIFE;
+  }
+
+  const canonicalCategory = normalizeCategory(input.category);
+  const canonicalDomain = normalizeDomain(input.domain);
+
+  return (
+    DECAY_HALF_LIFE[`${canonicalCategory}.${canonicalDomain}`] ??
+    DECAY_HALF_LIFE[`${canonicalCategory}.${DEFAULT_DOMAIN}`] ??
+    DECAY_DEFAULT_HALF_LIFE
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers for tool schemas
+// ---------------------------------------------------------------------------
+
+export function categoryValues(): NonEmptyStringArray {
+  return Object.keys(CATEGORIES) as NonEmptyStringArray;
+}
+
+export function canonicalCategoryValues(): NonEmptyStringArray {
+  return Object.keys(CATEGORIES) as NonEmptyStringArray;
+}
+
+export function domainValues(): NonEmptyStringArray {
+  return Object.keys(DOMAINS) as NonEmptyStringArray;
+}
+
+export function canonicalDomainValues(): NonEmptyStringArray {
+  return Object.keys(DOMAINS) as NonEmptyStringArray;
+}
+
+export function kindValues(): NonEmptyStringArray {
+  return Object.keys(KINDS) as NonEmptyStringArray;
+}
+
+export function layerValues(): NonEmptyStringArray {
+  return Object.keys(LAYERS) as NonEmptyStringArray;
+}
+
+export function memorySubtypeValues(): NonEmptyStringArray {
+  return Object.values(MEMORY_SUBTYPES).flat() as NonEmptyStringArray;
+}
+
+export function memorySubtypeValuesForKind(kind: string | null | undefined): string[] {
+  return [...MEMORY_SUBTYPES[normalizeKind(kind)]];
+}
+
+export function sourceValues(): NonEmptyStringArray {
+  return Object.keys(SOURCES) as NonEmptyStringArray;
+}

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,5 +1,5 @@
 /**
- * MCP tool definitions — all 12 memory tools.
+ * MCP tool definitions for memory.
  */
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -14,10 +14,18 @@ import {
   categoryValues,
   domainValues,
   kindValues,
+  memorySubtypeValues,
   sourceValues,
+  DEFAULT_CATEGORY,
   DEFAULT_DOMAIN,
   DEFAULT_KIND,
   DEFAULT_SOURCE,
+  categoryForMemorySubtype,
+  layerForMemorySubtype,
+  normalizeCategory,
+  normalizeDomain,
+  normalizeKind,
+  validateMemorySubtype,
 } from "./taxonomy.js";
 import {
   contentHash,
@@ -26,6 +34,7 @@ import {
   computeCombinedScore,
   buildFilter,
   formatFact,
+  MEMORY_RECALL_EXCLUDED_KINDS,
 } from "./helpers.js";
 import {
   ready,
@@ -38,7 +47,6 @@ import {
   log,
   embed,
   getEmbeddingConfig,
-  chatComplete,
   qdrantReq,
   ensureCollection,
   qdrantUpsert,
@@ -67,6 +75,66 @@ function nowISO(): string {
 
 function newId(): string {
   return crypto.randomUUID();
+}
+
+interface WorkspaceScope {
+  workspaceId?: string;
+  actorId?: string;
+  includeLegacy: boolean;
+}
+
+interface RedactionResult {
+  text: string;
+  redacted: boolean;
+  summary: string;
+  matches: Array<{ type: string; count: number }>;
+}
+
+type RedactionSummary = Omit<RedactionResult, "text">;
+
+function redactionOptions(): { enabled: boolean; redactPii: boolean } {
+  return { enabled: false, redactPii: false };
+}
+
+function redactStorageText(text: string): RedactionResult {
+  return { text, redacted: false, summary: "none", matches: [] };
+}
+
+function combineRedactions(_items: RedactionResult[]): RedactionSummary {
+  return { redacted: false, summary: "none", matches: [] };
+}
+
+function resolveScope(workspaceId?: string, includeLegacyWorkspace = false): WorkspaceScope {
+  return {
+    workspaceId: workspaceId?.trim() || undefined,
+    includeLegacy: includeLegacyWorkspace,
+  };
+}
+
+function scopedFilter(scope: WorkspaceScope, extra: Parameters<typeof buildFilter>[0] = {}): QdrantFilter | undefined {
+  return buildFilter({
+    ...extra,
+    workspace_id: scope.workspaceId,
+    includeLegacyWorkspace: scope.includeLegacy,
+  });
+}
+
+function addWorkspacePayload(payload: Record<string, unknown>, scope: WorkspaceScope): void {
+  if (scope.workspaceId) payload["workspace_id"] = scope.workspaceId;
+  if (scope.actorId) payload["actor_id"] = scope.actorId;
+}
+
+function addRedactionPayload(_payload: Record<string, unknown>, _summary: RedactionSummary): void {
+  // Task 243 keeps storage pass-through; redaction policy is out of scope for this branch.
+}
+
+async function getPointForWorkspaceWrite(factId: string, _scope: WorkspaceScope): Promise<{ point?: QdrantPoint; error?: Record<string, unknown> }> {
+  const existing = await qdrantGetPoints([factId]);
+  const point = existing.result?.[0];
+  if (!point) {
+    return { error: { status: "not_found", fact_id: factId } };
+  }
+  return { point };
 }
 
 function requireReady(): McpToolResult | null {
@@ -106,7 +174,7 @@ function buildMemoryNudge(): string | null {
 /**
  * Entity-graph traversal for memory_recall.
  */
-async function graphTraversal(primaryResults: QdrantPoint[], limit: number): Promise<string[]> {
+async function graphTraversal(primaryResults: QdrantPoint[], limit: number, scope: WorkspaceScope): Promise<string[]> {
   try {
     const primaryEntities = new Set<string>();
     const primaryIds = new Set<string>();
@@ -121,23 +189,17 @@ async function graphTraversal(primaryResults: QdrantPoint[], limit: number): Pro
 
     const relatedEntities = new Set<string>();
     for (const entity of primaryEntities) {
-      const outgoing = await qdrantScroll({
-        must: [
-          { key: "from_entity", match: { value: entity } },
-          { is_null: { key: "superseded_by" } },
-        ],
-      }, 10).catch(() => ({ result: { points: [] as QdrantPoint[] } }));
+      const outgoingFilter: QdrantFilter = scopedFilter(scope, { excludeKinds: MEMORY_RECALL_EXCLUDED_KINDS }) ?? { must: [] };
+      outgoingFilter.must.push({ key: "from_entity", match: { value: entity } });
+      const outgoing = await qdrantScroll(outgoingFilter, 10).catch(() => ({ result: { points: [] as QdrantPoint[] } }));
 
       for (const pt of (outgoing.result?.points ?? [])) {
         if (pt.payload.to_entity) relatedEntities.add(pt.payload.to_entity);
       }
 
-      const incoming = await qdrantScroll({
-        must: [
-          { key: "to_entity", match: { value: entity } },
-          { is_null: { key: "superseded_by" } },
-        ],
-      }, 10).catch(() => ({ result: { points: [] as QdrantPoint[] } }));
+      const incomingFilter: QdrantFilter = scopedFilter(scope, { excludeKinds: MEMORY_RECALL_EXCLUDED_KINDS }) ?? { must: [] };
+      incomingFilter.must.push({ key: "to_entity", match: { value: entity } });
+      const incoming = await qdrantScroll(incomingFilter, 10).catch(() => ({ result: { points: [] as QdrantPoint[] } }));
 
       for (const pt of (incoming.result?.points ?? [])) {
         if (pt.payload.from_entity) relatedEntities.add(pt.payload.from_entity);
@@ -150,12 +212,9 @@ async function graphTraversal(primaryResults: QdrantPoint[], limit: number): Pro
     const relatedFacts: QdrantPoint[] = [];
     const maxPerEntity = Math.max(2, Math.floor(limit / relatedEntities.size));
     for (const entity of relatedEntities) {
-      const result = await qdrantScroll({
-        must: [
-          { key: "entities", match: { value: entity } },
-          { is_null: { key: "superseded_by" } },
-        ],
-      }, maxPerEntity).catch(() => ({ result: { points: [] as QdrantPoint[] } }));
+      const filter: QdrantFilter = scopedFilter(scope, { excludeKinds: MEMORY_RECALL_EXCLUDED_KINDS }) ?? { must: [] };
+      filter.must.push({ key: "entities", match: { value: entity } });
+      const result = await qdrantScroll(filter, maxPerEntity).catch(() => ({ result: { points: [] as QdrantPoint[] } }));
 
       for (const pt of (result.result?.points ?? [])) {
         if (!primaryIds.has(pt.id)) {
@@ -330,12 +389,23 @@ export function registerTools(mcp: McpServer): void {
     {
       content: z.string().describe("The fact to store (atomic, single piece of knowledge)"),
       category: z.enum(categoryValues())
-        .describe("Topic: infrastructure, decisions, observation, preferences, projects, team"),
+        .describe("Subject matter: codebase, infrastructure, operations, decisions, product_domain, projects, people, preferences, observations"),
       entities: z.array(z.string()).describe("Related entities (lowercase, e.g. ['qdrant', 'platform'])"),
       domain: z.enum(domainValues()).default(DEFAULT_DOMAIN)
-        .describe("Life scope — work or personal"),
+        .describe("Activity profile — e.g. software_engineering, product_strategy, business_operations, research, personal_productivity"),
       kind: z.enum(kindValues()).default(DEFAULT_KIND)
         .describe("Knowledge form — fact, summary, distilled, relation"),
+      memory_subtype: z.enum(memorySubtypeValues()).optional()
+        .describe("Optional subtype within kind, such as codebase_map, episode, workstream, convention, or recall_event"),
+      workspace_id: z.string().optional()
+        .describe("Optional workspace namespace for team memory."),
+      episode_id: z.string().optional().describe("Optional coherent episode identifier"),
+      workstream_key: z.string().optional().describe("Optional durable workstream key"),
+      task_key: z.string().optional().describe("Optional task or issue key"),
+      repo: z.string().optional().describe("Optional repository or project surface"),
+      branch: z.string().optional().describe("Optional branch or working surface"),
+      review_status: z.enum(["candidate", "reviewed", "approved", "rejected"]).optional()
+        .describe("Optional review lifecycle status"),
       source: z.enum(sourceValues()).default(DEFAULT_SOURCE)
         .describe("Creator — agent, daemon, system, user"),
       confidence: z.number().min(0).max(1).default(0.9).describe("How certain (0.0-1.0)"),
@@ -349,23 +419,73 @@ export function registerTools(mcp: McpServer): void {
       metadata: z.record(z.string(), z.string()).optional()
         .describe("Optional key-value metadata. Stored with the fact and filterable via memory_recall."),
     },
-    async ({ content, category, entities, domain, kind, source, confidence, importance, supersedes, relation, metadata }): Promise<McpToolResult> => {
+    async ({
+      content,
+      category,
+      entities,
+      domain,
+      kind,
+      memory_subtype,
+      workspace_id,
+      episode_id,
+      workstream_key,
+      task_key,
+      repo,
+      branch,
+      review_status,
+      source,
+      confidence,
+      importance,
+      supersedes,
+      relation,
+      metadata,
+    }): Promise<McpToolResult> => {
       const guard = requireReady();
       if (guard) return guard;
       lastStoreTime = Date.now();
       const now = nowISO();
-      const hash = contentHash(category, content);
-      const normalizedEntities = entities.map((e) => e.toLowerCase());
+      const scope = resolveScope(workspace_id);
+      const normalizedKind = normalizeKind(kind);
+      let normalizedSubtype: string | null = null;
+      try {
+        normalizedSubtype = validateMemorySubtype(normalizedKind, memory_subtype);
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }],
+          isError: true,
+        };
+      }
+      const normalizedCategory = normalizedSubtype
+        ? categoryForMemorySubtype(normalizedSubtype) ?? normalizeCategory(category)
+        : normalizeCategory(category);
+      const normalizedDomain = normalizeDomain(domain);
+      const normalizedLayer = normalizedSubtype ? layerForMemorySubtype(normalizedSubtype) : null;
+      const redactedContent = redactStorageText(content);
+      const redactedEntities = entities.map((entity) => redactStorageText(entity));
+      const sanitizedEntities = redactedEntities.map((entity) => entity.text);
+      const redactedRelation = relation ? {
+        from: redactStorageText(relation.from),
+        type: redactStorageText(relation.type),
+        to: redactStorageText(relation.to),
+      } : null;
+      const redactionSummary = combineRedactions([
+        redactedContent,
+        ...redactedEntities,
+        ...(redactedRelation ? [redactedRelation.from, redactedRelation.type, redactedRelation.to] : []),
+      ]);
+      const hash = contentHash(normalizedCategory, redactedContent.text);
+      const normalizedEntities = sanitizedEntities.map((e) => e.toLowerCase());
+      const sanitizedRelation = redactedRelation ? {
+        from: redactedRelation.from.text,
+        type: redactedRelation.type.text,
+        to: redactedRelation.to.text,
+      } : null;
 
       // 1. Exact dedup via content hash
       try {
-        const existing = await qdrantScroll(
-          { must: [
-            { key: "content_hash", match: { value: hash } },
-            { is_null: { key: "superseded_by" } },
-          ] },
-          1,
-        );
+        const hashFilter: QdrantFilter = scopedFilter(scope) ?? { must: [] };
+        hashFilter.must.push({ key: "content_hash", match: { value: hash } });
+        const existing = await qdrantScroll(hashFilter, 1);
         const existingPoint = existing.result?.points?.[0];
         if (existingPoint) {
           const point = existingPoint;
@@ -389,19 +509,18 @@ export function registerTools(mcp: McpServer): void {
       }
 
       // 2. Generate embedding
-      const vector = await embed(content);
+      const vector = await embed(redactedContent.text);
 
       // 3. Semantic dedup
       let similarFacts: Array<{ id: string; content: string; score: number }> = [];
       let potentialConflicts: Array<{ id: string; content: string; category: string; similarity: number; shared_entities: string[] }> = [];
       try {
-        const filter = { must: [] as Array<Record<string, unknown>> };
+        const filter: QdrantFilter = scopedFilter(scope) ?? { must: [] };
         if (normalizedEntities.length > 0) {
           filter.must.push({ key: "entities", match: { any: normalizedEntities } });
         }
-        filter.must.push({ is_null: { key: "superseded_by" } });
 
-        const results = await qdrantSearch(vector, filter.must.length > 0 ? filter as unknown as QdrantFilter : undefined, 3);
+        const results = await qdrantSearch(vector, filter, 3);
         const firstResult = results.result?.[0];
         if (results.result?.length > 0 && firstResult) {
           const topScore = firstResult.score ?? 0;
@@ -461,6 +580,10 @@ export function registerTools(mcp: McpServer): void {
       // 5. Supersede old fact if requested
       if (supersedes) {
         try {
+          const existing = await getPointForWorkspaceWrite(supersedes, scope);
+          if (existing.error) {
+            return { content: [{ type: "text", text: JSON.stringify(existing.error, null, 2) }], isError: true };
+          }
           await qdrantSetPayload([supersedes], {
             superseded_by: factId,
             superseded_at: now,
@@ -472,10 +595,10 @@ export function registerTools(mcp: McpServer): void {
 
       // 6. Insert new fact
       const payload: Record<string, unknown> = {
-        content,
-        category,
-        domain,
-        kind,
+        content: redactedContent.text,
+        category: normalizedCategory,
+        domain: normalizedDomain,
+        kind: normalizedKind,
         entities: normalizedEntities,
         source,
         confidence,
@@ -488,6 +611,20 @@ export function registerTools(mcp: McpServer): void {
         created_at: now,
         updated_at: now,
       };
+      if (normalizedSubtype) {
+        payload["memory_subtype"] = normalizedSubtype;
+      }
+      if (normalizedLayer) {
+        payload["layer"] = normalizedLayer;
+      }
+      if (episode_id) payload["episode_id"] = episode_id;
+      if (workstream_key) payload["workstream_key"] = workstream_key;
+      if (task_key) payload["task_key"] = task_key;
+      if (repo) payload["repo"] = repo;
+      if (branch) payload["branch"] = branch;
+      if (review_status) payload["review_status"] = review_status;
+      addWorkspacePayload(payload, scope);
+      addRedactionPayload(payload, redactionSummary);
       if (metadata && Object.keys(metadata).length > 0) {
         payload["metadata"] = metadata;
       }
@@ -495,16 +632,17 @@ export function registerTools(mcp: McpServer): void {
 
       // 7. Insert relation point if provided
       let relationId: string | null = null;
-      if (relation) {
+      if (sanitizedRelation) {
         relationId = newId();
-        const relContent = `${relation.from} ${relation.type} ${relation.to}`;
+        const relContent = `${sanitizedRelation.from} ${sanitizedRelation.type} ${sanitizedRelation.to}`;
         const relVector = await embed(relContent);
         const relPayload: Record<string, unknown> = {
           content: relContent,
-          category,
-          domain,
+          category: normalizedCategory,
+          domain: normalizedDomain,
           kind: "relation",
-          entities: [relation.from.toLowerCase(), relation.to.toLowerCase()],
+          layer: "memory_object",
+          entities: [sanitizedRelation.from.toLowerCase(), sanitizedRelation.to.toLowerCase()],
           source,
           confidence,
           content_hash: contentHash("relation", relContent),
@@ -514,18 +652,22 @@ export function registerTools(mcp: McpServer): void {
           superseded_at: null,
           created_at: now,
           updated_at: now,
-          from_entity: relation.from.toLowerCase(),
-          relation_type: relation.type.toLowerCase(),
-          to_entity: relation.to.toLowerCase(),
+          from_entity: sanitizedRelation.from.toLowerCase(),
+          relation_type: sanitizedRelation.type.toLowerCase(),
+          to_entity: sanitizedRelation.to.toLowerCase(),
         };
+        addWorkspacePayload(relPayload, scope);
+        addRedactionPayload(relPayload, redactionSummary);
         await qdrantUpsert(relationId, relVector, relPayload);
       }
 
       const result: Record<string, unknown> = {
         action: "inserted",
         fact_id: factId,
+        workspace_id: scope.workspaceId,
       };
       if (relationId) result["relation_id"] = relationId;
+      if (redactionSummary.redacted) result["redaction"] = redactionSummary;
       if (similarFacts.length > 0) result["similar_facts"] = similarFacts;
       if (potentialConflicts.length > 0) {
         result["potential_conflicts"] = potentialConflicts;
@@ -547,9 +689,19 @@ export function registerTools(mcp: McpServer): void {
     {
       query: z.string().describe("What to search for (natural language)"),
       category: z.string().optional().describe("Filter by category"),
-      domain: z.string().optional().describe("Filter by domain (work or personal)"),
+      domain: z.string().optional().describe("Filter by domain activity profile"),
       kind: z.string().optional().describe("Filter by kind (fact, summary, distilled, relation)"),
+      memory_subtype: z.string().optional().describe("Filter by memory subtype"),
+      workspace_id: z.string().optional().describe("Filter by optional workspace namespace."),
+      include_legacy_workspace: z.boolean().optional()
+        .describe("Include legacy facts without workspace_id in this workspace query."),
       entity: z.string().optional().describe("Filter by entity name"),
+      episode_id: z.string().optional().describe("Filter by coherent episode ID"),
+      workstream_key: z.string().optional().describe("Filter by durable workstream key"),
+      task_key: z.string().optional().describe("Filter by task or issue key"),
+      repo: z.string().optional().describe("Filter by repository or project surface"),
+      branch: z.string().optional().describe("Filter by branch or working surface"),
+      review_status: z.string().optional().describe("Filter by review lifecycle status"),
       since: z.string().optional().describe("Only facts created after this ISO date"),
       until: z.string().optional().describe("Only facts created before this ISO date"),
       limit: z.number().optional().default(10).describe("Max results (default 10)"),
@@ -557,12 +709,62 @@ export function registerTools(mcp: McpServer): void {
       metadata_filter: z.record(z.string(), z.string()).optional()
         .describe("Filter by metadata key-value pairs. All pairs must match."),
     },
-    async ({ query, category, domain, kind, entity, since, until, limit, graph_depth, metadata_filter }): Promise<McpToolResult> => {
+    async ({
+      query,
+      category,
+      domain,
+      kind,
+      memory_subtype,
+      workspace_id,
+      include_legacy_workspace,
+      entity,
+      episode_id,
+      workstream_key,
+      task_key,
+      repo,
+      branch,
+      review_status,
+      since,
+      until,
+      limit,
+      graph_depth,
+      metadata_filter,
+    }): Promise<McpToolResult> => {
       const guard = requireReady();
       if (guard) return guard;
       const requestedLimit = limit ?? 10;
-      const vector = await embed(query);
-      const filter = buildFilter({ category, domain, kind, entity, since, until, metadata: metadata_filter });
+      const scope = resolveScope(workspace_id, include_legacy_workspace);
+      const redactedQuery = redactStorageText(query);
+      const vector = await embed(redactedQuery.text);
+      const normalizedKind = kind ? normalizeKind(kind) : undefined;
+      let normalizedSubtype: string | undefined;
+      if (memory_subtype) {
+        try {
+          normalizedSubtype = validateMemorySubtype(normalizedKind, memory_subtype) ?? undefined;
+        } catch (e) {
+          return {
+            content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }],
+            isError: true,
+          };
+        }
+      }
+      const filter = scopedFilter(scope, {
+        category: category ? normalizeCategory(category) : undefined,
+        domain: domain ? normalizeDomain(domain) : undefined,
+        kind: normalizedKind,
+        memory_subtype: normalizedSubtype,
+        entity,
+        episode_id,
+        workstream_key,
+        task_key,
+        repo,
+        branch,
+        review_status,
+        since,
+        until,
+        metadata: metadata_filter,
+        excludeKinds: MEMORY_RECALL_EXCLUDED_KINDS,
+      });
       const results = await qdrantSearch(vector, filter, requestedLimit * 2);
 
       if (!results.result?.length) {
@@ -579,7 +781,7 @@ export function registerTools(mcp: McpServer): void {
       const lines = ranked.map((r) => formatFact(r));
 
       if ((graph_depth ?? 0) >= 1) {
-        const relatedLines = await graphTraversal(ranked, requestedLimit);
+        const relatedLines = await graphTraversal(ranked, requestedLimit, scope);
         if (relatedLines.length > 0) {
           lines.push("", "── Related (1-hop) ──");
           lines.push(...relatedLines);
@@ -600,36 +802,27 @@ export function registerTools(mcp: McpServer): void {
     {
       name: z.string().describe("Entity name (e.g. 'qdrant', 'platform')"),
       limit: z.number().optional().default(20).describe("Max facts to return"),
+      workspace_id: z.string().optional().describe("Filter by optional workspace namespace."),
+      include_legacy_workspace: z.boolean().optional()
+        .describe("Include legacy facts without workspace_id in this workspace query."),
     },
-    async ({ name, limit }): Promise<McpToolResult> => {
+    async ({ name, limit, workspace_id, include_legacy_workspace }): Promise<McpToolResult> => {
       const guard = requireReady();
       if (guard) return guard;
       const entityName = name.toLowerCase();
+      const scope = resolveScope(workspace_id, include_legacy_workspace);
 
-      const facts = await qdrantScroll(
-        {
-          must: [
-            { key: "entities", match: { value: entityName } },
-            { is_null: { key: "superseded_by" } },
-          ],
-        },
-        limit ?? 20,
-      );
+      const factsFilter: QdrantFilter = scopedFilter(scope) ?? { must: [] };
+      factsFilter.must.push({ key: "entities", match: { value: entityName } });
+      const facts = await qdrantScroll(factsFilter, limit ?? 20);
 
-      const relationsFrom = await qdrantScroll(
-        { must: [
-          { key: "from_entity", match: { value: entityName } },
-          { is_null: { key: "superseded_by" } },
-        ] },
-        50,
-      );
-      const relationsTo = await qdrantScroll(
-        { must: [
-          { key: "to_entity", match: { value: entityName } },
-          { is_null: { key: "superseded_by" } },
-        ] },
-        50,
-      );
+      const fromFilter: QdrantFilter = scopedFilter(scope) ?? { must: [] };
+      fromFilter.must.push({ key: "from_entity", match: { value: entityName } });
+      const relationsFrom = await qdrantScroll(fromFilter, 50);
+
+      const toFilter: QdrantFilter = scopedFilter(scope) ?? { must: [] };
+      toFilter.must.push({ key: "to_entity", match: { value: entityName } });
+      const relationsTo = await qdrantScroll(toFilter, 50);
 
       const output: string[] = [];
 
@@ -680,18 +873,20 @@ export function registerTools(mcp: McpServer): void {
       relation_type: z.string().optional().describe("Filter by relation type (e.g. 'owns', 'uses', 'decided')"),
       direction: z.enum(["from", "to", "both"]).optional().default("both")
         .describe("Direction: 'from' (entity as source), 'to' (entity as target), 'both'"),
+      workspace_id: z.string().optional().describe("Filter by optional workspace namespace."),
+      include_legacy_workspace: z.boolean().optional()
+        .describe("Include legacy facts without workspace_id in this workspace query."),
     },
-    async ({ entity, relation_type, direction }): Promise<McpToolResult> => {
+    async ({ entity, relation_type, direction, workspace_id, include_legacy_workspace }): Promise<McpToolResult> => {
       const guard = requireReady();
       if (guard) return guard;
       const entityName = entity.toLowerCase();
+      const scope = resolveScope(workspace_id, include_legacy_workspace);
       const results: QdrantPoint[] = [];
 
       if (direction === "from" || direction === "both") {
-        const filter = { must: [
-          { key: "from_entity", match: { value: entityName } },
-          { is_null: { key: "superseded_by" } },
-        ] as QdrantFilter["must"] };
+        const filter: QdrantFilter = scopedFilter(scope) ?? { must: [] };
+        filter.must.push({ key: "from_entity", match: { value: entityName } });
         if (relation_type) {
           filter.must.push({ key: "relation_type", match: { value: relation_type.toLowerCase() } });
         }
@@ -700,10 +895,8 @@ export function registerTools(mcp: McpServer): void {
       }
 
       if (direction === "to" || direction === "both") {
-        const filter = { must: [
-          { key: "to_entity", match: { value: entityName } },
-          { is_null: { key: "superseded_by" } },
-        ] as QdrantFilter["must"] };
+        const filter: QdrantFilter = scopedFilter(scope) ?? { must: [] };
+        filter.must.push({ key: "to_entity", match: { value: entityName } });
         if (relation_type) {
           filter.must.push({ key: "relation_type", match: { value: relation_type.toLowerCase() } });
         }
@@ -738,18 +931,30 @@ export function registerTools(mcp: McpServer): void {
     {
       fact_id: z.string().describe("ID of the fact to forget"),
       reason: z.string().describe("Why this fact is being superseded"),
+      workspace_id: z.string().optional().describe("Optional workspace namespace."),
     },
-    async ({ fact_id, reason }): Promise<McpToolResult> => {
+    async ({ fact_id, reason, workspace_id }): Promise<McpToolResult> => {
       const guard = requireReady();
       if (guard) return guard;
       const now = nowISO();
       try {
+        const scope = resolveScope(workspace_id);
+        const existing = await getPointForWorkspaceWrite(fact_id, scope);
+        if (existing.error) {
+          return { content: [{ type: "text", text: JSON.stringify(existing.error, null, 2) }], isError: true };
+        }
+        const redactedReason = redactStorageText(reason);
         await qdrantSetPayload([fact_id], {
-          superseded_by: `forgotten:${reason}`,
+          superseded_by: `forgotten:${redactedReason.text}`,
           superseded_at: now,
           updated_at: now,
         });
-        return { content: [{ type: "text", text: JSON.stringify({ status: "forgotten", fact_id, reason }) }] };
+        return { content: [{ type: "text", text: JSON.stringify({
+          status: "forgotten",
+          fact_id,
+          reason: redactedReason.text,
+          ...(redactedReason.redacted ? { redaction: redactedReason } : {}),
+        }) }] };
       } catch (e) {
         return { content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }] };
       }
@@ -763,15 +968,20 @@ export function registerTools(mcp: McpServer): void {
     "Confirm a fact is still accurate. Resets the staleness clock and bumps verification count.",
     {
       fact_id: z.string().describe("ID of the fact to verify"),
+      workspace_id: z.string().optional().describe("Optional workspace namespace."),
     },
-    async ({ fact_id }): Promise<McpToolResult> => {
+    async ({ fact_id, workspace_id }): Promise<McpToolResult> => {
       const guard = requireReady();
       if (guard) return guard;
       const now = nowISO();
       try {
-        const existing = await qdrantGetPoints([fact_id]).catch(() => null);
+        const scope = resolveScope(workspace_id);
+        const writable = await getPointForWorkspaceWrite(fact_id, scope);
+        if (writable.error) {
+          return { content: [{ type: "text", text: JSON.stringify(writable.error, null, 2) }], isError: true };
+        }
         let currentCount = 0;
-        const existingPt = existing?.result?.[0];
+        const existingPt = writable.point;
         if (existingPt) {
           currentCount = existingPt.payload.verification_count ?? 0;
         }
@@ -808,18 +1018,19 @@ export function registerTools(mcp: McpServer): void {
       fact_id: z.string().optional().describe("Fact ID (required for approve/reject/correct)"),
       reason: z.string().optional().describe("Reason for rejection"),
       corrected_content: z.string().optional().describe("Corrected fact text (for correct action)"),
+      workspace_id: z.string().optional().describe("Filter by optional workspace namespace."),
+      include_legacy_workspace: z.boolean().optional()
+        .describe("Include legacy facts without workspace_id in this workspace query."),
     },
-    async ({ limit, action, fact_id, reason, corrected_content }): Promise<McpToolResult> => {
+    async ({ limit, action, fact_id, reason, corrected_content, workspace_id, include_legacy_workspace }): Promise<McpToolResult> => {
       const guard = requireReady();
       if (guard) return guard;
+      const scope = resolveScope(workspace_id, include_legacy_workspace);
 
       if (action === "list") {
-        const result = await qdrantScroll({
-          must: [
-            { key: "source", match: { value: "daemon" } },
-            { is_null: { key: "superseded_by" } },
-          ],
-        }, (limit ?? 10) * 2);
+        const filter: QdrantFilter = scopedFilter(scope) ?? { must: [] };
+        filter.must.push({ key: "source", match: { value: "daemon" } });
+        const result = await qdrantScroll(filter, (limit ?? 10) * 2);
 
         const points = (result.result?.points ?? [])
           .sort((a, b) => (b.payload.created_at ?? "").localeCompare(a.payload.created_at ?? ""))
@@ -843,9 +1054,12 @@ export function registerTools(mcp: McpServer): void {
       const now = nowISO();
 
       if (action === "approve") {
-        const existing = await qdrantGetPoints([fact_id]).catch(() => null);
+        const writable = await getPointForWorkspaceWrite(fact_id, scope);
+        if (writable.error) {
+          return { content: [{ type: "text", text: JSON.stringify(writable.error, null, 2) }], isError: true };
+        }
         let currentCount = 0;
-        const approvePt = existing?.result?.[0];
+        const approvePt = writable.point;
         if (approvePt) {
           currentCount = approvePt.payload.verification_count ?? 0;
         }
@@ -861,30 +1075,54 @@ export function registerTools(mcp: McpServer): void {
         if (!reason) {
           return { content: [{ type: "text", text: "Error: reason is required for reject action." }] };
         }
+        const writable = await getPointForWorkspaceWrite(fact_id, scope);
+        if (writable.error) {
+          return { content: [{ type: "text", text: JSON.stringify(writable.error, null, 2) }], isError: true };
+        }
+        const redactedReason = redactStorageText(reason);
         await qdrantSetPayload([fact_id], {
-          superseded_by: `rejected:${reason}`,
+          superseded_by: `rejected:${redactedReason.text}`,
           superseded_at: now,
           updated_at: now,
         });
-        return { content: [{ type: "text", text: JSON.stringify({ status: "rejected", fact_id, reason }) }] };
+        return { content: [{ type: "text", text: JSON.stringify({
+          status: "rejected",
+          fact_id,
+          reason: redactedReason.text,
+          ...(redactedReason.redacted ? { redaction: redactedReason } : {}),
+        }) }] };
       }
 
       if (action === "correct") {
         if (!corrected_content) {
           return { content: [{ type: "text", text: "Error: corrected_content is required for correct action." }] };
         }
-        const original = await qdrantGetPoints([fact_id]).catch(() => null);
-        const origPayload = original?.result?.[0]?.payload;
+        const writable = await getPointForWorkspaceWrite(fact_id, scope);
+        if (writable.error) {
+          return { content: [{ type: "text", text: JSON.stringify(writable.error, null, 2) }], isError: true };
+        }
+        const origPayload = writable.point?.payload;
+        const redactedCorrected = redactStorageText(corrected_content);
+        const correctionScope = origPayload?.workspace_id
+          ? resolveScope(origPayload.workspace_id, false)
+          : scope;
 
-        const vector = await embed(corrected_content);
+        const vector = await embed(redactedCorrected.text);
         const correctedId = crypto.randomUUID();
-        const origCategory = origPayload?.category ?? "observation";
-        const hash = contentHash(origCategory, corrected_content);
-        await qdrantUpsert(correctedId, vector, {
-          content: corrected_content,
+        const origCategory = normalizeCategory(origPayload?.category ?? DEFAULT_CATEGORY);
+        const hash = contentHash(origCategory, redactedCorrected.text);
+        const correctedPayload: Record<string, unknown> = {
+          content: redactedCorrected.text,
           category: origCategory,
-          domain: origPayload?.domain ?? "work",
-          kind: origPayload?.kind ?? "fact",
+          domain: normalizeDomain(origPayload?.domain ?? DEFAULT_DOMAIN),
+          kind: normalizeKind(origPayload?.kind ?? "fact"),
+          ...(origPayload?.memory_subtype ? { memory_subtype: origPayload.memory_subtype } : {}),
+          ...(origPayload?.layer ? { layer: origPayload.layer } : {}),
+          ...(origPayload?.episode_id ? { episode_id: origPayload.episode_id } : {}),
+          ...(origPayload?.workstream_key ? { workstream_key: origPayload.workstream_key } : {}),
+          ...(origPayload?.task_key ? { task_key: origPayload.task_key } : {}),
+          ...(origPayload?.repo ? { repo: origPayload.repo } : {}),
+          ...(origPayload?.branch ? { branch: origPayload.branch } : {}),
           entities: origPayload?.entities ?? [],
           source: "user",
           confidence: 0.95,
@@ -897,7 +1135,10 @@ export function registerTools(mcp: McpServer): void {
           created_at: now,
           updated_at: now,
           metadata: { ...(origPayload?.metadata ?? {}), corrected_from: fact_id },
-        });
+        };
+        addWorkspacePayload(correctedPayload, correctionScope);
+        addRedactionPayload(correctedPayload, redactedCorrected);
+        await qdrantUpsert(correctedId, vector, correctedPayload);
 
         await qdrantSetPayload([fact_id], {
           superseded_by: correctedId,
@@ -909,201 +1150,6 @@ export function registerTools(mcp: McpServer): void {
       }
 
       return { content: [{ type: "text", text: `Unknown action: ${String(action)}` }] };
-    },
-  );
-
-  // ── memory_session_summary ──────────────────────────────────────────────
-
-  mcp.tool(
-    "memory_session_summary",
-    "Store a compressed summary of the current session. Call before a session ends or when a major task completes. " +
-    "Future sessions receive this via memory_recall('session briefing'). Idempotent per session_id.",
-    {
-      session_id: z.string().describe("Session UUID"),
-      summary: z.string().describe("2-5 sentence compressed summary of what happened this session"),
-      tasks_completed: z.array(z.string()).optional().default([]).describe("Task slugs completed"),
-      decisions_made: z.array(z.string()).optional().default([]).describe("Key decisions"),
-      entities_touched: z.array(z.string()).optional().default([]).describe("Entities involved (lowercase)"),
-    },
-    async ({ session_id, summary, tasks_completed, decisions_made, entities_touched }): Promise<McpToolResult> => {
-      const guard = requireReady();
-      if (guard) return guard;
-      const now = nowISO();
-      const normalizedEntities = entities_touched.map((e) => e.toLowerCase());
-
-      // Check for existing summary for this session
-      try {
-        const existing = await qdrantScroll(
-          { must: [
-            { key: "session_id", match: { value: session_id } },
-            { key: "kind", match: { value: "summary" } },
-            { is_null: { key: "superseded_by" } },
-          ] },
-          1,
-        );
-        const summaryPoint = existing.result?.points?.[0];
-        if (summaryPoint) {
-          const point = summaryPoint;
-          const vector = await embed(summary);
-          await qdrantUpsert(point.id, vector, {
-            ...point.payload,
-            content: summary,
-            kind: "summary",
-            domain: "work",
-            source: "system",
-            tasks_completed,
-            decisions_made,
-            entities: normalizedEntities,
-            content_hash: contentHash("observation", summary),
-            updated_at: now,
-          });
-          return {
-            content: [{ type: "text", text: JSON.stringify({
-              action: "updated", fact_id: point.id, session_id,
-            }) }],
-          };
-        }
-      } catch (e) {
-        log("WARN", `Session summary lookup failed: ${e instanceof Error ? e.message : String(e)}`);
-      }
-
-      // Insert new summary
-      const vector = await embed(summary);
-      const factId = newId();
-      await qdrantUpsert(factId, vector, {
-        content: summary,
-        category: "observation",
-        domain: "work",
-        kind: "summary",
-        entities: normalizedEntities,
-        source: "system",
-        confidence: 1.0,
-        content_hash: contentHash("observation", summary),
-        reinforcement_count: 1,
-        last_reinforced_at: now,
-        superseded_by: null,
-        superseded_at: null,
-        created_at: now,
-        updated_at: now,
-        session_id,
-        tasks_completed,
-        decisions_made,
-      });
-
-      return {
-        content: [{ type: "text", text: JSON.stringify({
-          action: "stored", fact_id: factId, session_id,
-        }) }],
-      };
-    },
-  );
-
-  // ── memory_distill ──────────────────────────────────────────────────────
-
-  mcp.tool(
-    "memory_distill",
-    "Consolidate recent session summaries into distilled patterns. Call when 5+ session summaries exist. " +
-    "Uses LLM to extract recurring patterns and key learnings, then supersedes the source summaries.",
-    {
-      days: z.number().optional().default(14).describe("Look-back period in days (default 14)"),
-      max_summaries: z.number().optional().default(20).describe("Max summaries to consolidate"),
-    },
-    async ({ days, max_summaries }): Promise<McpToolResult> => {
-      const guard = requireReady();
-      if (guard) return guard;
-      const now = nowISO();
-      const daysVal = days ?? 14;
-      const maxVal = max_summaries ?? 20;
-      const since = new Date(Date.now() - daysVal * 86400000).toISOString();
-
-      const summaryResults = await qdrantScroll(
-        { must: [
-          { key: "kind", match: { value: "summary" } },
-          { key: "created_at", range: { gte: since } },
-          { is_null: { key: "superseded_by" } },
-        ] },
-        maxVal,
-      );
-
-      const summaries = summaryResults.result?.points ?? [];
-
-      if (summaries.length < 3) {
-        return {
-          content: [{ type: "text", text: JSON.stringify({
-            action: "skipped",
-            reason: `Only ${summaries.length} session summaries in the last ${daysVal} days. Need at least 3.`,
-          }) }],
-        };
-      }
-
-      const summaryTexts = summaries.map((s, i) => {
-        const p = s.payload;
-        const parts = [`Session ${i + 1} (${p.created_at}):\n${p.content}`];
-        if (p.tasks_completed?.length) parts.push(`Tasks: ${p.tasks_completed.join(", ")}`);
-        if (p.decisions_made?.length) parts.push(`Decisions: ${p.decisions_made.join("; ")}`);
-        return parts.join("\n");
-      }).join("\n\n---\n\n");
-
-      const systemPrompt =
-        "You are a memory consolidation system. Given session summaries from an engineering agent, " +
-        "extract recurring patterns, consolidated learnings, and key facts. Output:\n" +
-        "1. Recurring patterns (things that keep coming up)\n" +
-        "2. Key infrastructure/project facts learned\n" +
-        "3. Decisions made and their rationale\n" +
-        "4. Open issues or recurring problems\n" +
-        "Be concise — one line per point. Omit ephemeral details.";
-
-      let distilledContent: string;
-      try {
-        distilledContent = await chatComplete(systemPrompt, summaryTexts);
-      } catch (e) {
-        return { content: [{ type: "text", text: `Distillation failed: ${e instanceof Error ? e.message : String(e)}` }] };
-      }
-
-      const allEntities = [...new Set(summaries.flatMap((s) => s.payload.entities ?? []))];
-      const vector = await embed(distilledContent);
-      const factId = newId();
-      const sourceIds = summaries.map((s) => s.id);
-      await qdrantUpsert(factId, vector, {
-        content: distilledContent,
-        category: "observation",
-        domain: "work",
-        kind: "distilled",
-        entities: allEntities,
-        source: "system",
-        confidence: 0.9,
-        content_hash: contentHash("observation", distilledContent),
-        reinforcement_count: 1,
-        last_reinforced_at: now,
-        superseded_by: null,
-        superseded_at: null,
-        created_at: now,
-        updated_at: now,
-        distilled_from: sourceIds,
-        distilled_period_start: since,
-        distilled_period_end: now,
-        summary_count: summaries.length,
-      });
-
-      try {
-        await qdrantSetPayload(sourceIds, {
-          superseded_by: factId,
-          superseded_at: now,
-        });
-      } catch (e) {
-        log("WARN", `Failed to supersede some source summaries: ${e instanceof Error ? e.message : String(e)}`);
-      }
-
-      return {
-        content: [{ type: "text", text: JSON.stringify({
-          action: "distilled",
-          fact_id: factId,
-          summaries_consolidated: summaries.length,
-          period: { start: since, end: now },
-          entities: allEntities,
-          preview: distilledContent.substring(0, 300) + (distilledContent.length > 300 ? "..." : ""),
-        }, null, 2) }],
-      };
     },
   );
 
@@ -1123,18 +1169,18 @@ export function registerTools(mcp: McpServer): void {
       if (heartbeatCount % 3 === 0 && ready) {
         try {
           const staleThreshold = new Date(Date.now() - STALENESS_DAYS * 86400000).toISOString();
+          const scope = resolveScope();
+          const staleFilter: QdrantFilter = scopedFilter(scope) ?? { must: [] };
+          staleFilter.must.push({ key: "category", match: { any: ["infrastructure", "projects", "decisions"] } });
+          staleFilter.should = [
+            { key: "last_reinforced_at", range: { lte: staleThreshold } },
+            { is_null: { key: "last_reinforced_at" } },
+          ];
+          staleFilter.must_not = [
+            { key: "last_verified_at", range: { gte: staleThreshold } },
+          ];
           const staleResults = await qdrantScroll(
-            { must: [
-              { key: "category", match: { any: ["infrastructure", "projects", "decisions"] } },
-              { is_null: { key: "superseded_by" } },
-            ],
-            should: [
-              { key: "last_reinforced_at", range: { lte: staleThreshold } },
-              { is_null: { key: "last_reinforced_at" } },
-            ],
-            must_not: [
-              { key: "last_verified_at", range: { gte: staleThreshold } },
-            ] },
+            staleFilter,
             3,
           );
           const staleFacts = staleResults.result?.points ?? [];

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -18,13 +18,7 @@ export interface McpToolResult {
 
 export interface CategoryDef {
   description: string;
-  extractionHint: string;
-  examples: Array<{
-    content: string;
-    entities: string[];
-    confidence: number;
-    importance: number;
-  }>;
+  examples: string[];
 }
 
 export interface AxisDef {
@@ -45,6 +39,7 @@ export interface QdrantFilterCondition {
   match?: { value?: string | number; any?: string[] };
   range?: { gte?: string; lte?: string };
   is_null?: { key: string };
+  is_empty?: { key: string };
 }
 
 export interface QdrantFilter {
@@ -84,6 +79,10 @@ export interface FactPayload {
   category: string;
   domain?: string;
   kind?: string;
+  layer?: string | null;
+  memory_subtype?: string | null;
+  workspace_id?: string;
+  actor_id?: string;
   entities: string[];
   source?: string;
   confidence: number;
@@ -93,11 +92,43 @@ export interface FactPayload {
   last_reinforced_at: string;
   last_verified_at?: string;
   verification_count?: number;
+  useful_count?: number;
+  not_useful_count?: number;
+  last_used_at?: string;
+  last_feedback_at?: string;
   superseded_by: string | null;
   superseded_at: string | null;
   created_at: string;
   updated_at: string;
-  metadata?: Record<string, string>;
+  metadata?: Record<string, string | number | boolean | null>;
+  episode_id?: string | null;
+  workstream_key?: string | null;
+  task_key?: string | null;
+  repo?: string | null;
+  branch?: string | null;
+  surface?: string | null;
+  issue_id?: string | null;
+  pr_id?: string | null;
+  source_event_ids?: string[];
+  source_fact_ids?: string[];
+  source_episode_ids?: string[];
+  prompt_version?: string | null;
+  capture_policy_version?: string | null;
+  review_status?: string | null;
+  volatility?: string | null;
+  valid_from?: string | null;
+  expires_at?: string | null;
+  quality_score?: number | null;
+  confidence_reason?: string | null;
+  owner_scope?: string | null;
+  visibility?: string | null;
+  audience?: string | null;
+  sensitivity?: string | null;
+  redaction?: {
+    redacted: boolean;
+    summary: string;
+    matches: Array<{ type: string; count: number }>;
+  };
 
   // Relation fields
   from_entity?: string;
@@ -114,6 +145,15 @@ export interface FactPayload {
   distilled_period_start?: string;
   distilled_period_end?: string;
   summary_count?: number;
+
+  // Telemetry fields
+  telemetry_type?: string;
+  event_session_id?: string;
+  recall_query?: string;
+  returned_fact_ids?: string[];
+  feedback_note?: string;
+  outcome?: string;
+  outcome_summary?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -124,10 +164,22 @@ export interface FilterParams {
   category?: string;
   domain?: string;
   kind?: string;
+  memory_subtype?: string;
+  workspace_id?: string;
+  includeLegacyWorkspace?: boolean;
+  actor_id?: string;
   entity?: string;
+  session_id?: string;
+  episode_id?: string;
+  workstream_key?: string;
+  task_key?: string;
+  repo?: string;
+  branch?: string;
+  review_status?: string;
   since?: string;
   until?: string;
   excludeSuperseded?: boolean;
+  excludeKinds?: string[];
   metadata?: Record<string, string>;
 }
 


### PR DESCRIPTION
## Summary
- adds canonical ontology v2 taxonomy fields, domains, categories, kinds, subtypes, decay policy, and Qdrant indexes
- adds daemon capture-policy constants plus stronger fact extraction quality gates and prompt/version metadata
- replaces durable session summaries with episode summaries, low-priority session indexes, and conservative current-state workstream summaries
- updates MCP store/recall wiring and public docs for ontology v2

## Validation
- npm run build -- --pretty false
- npm test
- git diff --check
- forbidden import/tool check for accidental workspace/redaction helper dependencies and feedback/outcome MCP tools

## Known follow-up
- npm run check still fails because ESLint v9 requires an eslint.config.js flat config; this is an existing repo-level blocker and is not changed in this PR.

Closes #16