### PR TITLE
feat(cli): add bikky render subcommand for external eval harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,24 @@ bikky setup     # interactive setup wizard
 bikky status    # check memory system health
 bikky install   # write MCP config for Copilot + Claude Code
 bikky templates # print config snippets for Copilot, Claude Code, Cursor, and Codex
+bikky render    # render a prompt to JSON (for eval harnesses & debugging)
 ```
 
 See **[docs/integrations.md](docs/integrations.md)** for copy-paste MCP templates.
+
+### `bikky render` — inspect prompts
+
+Render any of bikky'''s prompts to JSON without booting the MCP server. Useful for
+external evaluation harnesses, prompt debugging, and reproducing model calls.
+
+```bash
+bikky render --list                                    # list available prompts
+echo '''{"transcript":"..."}''' | bikky render extraction  # via stdin
+bikky render extraction --input case.json              # via file
+```
+
+Output: a JSON object with `promptName`, `messages`, `temperature`,
+`max_tokens`, and `response_format` — exactly what bikky sends to the LLM.
 
 ## License
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@
  *   bikky setup      — install MCP configs + start daemon (alias for start)
  *   bikky status     — check memory system status
  *   bikky ui         — open memory explorer web UI
+ *   bikky render     — render a prompt to JSON (for eval harnesses)
  *   bikky --version  — print version
  */
 
@@ -16,6 +17,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { startMcpServer } from "./mcp/index.js";
 import { getDaemonStatus, startAll, killDaemon } from "./lifecycle.js";
+import { runRenderCli } from "./render.js";
 
 const command = process.argv[2] ?? "mcp";
 
@@ -85,6 +87,11 @@ async function main(): Promise<void> {
       break;
     }
 
+    case "render": {
+      const code = await runRenderCli(process.argv.slice(3));
+      process.exit(code);
+    }
+
     case "ui": {
       const { execSync } = await import("node:child_process");
       console.log("🧠 Launching bikky ui…");
@@ -98,7 +105,7 @@ async function main(): Promise<void> {
 
     default:
       console.error(`Unknown command: ${command}`);
-      console.error("Usage: bikky [start|stop|mcp|daemon|setup|status|ui|--version]");
+      console.error("Usage: bikky [start|stop|mcp|daemon|setup|status|ui|render|--version]");
       process.exit(1);
   }
 }

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Tests for the `bikky render` CLI plumbing.
+ *
+ * We test the pure pieces (parseRenderArgs, renderPrompt, listPrompts) directly.
+ * The full runRenderCli is tested via stdout capture.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  PROMPT_REGISTRY,
+  listPrompts,
+  parseRenderArgs,
+  renderPrompt,
+  runRenderCli,
+} from "./render.js";
+
+// ── parseRenderArgs ─────────────────────────────────────────────────────────
+
+test("parseRenderArgs: bare name", () => {
+  const args = parseRenderArgs(["extraction"]);
+  assert.equal(args.name, "extraction");
+  assert.equal(args.inputPath, null);
+  assert.equal(args.list, false);
+});
+
+test("parseRenderArgs: --input <path>", () => {
+  const args = parseRenderArgs(["extraction", "--input", "case.json"]);
+  assert.equal(args.name, "extraction");
+  assert.equal(args.inputPath, "case.json");
+});
+
+test("parseRenderArgs: --input=path", () => {
+  const args = parseRenderArgs(["extraction", "--input=case.json"]);
+  assert.equal(args.inputPath, "case.json");
+});
+
+test("parseRenderArgs: --list", () => {
+  const args = parseRenderArgs(["--list"]);
+  assert.equal(args.list, true);
+  assert.equal(args.name, null);
+});
+
+test("parseRenderArgs: --help", () => {
+  const args = parseRenderArgs(["--help"]);
+  assert.equal(args.help, true);
+});
+
+test("parseRenderArgs: rejects unknown flag", () => {
+  assert.throws(() => parseRenderArgs(["--nope"]), /Unknown flag/);
+});
+
+test("parseRenderArgs: rejects extra positional", () => {
+  assert.throws(() => parseRenderArgs(["a", "b"]), /Unexpected positional/);
+});
+
+test("parseRenderArgs: --input requires a value", () => {
+  assert.throws(() => parseRenderArgs(["x", "--input"]), /requires a path/);
+});
+
+// ── listPrompts ─────────────────────────────────────────────────────────────
+
+test("listPrompts returns all 5 prompts", () => {
+  const list = listPrompts();
+  const names = list.map((p) => p.name).sort();
+  assert.deepEqual(names, ["brief", "contradiction", "distill", "extraction", "relations"]);
+  for (const p of list) {
+    assert.ok(p.id, `${p.name} has no id`);
+    assert.ok(p.version, `${p.name} has no version`);
+    assert.ok(p.describe, `${p.name} has no description`);
+  }
+});
+
+test("PROMPT_REGISTRY ids match descriptors", () => {
+  // Stable ids; if a prompt rename happens, both this test and the registry must update.
+  assert.equal(PROMPT_REGISTRY.extraction.id, "extraction");
+  assert.equal(PROMPT_REGISTRY.distill.id, "distill");
+  assert.equal(PROMPT_REGISTRY.contradiction.id, "contradiction");
+  assert.equal(PROMPT_REGISTRY.relations.id, "relations");
+  assert.equal(PROMPT_REGISTRY.brief.id, "brief");
+});
+
+// ── renderPrompt ────────────────────────────────────────────────────────────
+
+test("renderPrompt: extraction renders with system+user messages", () => {
+  const out = renderPrompt("extraction", { transcript: "hello world" });
+  assert.match(out.promptName, /^extraction@/);
+  assert.equal(out.messages.length, 2);
+  assert.equal(out.messages[0].role, "system");
+  assert.equal(out.messages[1].role, "user");
+  assert.ok(out.messages[1].content.includes("hello world"), "user message must include input");
+  assert.ok(typeof out.temperature === "number");
+});
+
+test("renderPrompt: distill renders with summaries", () => {
+  const out = renderPrompt("distill", {
+    summaries: [
+      { id: 1, date: "2026-04-01", content: "first session", tasks_completed: ["a"], decisions_made: [] },
+      { id: 2, date: "2026-04-02", content: "second session", tasks_completed: [], decisions_made: ["b"] },
+      { id: 3, date: "2026-04-03", content: "third session", tasks_completed: [], decisions_made: [] },
+    ],
+  });
+  assert.match(out.promptName, /^distill@/);
+  assert.ok(out.messages[1].content.includes("first session"));
+  assert.ok(out.messages[1].content.includes("third session"));
+});
+
+test("renderPrompt: contradiction renders", () => {
+  const out = renderPrompt("contradiction", {
+    newFact: { content: "user lives in Berlin", category: "team" },
+    candidates: [{ id: "f1", content: "user lives in Paris", category: "team", score: 0.91 }],
+  });
+  assert.match(out.promptName, /^contradiction@/);
+  assert.ok(out.messages[1].content.includes("Berlin"));
+  assert.ok(out.messages[1].content.includes("Paris"));
+});
+
+test("renderPrompt: relations renders", () => {
+  const out = renderPrompt("relations", {
+    entityA: "alice",
+    entityB: "platform",
+    sharedFacts: [{ content: "alice deployed platform v2", category: "projects" }],
+  });
+  assert.match(out.promptName, /^relations@/);
+  assert.ok(out.messages[1].content.includes("alice"));
+  assert.ok(out.messages[1].content.includes("platform"));
+});
+
+test("renderPrompt: brief renders", () => {
+  const out = renderPrompt("brief", {
+    generatedAt: "2026-04-25",
+    sections: { "Open threads": ["thread one", "thread two"] },
+  });
+  assert.match(out.promptName, /^brief@/);
+  assert.ok(out.messages[1].content.includes("thread one"));
+});
+
+test("renderPrompt: unknown name throws with helpful message", () => {
+  assert.throws(
+    () => renderPrompt("nope", {}),
+    /Unknown prompt: "nope".*Available:/s,
+  );
+});
+
+// ── runRenderCli (full integration via stdout capture) ──────────────────────
+
+function captureStdout<T>(fn: () => T | Promise<T>): { code: T; stdout: string; stderr: string } | Promise<{ code: T; stdout: string; stderr: string }> {
+  const origLog = console.log;
+  const origErr = console.error;
+  let stdout = "";
+  let stderr = "";
+  console.log = (...args: unknown[]) => { stdout += args.join(" ") + "\n"; };
+  console.error = (...args: unknown[]) => { stderr += args.join(" ") + "\n"; };
+  try {
+    const result = fn();
+    if (result instanceof Promise) {
+      return result.then((code) => {
+        console.log = origLog;
+        console.error = origErr;
+        return { code, stdout, stderr };
+      }).catch((err) => {
+        console.log = origLog;
+        console.error = origErr;
+        throw err;
+      });
+    }
+    console.log = origLog;
+    console.error = origErr;
+    return { code: result, stdout, stderr };
+  } catch (err) {
+    console.log = origLog;
+    console.error = origErr;
+    throw err;
+  }
+}
+
+test("runRenderCli: --list prints JSON list of prompts", async () => {
+  const result = await captureStdout(() => runRenderCli(["--list"]));
+  assert.equal(result.code, 0);
+  const parsed = JSON.parse(result.stdout) as Array<{ name: string }>;
+  assert.equal(parsed.length, 5);
+  assert.ok(parsed.find((p) => p.name === "extraction"));
+});
+
+test("runRenderCli: --help exits 0", async () => {
+  const result = await captureStdout(() => runRenderCli(["--help"]));
+  assert.equal(result.code, 0);
+  assert.ok(result.stdout.includes("Usage:"));
+});
+
+test("runRenderCli: missing name returns 1", async () => {
+  const result = await captureStdout(() => runRenderCli([]));
+  assert.equal(result.code, 1);
+  assert.ok(result.stderr.includes("prompt name is required"));
+});
+
+test("runRenderCli: unknown prompt returns 1 with available list", async () => {
+  // Fake stdin via --input pointing at /dev/null trick — instead use a temp file
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+  const os = await import("node:os");
+  const tmp = path.join(os.tmpdir(), `bikky-render-test-${Date.now()}.json`);
+  fs.writeFileSync(tmp, "{}");
+  try {
+    const result = await captureStdout(() => runRenderCli(["nope", "--input", tmp]));
+    assert.equal(result.code, 1);
+    assert.ok(result.stderr.includes("Unknown prompt"));
+    assert.ok(result.stderr.includes("extraction"), "should list available prompts");
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});
+
+test("runRenderCli: malformed input JSON returns 1", async () => {
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+  const os = await import("node:os");
+  const tmp = path.join(os.tmpdir(), `bikky-render-test-${Date.now()}.json`);
+  fs.writeFileSync(tmp, "not json {");
+  try {
+    const result = await captureStdout(() => runRenderCli(["extraction", "--input", tmp]));
+    assert.equal(result.code, 1);
+    assert.ok(result.stderr.includes("parsing input JSON"));
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});
+
+test("runRenderCli: full render via --input file produces valid JSON", async () => {
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+  const os = await import("node:os");
+  const tmp = path.join(os.tmpdir(), `bikky-render-test-${Date.now()}.json`);
+  fs.writeFileSync(tmp, JSON.stringify({ transcript: "test transcript" }));
+  try {
+    const result = await captureStdout(() => runRenderCli(["extraction", "--input", tmp]));
+    assert.equal(result.code, 0);
+    const parsed = JSON.parse(result.stdout) as { promptName: string; messages: unknown[] };
+    assert.match(parsed.promptName, /^extraction@/);
+    assert.equal(parsed.messages.length, 2);
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,0 +1,203 @@
+/**
+ * `bikky render` — render a prompt to JSON without booting the MCP server.
+ *
+ * Designed for external evaluation harnesses (e.g. DeepEval-based test suites)
+ * and for debugging prompts manually. Prompts remain the single source of truth
+ * in src/prompts/; consumers shell out to this command instead of re-implementing
+ * the rendering logic.
+ *
+ * Usage:
+ *   bikky render <name>                  # reads input JSON from stdin
+ *   bikky render <name> --input <path>   # reads input JSON from file
+ *   bikky render --list                  # list available prompts
+ *
+ * Output (stdout): JSON object with promptName, messages, temperature, etc.
+ * Errors → stderr, exit 1.
+ */
+
+import fs from "node:fs";
+import {
+  extractionPrompt,
+  distillPrompt,
+  contradictionPrompt,
+  relationsPrompt,
+  briefPrompt,
+  EXTRACTION_PROMPT_DESCRIPTOR,
+  DISTILL_PROMPT_DESCRIPTOR,
+  CONTRADICTION_PROMPT_DESCRIPTOR,
+  RELATIONS_PROMPT_DESCRIPTOR,
+  BRIEF_PROMPT_DESCRIPTOR,
+  type RenderedPrompt,
+} from "./prompts/index.js";
+
+interface PromptEntry {
+  id: string;
+  version: string;
+  describe: string;
+  build: (input: unknown) => RenderedPrompt;
+}
+
+export const PROMPT_REGISTRY: Record<string, PromptEntry> = {
+  extraction: {
+    id: EXTRACTION_PROMPT_DESCRIPTOR.id,
+    version: EXTRACTION_PROMPT_DESCRIPTOR.version,
+    describe: 'Extract atomic facts from a session transcript. Input: { transcript: string, systemOverride?: string|null }',
+    build: (input) => extractionPrompt(input as Parameters<typeof extractionPrompt>[0]),
+  },
+  distill: {
+    id: DISTILL_PROMPT_DESCRIPTOR.id,
+    version: DISTILL_PROMPT_DESCRIPTOR.version,
+    describe: 'Consolidate >=3 session summaries into reusable patterns. Input: { summaries: [{ id, date, content, tasks_completed?, decisions_made? }] }',
+    build: (input) => distillPrompt(input as Parameters<typeof distillPrompt>[0]),
+  },
+  contradiction: {
+    id: CONTRADICTION_PROMPT_DESCRIPTOR.id,
+    version: CONTRADICTION_PROMPT_DESCRIPTOR.version,
+    describe: 'Decide whether a new fact contradicts existing candidates. Input: { newFact: { content, category }, candidates: [{ id, content, category, score }] }',
+    build: (input) => contradictionPrompt(input as Parameters<typeof contradictionPrompt>[0]),
+  },
+  relations: {
+    id: RELATIONS_PROMPT_DESCRIPTOR.id,
+    version: RELATIONS_PROMPT_DESCRIPTOR.version,
+    describe: 'Infer typed relations between two entities from shared facts. Input: { entityA, entityB, sharedFacts: [{ content, category }] }',
+    build: (input) => relationsPrompt(input as Parameters<typeof relationsPrompt>[0]),
+  },
+  brief: {
+    id: BRIEF_PROMPT_DESCRIPTOR.id,
+    version: BRIEF_PROMPT_DESCRIPTOR.version,
+    describe: 'Generate a session briefing from grouped fact sections. Input: { generatedAt: ISO date, sections: { <heading>: string[] } }',
+    build: (input) => briefPrompt(input as Parameters<typeof briefPrompt>[0]),
+  },
+};
+
+export function listPrompts(): Array<{ name: string; id: string; version: string; describe: string }> {
+  return Object.entries(PROMPT_REGISTRY).map(([name, entry]) => ({
+    name,
+    id: entry.id,
+    version: entry.version,
+    describe: entry.describe,
+  }));
+}
+
+export function renderPrompt(name: string, input: unknown): RenderedPrompt {
+  const entry = PROMPT_REGISTRY[name];
+  if (!entry) {
+    const available = Object.keys(PROMPT_REGISTRY).join(", ");
+    throw new Error(`Unknown prompt: "${name}". Available: ${available}`);
+  }
+  return entry.build(input);
+}
+
+function readStdinSync(): string {
+  try {
+    return fs.readFileSync(0, "utf-8");
+  } catch (err) {
+    throw new Error(`Failed to read stdin: ${(err as Error).message}`);
+  }
+}
+
+interface ParsedArgs {
+  name: string | null;
+  inputPath: string | null;
+  list: boolean;
+  help: boolean;
+}
+
+export function parseRenderArgs(argv: string[]): ParsedArgs {
+  const args: ParsedArgs = { name: null, inputPath: null, list: false, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--list" || a === "-l") {
+      args.list = true;
+    } else if (a === "--help" || a === "-h") {
+      args.help = true;
+    } else if (a === "--input" || a === "-i") {
+      args.inputPath = argv[++i] ?? null;
+      if (!args.inputPath) {
+        throw new Error("--input requires a path argument");
+      }
+    } else if (a.startsWith("--input=")) {
+      args.inputPath = a.slice("--input=".length);
+    } else if (a.startsWith("-")) {
+      throw new Error(`Unknown flag: ${a}`);
+    } else if (args.name === null) {
+      args.name = a;
+    } else {
+      throw new Error(`Unexpected positional argument: ${a}`);
+    }
+  }
+  return args;
+}
+
+function printHelp(): void {
+  console.log(`Usage:
+  bikky render <name>                  Render prompt; reads JSON input from stdin
+  bikky render <name> --input <path>   Render prompt; reads JSON input from file
+  bikky render --list                  List available prompts
+  bikky render --help                  Show this help
+
+Available prompts:`);
+  for (const p of listPrompts()) {
+    console.log(`  ${p.name.padEnd(15)} ${p.id}@${p.version}`);
+    console.log(`  ${"".padEnd(15)} ${p.describe}`);
+  }
+}
+
+export async function runRenderCli(argv: string[]): Promise<number> {
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseRenderArgs(argv);
+  } catch (err) {
+    console.error((err as Error).message);
+    console.error("Run `bikky render --help` for usage.");
+    return 1;
+  }
+
+  if (parsed.help) {
+    printHelp();
+    return 0;
+  }
+
+  if (parsed.list) {
+    console.log(JSON.stringify(listPrompts(), null, 2));
+    return 0;
+  }
+
+  if (!parsed.name) {
+    console.error("Error: prompt name is required");
+    console.error("Run `bikky render --help` for usage.");
+    return 1;
+  }
+
+  let raw: string;
+  try {
+    raw = parsed.inputPath ? fs.readFileSync(parsed.inputPath, "utf-8") : readStdinSync();
+  } catch (err) {
+    console.error(`Error reading input: ${(err as Error).message}`);
+    return 1;
+  }
+
+  if (!raw.trim()) {
+    console.error("Error: input JSON is empty (provide via stdin or --input)");
+    return 1;
+  }
+
+  let input: unknown;
+  try {
+    input = JSON.parse(raw);
+  } catch (err) {
+    console.error(`Error parsing input JSON: ${(err as Error).message}`);
+    return 1;
+  }
+
+  let rendered: RenderedPrompt;
+  try {
+    rendered = renderPrompt(parsed.name, input);
+  } catch (err) {
+    console.error(`Error: ${(err as Error).message}`);
+    return 1;
+  }
+
+  console.log(JSON.stringify(rendered, null, 2));
+  return 0;
+}


### PR DESCRIPTION
Supersedes #3. Rewrites the render-cli on top of current main (now includes the prompt registry from #18).

## What

Adds `bikky render` — renders any of the 5 prompts to JSON without booting the MCP server. Designed as the bridge for external eval harnesses (e.g. Python + DeepEval): prompts stay the single source of truth in TS; consumers shell out to this command instead of re-implementing rendering.

## Usage

```bash
bikky render --list                                    # list available prompts
echo '{"transcript":"..."}' | bikky render extraction  # via stdin
bikky render extraction --input case.json              # via file
```

Output: `{ promptName, messages, temperature, max_tokens, response_format }` — exactly what bikky sends to the LLM.

## Files

- `src/render.ts` (NEW) — argv parsing, input loading, prompt dispatch
- `src/render.test.ts` (NEW) — unit tests for all 5 prompts + CLI parsing
- `src/cli.ts` — wired `render` subcommand
- `README.md` — usage docs

## Tests

**323/323 pass** (was 301 on main; +22 from render.test.ts).