### PR TITLE
test: add comprehensive unit-test harness + Qdrant integration smoke test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,25 @@ Good references for new tests:
 | Mocking `globalThis.fetch`       | `src/mcp/api.test.ts`, `packages/ui/src/lib/qdrant.test.ts` |
 | Hono route via `app.fetch`       | `packages/ui/src/routes/memory.test.ts` |
 
+### Integration tests (opt-in, real Qdrant)
+
+The default `npm test` mocks every external call. We also ship one **opt-in** end-to-end smoke test that talks to a real Qdrant Cloud instance and a real embedding provider — it's the only thing that catches filter-shape rejections, payload-index mismatches, vector-dimension drift, and whether the dedup similarity thresholds (`THRESHOLD_DUPLICATE`, `THRESHOLD_RELATED`) actually correspond to near-duplicates against your embedding model.
+
+```bash
+# Uses your existing ~/.bikky/config.json + QDRANT_URL/QDRANT_API_KEY env.
+BIKKY_INTEGRATION=1 npm run test:integration
+```
+
+What it does:
+
+1. Creates a throwaway collection named `bikky-it-<short-uuid>` with the real payload indexes.
+2. Exercises `memory_store` (insert, exact-dup, near-duplicate paraphrase), `memory_recall`, `memory_entity`, and `memory_forget` against live Qdrant + your real embeddings.
+3. Drops the collection in `after()` regardless of pass/fail.
+
+Cost is negligible — a handful of small embedding calls per run (≈ $0.0001 on OpenAI's `text-embedding-3-small`, free on Ollama). Files end in `.itest.ts` so the default `*.test.js` glob never picks them up.
+
+If the near-duplicate paraphrase doesn't reinforce on your embedding model, the test logs the actual similarity score so you can re-tune `THRESHOLD_DUPLICATE` rather than failing outright.
+
 ## Adding an embedding or LLM provider
 
 The most common contribution is **adding a new embedding or LLM provider**. Each provider is a single file. The registry dispatches by `provider.name`, so no central edits are required beyond adding one import line to the barrel.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,95 @@
 # Contributing to bikky
 
-Thanks for considering a contribution! This guide focuses on the most common
-contribution: **adding a new embedding or LLM provider**.
+Thanks for your interest in bikky! We welcome PRs of all sizes — from typo fixes to new daemon features. This document covers the practical bits: how the repo is laid out, how to run the tests, and what we look for in a contribution.
 
-## Project layout
+## Repository layout
 
-- `src/llm/embedding/` — embedding registry + built-in providers (Ollama, OpenAI, Bedrock, Portkey)
-- `src/llm/inference/` — chat-completion registry + built-in providers (same set)
-- `packages/ui/src/lib/embedding/` — UI-side embedding registry (browser-friendly providers only)
-- `src/config.ts` — flat config with a generic `extra` bag for provider-specific options
+bikky is a small monorepo:
 
-## Adding an embedding provider
+```
+.
+├── src/                  # Core CLI + MCP server + daemon (published as `bikky`)
+│   ├── cli/              # `bikky <subcommand>` entrypoints
+│   ├── daemon/           # Background workers: extraction, consolidation, staleness, …
+│   ├── mcp/              # MCP server (the surface AI agents call into)
+│   ├── prompts/          # Versioned LLM prompt registry
+│   └── llm/              # Provider adapters (OpenAI, Bedrock, Ollama, Portkey)
+│       ├── embedding/    #   embedding registry + providers
+│       └── inference/    #   chat-completion registry + providers
+└── packages/
+    └── ui/               # Local web UI (`bikky-ui`) — Hono server + React frontend
+        ├── src/lib/      #   - config, qdrant client, embeddings
+        ├── src/routes/   #   - REST API routes
+        └── app/          #   - React/Vite frontend
+```
 
-Each provider is a single file. The registry dispatches by `provider.name`, so
-no central edits are required beyond adding one import line to the barrel.
+## Setup
+
+```bash
+git clone https://github.com/bikky-dev/bikky.git
+cd bikky
+npm install
+cd packages/ui && npm install && cd ../..
+```
+
+## Running the tests
+
+We use the Node.js built-in test runner ([`node:test`](https://nodejs.org/api/test.html)) — no Jest, no Vitest, no extra dependencies.
+
+```bash
+# Core (CLI, daemon, MCP server) — 300+ tests
+npm test
+
+# UI server + libraries — 50+ tests
+cd packages/ui && npm test
+```
+
+Both packages compile TypeScript into `dist/` first and then run the compiled `*.test.js` files. The UI test suite uses `--test-isolation=process --test-concurrency=1` because several tests share `~/.bikky/config.json` on the developer's machine; running them in isolation avoids flakiness.
+
+> **Note on `~/.bikky/config.json`** — UI tests back up your real config in `before()` and restore it in `after()`. If a test crashes mid-run the file *should* survive, but if you ever see odd behaviour after a failed test run, just delete the file and re-run `bikky setup`.
+
+### What we test
+
+We aim for **focused, fast unit tests** that lock in behaviour without being a maintenance tax:
+
+- Pure functions (filter builders, hashers, parsers) — exhaustive cases.
+- Stateful modules (config loaders, lifecycle/PID, daemons) — happy path + a couple of failure modes.
+- Network clients (Qdrant, embeddings, LLM providers) — mock `globalThis.fetch` and assert on the request, never call a real backend.
+- HTTP routes (Hono) — exercise via `app.fetch(new Request(...))` against the real router with mocked underlying calls.
+
+We deliberately **do not** test:
+
+- LLM prompt quality or extraction accuracy. Those live in the separate [`bikky-evals`](https://github.com/bikky-dev/bikky-evals) repo, which uses DeepEval for prompt-level scoring.
+- Implementation details (private function internals, exact log strings) — these change often and tests that pin them slow contributors down.
+- The React frontend — the testable surface there is small; we rely on type-checking and manual smoke tests.
+
+### Adding a new test
+
+Tests live alongside the source as `*.test.ts`:
+
+```
+src/foo.ts       # source
+src/foo.test.ts  # tests
+```
+
+Use the [`node:test`](https://nodejs.org/api/test.html) `describe/it/before/after` API and `node:assert/strict`. For mocking, prefer **dependency injection** (e.g. the `StaleDeps` pattern in `src/daemon/staleness.ts`) over module mocking — it keeps tests deterministic and the production code easier to reason about.
+
+Good references for new tests:
+
+| Pattern                          | Reference                              |
+|----------------------------------|----------------------------------------|
+| Filesystem with backup/restore   | `src/lifecycle.test.ts`                |
+| Temp dir with `mkdtemp`          | `src/logger.test.ts`                   |
+| Env-based path override          | `src/llm/telemetry.test.ts`            |
+| Dependency injection for daemons | `src/daemon/staleness.test.ts`         |
+| Mocking `globalThis.fetch`       | `src/mcp/api.test.ts`, `packages/ui/src/lib/qdrant.test.ts` |
+| Hono route via `app.fetch`       | `packages/ui/src/routes/memory.test.ts` |
+
+## Adding an embedding or LLM provider
+
+The most common contribution is **adding a new embedding or LLM provider**. Each provider is a single file. The registry dispatches by `provider.name`, so no central edits are required beyond adding one import line to the barrel.
+
+### Embedding provider
 
 1. Create `src/llm/embedding/providers/<name>.ts`:
 
@@ -74,7 +150,7 @@ no central edits are required beyond adding one import line to the barrel.
 
    Or via env: `BIKKY_EMBEDDING_EXTRA_<KEY>=value` flows into `extra`.
 
-## Adding an inference (LLM) provider
+### Inference (LLM) provider
 
 Same pattern, under `src/llm/inference/providers/`. The interface is
 `InferenceProvider` (see `src/llm/inference/types.ts`), the key method is
@@ -85,27 +161,27 @@ back to `cfg.fallback` if configured. Throw only for programmer errors.
 Configure a fallback chain via `llm.fallback_provider` in config (or
 `LLM_FALLBACK_PROVIDER` env).
 
-## Running checks
+## Submitting changes
 
-```sh
-npm run build      # tsc
-npm test           # all tests with concurrency=1 (avoids config-file races)
-npm run lint
-```
+1. **Open an issue first** for non-trivial changes so we can align on the approach.
+2. **Branch** from `main` (`git checkout -b your-feature-name`).
+3. **Run the tests** in both packages before pushing.
+4. **Open a PR** referencing the issue (`Closes #123`). CI will re-run tests on push.
+5. We aim to review within a few business days — ping the issue if it goes quiet.
 
-UI:
+## Style
 
-```sh
-cd packages/ui && npm run build
-```
+- TypeScript strict mode is on; no `any` unless interfacing with external SDK types (use a focused local interface to constrain the surface area).
+- We prefer small, pure functions and clear module boundaries to elaborate abstractions.
+- Tests live next to the source they cover (`foo.ts` + `foo.test.ts`).
+- Providers must not call `process.exit`, log to stdout, or modify global state beyond their own module-scope cache.
+- Heavy SDKs (e.g. `@aws-sdk/*`) **must be `await import(...)`-loaded inside the provider's `embed`/`chat`** so users on lighter providers don't pay the bundle cost.
+- Comments explain *why*, not *what* — the code shows the *what*.
 
-## Conventions
+## License
 
-- TypeScript strict mode; no `any` unless interfacing with external SDK types
-  (use a focused local interface to constrain the surface area)
-- Tests live next to the source they cover (`foo.ts` + `foo.test.ts`)
-- Providers must not call `process.exit`, log to stdout, or modify global state
-  beyond their own module-scope cache
-- Heavy SDKs (e.g. `@aws-sdk/*`) **must be `await import(...)`-loaded inside
-  the provider's `embed`/`chat`** so users on lighter providers don't pay the
-  bundle cost
+By contributing, you agree that your contributions will be licensed under the project's [AGPL-3.0-or-later](LICENSE) license.
+
+## Code of conduct
+
+Be kind. We follow the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lint": "eslint src/",
     "check": "tsc --noEmit && eslint src/",
     "test": "node --test --test-concurrency=1 $(find dist -name '*.test.js')",
+    "test:integration": "tsc && BIKKY_INTEGRATION=${BIKKY_INTEGRATION:-1} node --test $(find dist -name '*.itest.js')",
     "build:diagrams": "node scripts/build-diagrams.mjs",
     "prepublishOnly": "npm run build"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -22,6 +22,7 @@
     "build:ui": "vite build --config app/vite.config.ts",
     "dev": "vite --config app/vite.config.ts",
     "typecheck": "tsc --noEmit",
+    "test": "tsc && node --test --test-isolation=process --test-concurrency=1 \"dist/**/*.test.js\"",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/ui/src/lib/config.test.ts
+++ b/packages/ui/src/lib/config.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for the bikky-ui config loader.
+ */
+
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { loadConfig, _resetConfig, CONFIG_PATH } from "./config.js";
+
+const ENV_KEYS = [
+  "QDRANT_URL",
+  "QDRANT_API_KEY",
+  "BIKKY_COLLECTION",
+  "EMBEDDING_PROVIDER",
+  "EMBEDDING_MODEL",
+  "EMBEDDING_BASE_URL",
+  "OPENAI_API_KEY",
+];
+
+const savedEnv: Record<string, string | undefined> = {};
+let savedConfig: string | null = null;
+let configExisted = false;
+
+describe("ui/lib/config", () => {
+  before(() => {
+    for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+    if (fs.existsSync(CONFIG_PATH)) {
+      configExisted = true;
+      savedConfig = fs.readFileSync(CONFIG_PATH, "utf-8");
+    }
+  });
+
+  after(() => {
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+    if (savedConfig !== null) fs.writeFileSync(CONFIG_PATH, savedConfig);
+    else if (!configExisted && fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
+    _resetConfig();
+  });
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) delete process.env[k];
+    if (fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
+    _resetConfig();
+  });
+
+  it("returns defaults when no config file or env vars are set", () => {
+    const cfg = loadConfig();
+    assert.equal(cfg.qdrant_url, null);
+    assert.equal(cfg.qdrant_api_key, null);
+    assert.equal(cfg.collection, "bikky");
+    assert.equal(cfg.embedding.provider, "ollama");
+    assert.equal(cfg.embedding.base_url, "http://localhost:11434");
+  });
+
+  it("merges values from ~/.bikky/config.json", () => {
+    fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+      qdrant_url: "https://qdrant.example:6333",
+      qdrant_api_key: "abc123",
+      collection: "custom",
+      embedding: { provider: "openai", model: "text-embedding-3-small", api_key: "sk-xx" },
+    }));
+
+    const cfg = loadConfig();
+
+    assert.equal(cfg.qdrant_url, "https://qdrant.example:6333");
+    assert.equal(cfg.qdrant_api_key, "abc123");
+    assert.equal(cfg.collection, "custom");
+    assert.equal(cfg.embedding.provider, "openai");
+    assert.equal(cfg.embedding.model, "text-embedding-3-small");
+    assert.equal(cfg.embedding.api_key, "sk-xx");
+    // Non-overridden defaults remain
+    assert.equal(cfg.embedding.dimensions, 1024);
+  });
+
+  it("env vars take precedence over the config file", () => {
+    fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+      qdrant_url: "https://from-file:6333",
+      qdrant_api_key: "file-key",
+    }));
+    process.env.QDRANT_URL = "https://from-env:6333";
+    process.env.QDRANT_API_KEY = "env-key";
+    process.env.BIKKY_COLLECTION = "envcol";
+
+    const cfg = loadConfig();
+
+    assert.equal(cfg.qdrant_url, "https://from-env:6333");
+    assert.equal(cfg.qdrant_api_key, "env-key");
+    assert.equal(cfg.collection, "envcol");
+  });
+
+  it("strips trailing slashes from URLs", () => {
+    process.env.QDRANT_URL = "https://qdrant.example:6333/////";
+    process.env.EMBEDDING_BASE_URL = "http://ollama:11434/";
+
+    const cfg = loadConfig();
+
+    assert.equal(cfg.qdrant_url, "https://qdrant.example:6333");
+    assert.equal(cfg.embedding.base_url, "http://ollama:11434");
+  });
+
+  it("falls back to defaults when the config file is corrupt", () => {
+    fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(CONFIG_PATH, "not json{{{");
+
+    const cfg = loadConfig();
+
+    assert.equal(cfg.qdrant_url, null);
+    assert.equal(cfg.collection, "bikky");
+  });
+
+  it("memoises the loaded config", () => {
+    const a = loadConfig();
+    const b = loadConfig();
+    assert.equal(a, b);
+  });
+});

--- a/packages/ui/src/lib/config.ts
+++ b/packages/ui/src/lib/config.ts
@@ -81,3 +81,11 @@ export function loadConfig(): BikkyUIConfig {
   _config = config;
   return config;
 }
+
+/**
+ * Test-only: clear the memoised config so the next loadConfig() call
+ * re-reads the file and environment variables.
+ */
+export function _resetConfig(): void {
+  _config = null;
+}

--- a/packages/ui/src/lib/embed.test.ts
+++ b/packages/ui/src/lib/embed.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for the bikky-ui embedding client.
+ */
+
+import { describe, it, before, after, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { embed, isEmbeddingAvailable } from "./embed.js";
+import { CONFIG_PATH, _resetConfig } from "./config.js";
+
+const realFetch = globalThis.fetch;
+const ENV_KEYS = ["EMBEDDING_PROVIDER", "EMBEDDING_MODEL", "EMBEDDING_BASE_URL", "OPENAI_API_KEY"];
+const savedEnv: Record<string, string | undefined> = {};
+let savedConfig: string | null = null;
+let configExisted = false;
+
+interface FetchCall { url: string; init: RequestInit }
+
+function installMock(handler: (url: string, init: RequestInit) => Response | Promise<Response>): FetchCall[] {
+  const calls: FetchCall[] = [];
+  globalThis.fetch = (async (input: any, init: RequestInit = {}) => {
+    const url = typeof input === "string" ? input : input.toString();
+    calls.push({ url, init });
+    return handler(url, init);
+  }) as typeof fetch;
+  return calls;
+}
+
+function writeConfig(cfg: object): void {
+  fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg));
+  _resetConfig();
+}
+
+describe("ui/lib/embed", () => {
+  before(() => {
+    for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+    if (fs.existsSync(CONFIG_PATH)) {
+      configExisted = true;
+      savedConfig = fs.readFileSync(CONFIG_PATH, "utf-8");
+    }
+  });
+
+  after(() => {
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+    if (savedConfig !== null) fs.writeFileSync(CONFIG_PATH, savedConfig);
+    else if (!configExisted && fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
+    _resetConfig();
+    globalThis.fetch = realFetch;
+  });
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) delete process.env[k];
+    if (fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
+    _resetConfig();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it("isEmbeddingAvailable returns false for bedrock", () => {
+    writeConfig({ embedding: { provider: "bedrock" } });
+    assert.equal(isEmbeddingAvailable(), false);
+  });
+
+  it("isEmbeddingAvailable returns true for ollama", () => {
+    writeConfig({ embedding: { provider: "ollama" } });
+    assert.equal(isEmbeddingAvailable(), true);
+  });
+
+  it("isEmbeddingAvailable returns true for openai", () => {
+    writeConfig({ embedding: { provider: "openai", api_key: "k" } });
+    assert.equal(isEmbeddingAvailable(), true);
+  });
+
+  it("embed throws when provider is bedrock", async () => {
+    writeConfig({ embedding: { provider: "bedrock" } });
+    await assert.rejects(embed("x"), /Bedrock embeddings require AWS SDK/);
+  });
+
+  it("embed POSTs to /v1/embeddings with the right body for ollama", async () => {
+    writeConfig({
+      embedding: { provider: "ollama", model: "qwen3-embed", base_url: "http://ollama.local:11434/" },
+    });
+    const calls = installMock(() => new Response(JSON.stringify({
+      data: [{ embedding: [0.1, 0.2, 0.3] }],
+    }), { status: 200 }));
+
+    const vec = await embed("hello world");
+
+    assert.deepEqual(vec, [0.1, 0.2, 0.3]);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]!.url, "http://ollama.local:11434/v1/embeddings");
+    const body = JSON.parse(String(calls[0]!.init.body));
+    assert.equal(body.model, "qwen3-embed");
+    assert.equal(body.input, "hello world");
+    const headers = calls[0]!.init.headers as Record<string, string>;
+    assert.equal(headers["Content-Type"], "application/json");
+    assert.equal(headers["Authorization"], undefined);
+  });
+
+  it("embed adds Authorization: Bearer for openai", async () => {
+    writeConfig({
+      embedding: { provider: "openai", model: "text-embedding-3-small", api_key: "sk-test", base_url: "https://api.openai.com" },
+    });
+    const calls = installMock(() => new Response(JSON.stringify({
+      data: [{ embedding: [0.5] }],
+    }), { status: 200 }));
+
+    await embed("x");
+
+    const headers = calls[0]!.init.headers as Record<string, string>;
+    assert.equal(headers["Authorization"], "Bearer sk-test");
+    assert.equal(calls[0]!.url, "https://api.openai.com/v1/embeddings");
+  });
+
+  it("embed throws a descriptive error on non-2xx responses", async () => {
+    writeConfig({ embedding: { provider: "ollama", model: "qwen", base_url: "http://x" } });
+    installMock(() => new Response("internal", { status: 500 }));
+
+    await assert.rejects(embed("x"), /Embedding failed \[ollama\/qwen\] \(500\): internal/);
+  });
+
+  it("embed throws when the response has no data", async () => {
+    writeConfig({ embedding: { provider: "ollama", model: "qwen", base_url: "http://x" } });
+    installMock(() => new Response(JSON.stringify({ data: [] }), { status: 200 }));
+
+    await assert.rejects(embed("x"), /Embedding response missing data/);
+  });
+});

--- a/packages/ui/src/lib/qdrant.test.ts
+++ b/packages/ui/src/lib/qdrant.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for the bikky-ui Qdrant client and filter builder.
+ * Mocks global fetch — no real Qdrant required.
+ */
+
+import { describe, it, before, after, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  QdrantClient,
+  buildFilter,
+  isQdrantConfigured,
+  createQdrantClient,
+  QdrantNotConfiguredError,
+} from "./qdrant.js";
+import { CONFIG_PATH, _resetConfig } from "./config.js";
+
+const realFetch = globalThis.fetch;
+const ENV_KEYS = ["QDRANT_URL", "QDRANT_API_KEY", "BIKKY_COLLECTION"];
+const savedEnv: Record<string, string | undefined> = {};
+let savedConfig: string | null = null;
+let configExisted = false;
+
+interface FetchCall { url: string; init: RequestInit }
+
+function installMock(handler: (url: string, init: RequestInit) => Response | Promise<Response>): FetchCall[] {
+  const calls: FetchCall[] = [];
+  globalThis.fetch = (async (input: any, init: RequestInit = {}) => {
+    const url = typeof input === "string" ? input : input.toString();
+    calls.push({ url, init });
+    return handler(url, init);
+  }) as typeof fetch;
+  return calls;
+}
+
+describe("ui/lib/qdrant", () => {
+  describe("buildFilter", () => {
+    it("returns an empty must list when no options are given", () => {
+      assert.deepEqual(buildFilter({}), { must: [] });
+    });
+
+    it("adds is_null condition when excludeSuperseded is true", () => {
+      const f = buildFilter({ excludeSuperseded: true });
+      assert.deepEqual(f.must, [{ is_null: { key: "superseded_by" } }]);
+    });
+
+    it("adds match conditions for category, domain, kind, source", () => {
+      const f = buildFilter({ category: "infra", domain: "work", kind: "fact", source: "agent" });
+      assert.deepEqual(f.must, [
+        { key: "category", match: { value: "infra" } },
+        { key: "domain", match: { value: "work" } },
+        { key: "kind", match: { value: "fact" } },
+        { key: "source", match: { value: "agent" } },
+      ]);
+    });
+
+    it("lowercases the entity value", () => {
+      const f = buildFilter({ entity: "Bikky" });
+      assert.deepEqual(f.must, [{ key: "entities", match: { value: "bikky" } }]);
+    });
+
+    it("adds range conditions for since and until", () => {
+      const f = buildFilter({ since: "2024-01-01", until: "2024-12-31" });
+      assert.deepEqual(f.must, [
+        { key: "created_at", range: { gte: "2024-01-01" } },
+        { key: "created_at", range: { lte: "2024-12-31" } },
+      ]);
+    });
+  });
+
+  describe("QdrantClient", () => {
+    const client = new QdrantClient("https://q.test:6333/", "api-key", "col");
+
+    afterEach(() => {
+      globalThis.fetch = realFetch;
+    });
+
+    it("strips trailing slashes from the base URL", async () => {
+      const calls = installMock(() => new Response(JSON.stringify({ result: [] }), { status: 200 }));
+      await client.search([0.1, 0.2]);
+      assert.equal(calls[0]!.url, "https://q.test:6333/collections/col/points/search");
+    });
+
+    it("sends the api-key header on every request", async () => {
+      const calls = installMock(() => new Response(JSON.stringify({ result: [] }), { status: 200 }));
+      await client.search([0.1]);
+      const headers = calls[0]!.init.headers as Record<string, string>;
+      assert.equal(headers["api-key"], "api-key");
+      assert.equal(headers["Content-Type"], "application/json");
+    });
+
+    it("throws a descriptive error when the response is not ok", async () => {
+      installMock(() => new Response("oops", { status: 502 }));
+      await assert.rejects(
+        client.search([0.1]),
+        /Qdrant POST .* \(502\): oops/,
+      );
+    });
+
+    it("scroll passes offset and order_by when provided", async () => {
+      const calls = installMock(() => new Response(JSON.stringify({
+        result: { points: [], next_page_offset: "next-cursor" },
+      }), { status: 200 }));
+
+      const res = await client.scroll({ must: [] }, 50, "abc", { key: "created_at", direction: "desc" });
+
+      const body = JSON.parse(String(calls[0]!.init.body));
+      assert.equal(body.offset, "abc");
+      assert.deepEqual(body.order_by, { key: "created_at", direction: "desc" });
+      assert.equal(body.limit, 50);
+      assert.equal(res.nextOffset, "next-cursor");
+    });
+
+    it("scroll returns null nextOffset when omitted by Qdrant", async () => {
+      installMock(() => new Response(JSON.stringify({
+        result: { points: [{ id: "1", payload: {} }] },
+      }), { status: 200 }));
+
+      const res = await client.scroll({ must: [] });
+      assert.equal(res.nextOffset, null);
+      assert.equal(res.points.length, 1);
+    });
+
+    it("count returns the result.count value", async () => {
+      installMock(() => new Response(JSON.stringify({ result: { count: 42 } }), { status: 200 }));
+      const n = await client.count({ must: [{ key: "x", match: { value: "y" } }] });
+      assert.equal(n, 42);
+    });
+
+    it("upsert sends the canonical points body", async () => {
+      const calls = installMock(() => new Response(JSON.stringify({}), { status: 200 }));
+      await client.upsert("id1", [0.1, 0.2], { content: "hi" });
+
+      const body = JSON.parse(String(calls[0]!.init.body));
+      assert.deepEqual(body, { points: [{ id: "id1", vector: [0.1, 0.2], payload: { content: "hi" } }] });
+    });
+
+    it("setPayload sends the canonical points body", async () => {
+      const calls = installMock(() => new Response(JSON.stringify({}), { status: 200 }));
+      await client.setPayload(["id1", "id2"], { foo: "bar" });
+
+      const body = JSON.parse(String(calls[0]!.init.body));
+      assert.deepEqual(body, { points: ["id1", "id2"], payload: { foo: "bar" } });
+    });
+
+    it("collectionInfo uses GET /collections/<name>", async () => {
+      const calls = installMock(() => new Response(JSON.stringify({
+        result: { points_count: 12, vectors_count: 12 },
+      }), { status: 200 }));
+
+      const info = await client.collectionInfo();
+      assert.equal(calls[0]!.init.method, "GET");
+      assert.equal(calls[0]!.url, "https://q.test:6333/collections/col");
+      assert.equal(info.points_count, 12);
+    });
+  });
+
+  describe("createQdrantClient / isQdrantConfigured", () => {
+    before(() => {
+      for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+      if (fs.existsSync(CONFIG_PATH)) {
+        configExisted = true;
+        savedConfig = fs.readFileSync(CONFIG_PATH, "utf-8");
+      }
+    });
+
+    after(() => {
+      for (const k of ENV_KEYS) {
+        if (savedEnv[k] === undefined) delete process.env[k];
+        else process.env[k] = savedEnv[k];
+      }
+      if (savedConfig !== null) fs.writeFileSync(CONFIG_PATH, savedConfig);
+      else if (!configExisted && fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
+      _resetConfig();
+    });
+
+    beforeEach(() => {
+      for (const k of ENV_KEYS) delete process.env[k];
+      if (fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
+      _resetConfig();
+    });
+
+    it("returns false / throws when no Qdrant credentials are configured", () => {
+      fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
+      fs.writeFileSync(CONFIG_PATH, "{}");
+
+      assert.equal(isQdrantConfigured(), false);
+      assert.throws(() => createQdrantClient(), QdrantNotConfiguredError);
+    });
+
+    it("returns true and constructs a client when credentials are present", () => {
+      process.env.QDRANT_URL = "https://q.example:6333";
+      process.env.QDRANT_API_KEY = "k";
+
+      assert.equal(isQdrantConfigured(), true);
+      const c = createQdrantClient();
+      assert.ok(c instanceof QdrantClient);
+    });
+  });
+
+  it("QdrantNotConfiguredError carries a helpful message", () => {
+    const err = new QdrantNotConfiguredError();
+    assert.equal(err.name, "QdrantNotConfiguredError");
+    assert.match(err.message, /bikky setup/);
+  });
+});

--- a/packages/ui/src/routes/memory.test.ts
+++ b/packages/ui/src/routes/memory.test.ts
@@ -1,0 +1,457 @@
+/**
+ * Tests for the /api/memory/* Hono routes.
+ * Mocks global fetch (Qdrant + embeddings) — exercises the routes via app.fetch().
+ */
+
+import { describe, it, before, after, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+import { Hono } from "hono";
+import { memoryRoutes } from "./memory.js";
+import { CONFIG_PATH, _resetConfig } from "../lib/config.js";
+
+const realFetch = globalThis.fetch;
+const ENV_KEYS = ["QDRANT_URL", "QDRANT_API_KEY", "BIKKY_COLLECTION", "EMBEDDING_PROVIDER", "EMBEDDING_MODEL", "EMBEDDING_BASE_URL", "OPENAI_API_KEY"];
+const savedEnv: Record<string, string | undefined> = {};
+let savedConfig: string | null = null;
+let configExisted = false;
+
+interface QdrantCall { method: string; path: string; body: any }
+
+/**
+ * Install a fetch mock that pretends to be Qdrant + the embedding endpoint.
+ * Pass `qdrantHandler` to react to Qdrant calls; returns the call log so tests
+ * can assert on it.
+ */
+function installMock(opts: {
+  qdrantHandler?: (call: QdrantCall) => unknown;
+  embedding?: number[];
+} = {}): { calls: QdrantCall[]; embedCalls: number } {
+  const calls: QdrantCall[] = [];
+  const state = { embedCalls: 0 };
+
+  globalThis.fetch = (async (input: any, init: RequestInit = {}) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init.method ?? "GET").toUpperCase();
+    const body = init.body ? JSON.parse(String(init.body)) : null;
+
+    // Embedding endpoint
+    if (url.includes("/v1/embeddings")) {
+      state.embedCalls++;
+      return new Response(JSON.stringify({
+        data: [{ embedding: opts.embedding ?? [0.1, 0.2, 0.3] }],
+      }), { status: 200 });
+    }
+
+    // Qdrant endpoint — extract path after the base URL
+    const qdrantPath = url.replace("https://q.test", "");
+    const call: QdrantCall = { method, path: qdrantPath, body };
+    calls.push(call);
+
+    const result = opts.qdrantHandler ? opts.qdrantHandler(call) : { result: [] };
+    return new Response(JSON.stringify(result), { status: 200 });
+  }) as typeof fetch;
+
+  return new Proxy({ calls, embedCalls: state.embedCalls } as { calls: QdrantCall[]; embedCalls: number }, {
+    get(_target, prop) {
+      if (prop === "embedCalls") return state.embedCalls;
+      if (prop === "calls") return calls;
+      return undefined;
+    },
+  });
+}
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route("/api/memory", memoryRoutes);
+  return app;
+}
+
+const sampleFact = (overrides: Record<string, unknown> = {}) => ({
+  id: "11111111-1111-1111-1111-111111111111",
+  payload: {
+    content: "Bikky uses Qdrant",
+    category: "infrastructure",
+    domain: "work",
+    kind: "fact",
+    entities: ["bikky", "qdrant"],
+    confidence: 0.9,
+    superseded_by: null,
+    superseded_at: null,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    content_hash: "h",
+    reinforcement_count: 0,
+    last_reinforced_at: "2024-01-01T00:00:00Z",
+    ...overrides,
+  },
+});
+
+describe("ui/routes/memory", () => {
+  before(() => {
+    for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+    if (fs.existsSync(CONFIG_PATH)) {
+      configExisted = true;
+      savedConfig = fs.readFileSync(CONFIG_PATH, "utf-8");
+    }
+  });
+
+  after(() => {
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+    if (savedConfig !== null) fs.writeFileSync(CONFIG_PATH, savedConfig);
+    else if (!configExisted && fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
+    _resetConfig();
+    globalThis.fetch = realFetch;
+  });
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) delete process.env[k];
+    fs.mkdirSync(CONFIG_PATH.replace(/\/[^/]+$/, ""), { recursive: true });
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+      qdrant_url: "https://q.test",
+      qdrant_api_key: "test-key",
+      collection: "test",
+      embedding: { provider: "ollama", model: "qwen", base_url: "http://embed.test", dimensions: 3 },
+    }));
+    _resetConfig();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  describe("GET /search", () => {
+    it("returns 400 when q is missing", async () => {
+      const app = buildApp();
+      const res = await app.fetch(new Request("http://localhost/api/memory/search"));
+      assert.equal(res.status, 400);
+    });
+
+    it("returns 501 when embedding provider is bedrock", async () => {
+      fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+        qdrant_url: "https://q.test", qdrant_api_key: "k",
+        embedding: { provider: "bedrock" },
+      }));
+      _resetConfig();
+      const app = buildApp();
+
+      const res = await app.fetch(new Request("http://localhost/api/memory/search?q=hello"));
+      assert.equal(res.status, 501);
+    });
+
+    it("embeds the query, calls Qdrant search, and returns formatted results", async () => {
+      const log = installMock({
+        qdrantHandler: () => ({ result: [{ ...sampleFact(), score: 0.99 }] }),
+      });
+      const app = buildApp();
+
+      const res = await app.fetch(new Request("http://localhost/api/memory/search?q=hello&category=infrastructure&limit=5"));
+      assert.equal(res.status, 200);
+      const body = await res.json() as { results: any[]; count: number };
+      assert.equal(body.count, 1);
+      assert.equal(body.results[0].score, 0.99);
+      assert.equal(body.results[0].content, "Bikky uses Qdrant");
+
+      const search = log.calls.find((c) => c.path.endsWith("/points/search"));
+      assert.ok(search);
+      assert.equal(search!.body.limit, 5);
+      assert.equal(search!.body.filter.must[0].match.value, "infrastructure");
+    });
+
+    it("clamps limit to 100", async () => {
+      const log = installMock({ qdrantHandler: () => ({ result: [] }) });
+      const app = buildApp();
+
+      await app.fetch(new Request("http://localhost/api/memory/search?q=hi&limit=9999"));
+      const search = log.calls.find((c) => c.path.endsWith("/points/search"));
+      assert.equal(search!.body.limit, 100);
+    });
+  });
+
+  describe("GET /browse", () => {
+    it("calls scroll with order_by when sort=newest", async () => {
+      const log = installMock({
+        qdrantHandler: () => ({ result: { points: [sampleFact()], next_page_offset: "abc" } }),
+      });
+      const app = buildApp();
+
+      const res = await app.fetch(new Request("http://localhost/api/memory/browse?sort=newest&limit=10"));
+      assert.equal(res.status, 200);
+      const body = await res.json() as { results: any[]; nextOffset: string };
+      assert.equal(body.nextOffset, "abc");
+
+      const scroll = log.calls.find((c) => c.path.endsWith("/points/scroll"));
+      assert.deepEqual(scroll!.body.order_by, { key: "created_at", direction: "desc" });
+    });
+
+    it("forwards offset for pagination", async () => {
+      const log = installMock({
+        qdrantHandler: () => ({ result: { points: [], next_page_offset: null } }),
+      });
+      const app = buildApp();
+
+      await app.fetch(new Request("http://localhost/api/memory/browse?offset=cursor-1"));
+      const scroll = log.calls.find((c) => c.path.endsWith("/points/scroll"));
+      assert.equal(scroll!.body.offset, "cursor-1");
+    });
+  });
+
+  describe("GET /facts/:id", () => {
+    it("returns 404 when not found", async () => {
+      installMock({ qdrantHandler: () => ({ result: [] }) });
+      const app = buildApp();
+      const res = await app.fetch(new Request("http://localhost/api/memory/facts/missing-id"));
+      assert.equal(res.status, 404);
+    });
+
+    it("returns the formatted point when found", async () => {
+      installMock({ qdrantHandler: () => ({ result: [sampleFact()] }) });
+      const app = buildApp();
+      const res = await app.fetch(new Request("http://localhost/api/memory/facts/abc"));
+      assert.equal(res.status, 200);
+      const body = await res.json() as { id: string; content: string };
+      assert.equal(body.content, "Bikky uses Qdrant");
+    });
+  });
+
+  describe("PUT /facts/:id", () => {
+    it("returns 404 when fact does not exist", async () => {
+      installMock({ qdrantHandler: () => ({ result: [] }) });
+      const app = buildApp();
+      const res = await app.fetch(new Request("http://localhost/api/memory/facts/missing", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "new" }),
+      }));
+      assert.equal(res.status, 404);
+    });
+
+    it("calls setPayload with normalized entities and re-embeds when content changes", async () => {
+      let getCount = 0;
+      const log = installMock({
+        qdrantHandler: (c) => {
+          if (c.path.endsWith("/points") && c.method === "POST" && c.body?.ids) {
+            // getPoints
+            getCount++;
+            return { result: [sampleFact()] };
+          }
+          return { result: {} };
+        },
+      });
+      const app = buildApp();
+
+      const res = await app.fetch(new Request("http://localhost/api/memory/facts/id1", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "updated", entities: ["FOO", "Bar"] }),
+      }));
+      assert.equal(res.status, 200);
+
+      const setPayload = log.calls.find((c) => c.path.endsWith("/points/payload"));
+      assert.ok(setPayload, "expected setPayload call");
+      assert.deepEqual(setPayload!.body.payload.entities, ["foo", "bar"]);
+      assert.equal(setPayload!.body.payload.content, "updated");
+
+      // Re-embed + upsert because content changed
+      const upsert = log.calls.find((c) => c.method === "PUT" && c.path.endsWith("/points"));
+      assert.ok(upsert, "expected upsert call after re-embed");
+    });
+  });
+
+  describe("DELETE /facts/:id", () => {
+    it("soft-deletes by setting superseded_by", async () => {
+      const log = installMock({
+        qdrantHandler: (c) => {
+          if (c.method === "POST" && c.body?.ids) return { result: [sampleFact()] };
+          return { result: {} };
+        },
+      });
+      const app = buildApp();
+
+      const res = await app.fetch(new Request("http://localhost/api/memory/facts/id1", { method: "DELETE" }));
+      assert.equal(res.status, 200);
+      const setPayload = log.calls.find((c) => c.path.endsWith("/points/payload"));
+      assert.equal(setPayload!.body.payload.superseded_by, "ui-deleted");
+    });
+  });
+
+  describe("POST /facts", () => {
+    it("returns 400 when required fields are missing", async () => {
+      const app = buildApp();
+      const res = await app.fetch(new Request("http://localhost/api/memory/facts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "hi" }),
+      }));
+      assert.equal(res.status, 400);
+    });
+
+    it("returns 501 when embedding is unavailable", async () => {
+      fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+        qdrant_url: "https://q.test", qdrant_api_key: "k",
+        embedding: { provider: "bedrock" },
+      }));
+      _resetConfig();
+      const app = buildApp();
+      const res = await app.fetch(new Request("http://localhost/api/memory/facts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "x", category: "c", entities: ["e"] }),
+      }));
+      assert.equal(res.status, 501);
+    });
+
+    it("creates the fact, embeds it, lowercases entities, and returns 201", async () => {
+      const log = installMock({ qdrantHandler: () => ({ result: {} }) });
+      const app = buildApp();
+
+      const res = await app.fetch(new Request("http://localhost/api/memory/facts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "Hello world", category: "infrastructure", entities: ["FOO", "Bar"] }),
+      }));
+      assert.equal(res.status, 201);
+
+      const upsert = log.calls.find((c) => c.method === "PUT" && c.path.endsWith("/points"));
+      assert.ok(upsert);
+      const point = upsert!.body.points[0];
+      assert.deepEqual(point.payload.entities, ["foo", "bar"]);
+      assert.equal(point.payload.source, "ui");
+      assert.equal(point.payload.kind, "fact");
+      assert.equal(point.payload.domain, "work");
+      assert.equal(typeof point.id, "string");
+      assert.equal(typeof point.payload.content_hash, "string");
+    });
+  });
+
+  describe("GET /entities/:name", () => {
+    it("aggregates facts and from/to relations", async () => {
+      let scrollCount = 0;
+      installMock({
+        qdrantHandler: (c) => {
+          if (c.path.endsWith("/points/scroll")) {
+            scrollCount++;
+            // First: facts. Second: from-relations. Third: to-relations.
+            const points = scrollCount === 1
+              ? [sampleFact()]
+              : scrollCount === 2
+                ? [sampleFact({ from_entity: "alice", relation_type: "owns", to_entity: "bikky" })]
+                : [sampleFact({ from_entity: "bikky", relation_type: "uses", to_entity: "alice" })];
+            return { result: { points, next_page_offset: null } };
+          }
+          return { result: [] };
+        },
+      });
+      const app = buildApp();
+
+      const res = await app.fetch(new Request("http://localhost/api/memory/entities/Alice"));
+      assert.equal(res.status, 200);
+      const body = await res.json() as { entity: string; facts: any[]; relations: any[]; factCount: number; relationCount: number };
+      assert.equal(body.entity, "alice");
+      assert.equal(body.factCount, 1);
+      assert.equal(body.relationCount, 2);
+    });
+  });
+
+  describe("GET /shared", () => {
+    it("returns 400 when a or b is missing", async () => {
+      const app = buildApp();
+      const res = await app.fetch(new Request("http://localhost/api/memory/shared?a=foo"));
+      assert.equal(res.status, 400);
+    });
+
+    it("returns intersection facts when both a and b are provided", async () => {
+      installMock({
+        qdrantHandler: () => ({ result: { points: [sampleFact()], next_page_offset: null } }),
+      });
+      const app = buildApp();
+      const res = await app.fetch(new Request("http://localhost/api/memory/shared?a=BIKKY&b=Qdrant"));
+      assert.equal(res.status, 200);
+      const body = await res.json() as { entityA: string; entityB: string; count: number };
+      assert.equal(body.entityA, "bikky");
+      assert.equal(body.entityB, "qdrant");
+      assert.equal(body.count, 1);
+    });
+  });
+
+  describe("GET /relations", () => {
+    it("returns 400 when entity is missing", async () => {
+      const app = buildApp();
+      const res = await app.fetch(new Request("http://localhost/api/memory/relations"));
+      assert.equal(res.status, 400);
+    });
+
+    it("dedupes results when direction=both", async () => {
+      const dup = sampleFact({ from_entity: "alice", to_entity: "bob", relation_type: "knows" });
+      installMock({
+        qdrantHandler: () => ({ result: { points: [dup], next_page_offset: null } }),
+      });
+      const app = buildApp();
+
+      const res = await app.fetch(new Request("http://localhost/api/memory/relations?entity=alice"));
+      assert.equal(res.status, 200);
+      const body = await res.json() as { count: number; relations: any[] };
+      assert.equal(body.count, 1, "should dedupe duplicate point ids across from/to scrolls");
+    });
+  });
+
+  describe("GET /graph", () => {
+    it("aggregates entity nodes and edges from facts", async () => {
+      installMock({
+        qdrantHandler: () => ({
+          result: {
+            points: [
+              sampleFact({ entities: ["a", "b"], category: "infrastructure" }),
+              sampleFact({ entities: ["b", "c"], category: "decisions" }),
+            ],
+            next_page_offset: null,
+          },
+        }),
+      });
+      const app = buildApp();
+
+      const res = await app.fetch(new Request("http://localhost/api/memory/graph"));
+      assert.equal(res.status, 200);
+      const body = await res.json() as { nodes: any[]; edges: any[]; factCount: number };
+      assert.equal(body.factCount, 2);
+      assert.equal(body.nodes.length, 3);
+      assert.equal(body.edges.length, 2);
+      const b = body.nodes.find((n) => n.id === "b");
+      assert.equal(b.factCount, 2);
+    });
+  });
+
+  describe("GET /stats", () => {
+    it("returns total/active/superseded counts and per-category/per-kind breakdowns", async () => {
+      let pointsCount = 100;
+      installMock({
+        qdrantHandler: (c) => {
+          if (c.path === "/collections/test") {
+            return { result: { points_count: pointsCount, vectors_count: pointsCount } };
+          }
+          if (c.path.endsWith("/points/count")) {
+            // Return a different count per filter to exercise the merge logic
+            const must = c.body?.filter?.must ?? [];
+            if (must.length === 0) return { result: { count: 90 } };
+            return { result: { count: 10 } };
+          }
+          return { result: {} };
+        },
+      });
+      const app = buildApp();
+
+      const res = await app.fetch(new Request("http://localhost/api/memory/stats"));
+      assert.equal(res.status, 200);
+      const body = await res.json() as { total: number; active: number; superseded: number; byCategory: Record<string, number>; byKind: Record<string, number> };
+      assert.equal(body.total, 100);
+      assert.equal(body.active, 90);
+      assert.equal(body.superseded, 10);
+      assert.equal(body.byCategory.infrastructure, 10);
+      assert.equal(body.byKind.fact, 10);
+    });
+  });
+});

--- a/packages/ui/src/server.test.ts
+++ b/packages/ui/src/server.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for the createApp() Hono server — health, error mapping, SPA fallback.
+ */
+
+import { describe, it, before, after, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+import { createApp } from "./server.js";
+import { CONFIG_PATH, _resetConfig } from "./lib/config.js";
+
+const ENV_KEYS = ["QDRANT_URL", "QDRANT_API_KEY", "BIKKY_COLLECTION"];
+const savedEnv: Record<string, string | undefined> = {};
+let savedConfig: string | null = null;
+let configExisted = false;
+const realFetch = globalThis.fetch;
+
+describe("ui/server", () => {
+  before(() => {
+    for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+    if (fs.existsSync(CONFIG_PATH)) {
+      configExisted = true;
+      savedConfig = fs.readFileSync(CONFIG_PATH, "utf-8");
+    }
+  });
+
+  after(() => {
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+    if (savedConfig !== null) fs.writeFileSync(CONFIG_PATH, savedConfig);
+    else if (!configExisted && fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
+    _resetConfig();
+  });
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) delete process.env[k];
+    if (fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
+    _resetConfig();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it("/health reports qdrant_configured: false when not configured", async () => {
+    fs.writeFileSync(CONFIG_PATH, "{}");
+    _resetConfig();
+    const app = createApp();
+
+    const res = await app.fetch(new Request("http://localhost/health"));
+    assert.equal(res.status, 200);
+    const body = await res.json() as { ok: boolean; service: string; qdrant_configured: boolean; collection: string };
+    assert.equal(body.ok, true);
+    assert.equal(body.service, "bikky-ui");
+    assert.equal(body.qdrant_configured, false);
+    assert.equal(typeof body.collection, "string");
+  });
+
+  it("/health reports qdrant_configured: true when env vars set", async () => {
+    process.env.QDRANT_URL = "https://q.example:6333";
+    process.env.QDRANT_API_KEY = "k";
+    _resetConfig();
+    const app = createApp();
+
+    const res = await app.fetch(new Request("http://localhost/health"));
+    const body = await res.json() as { qdrant_configured: boolean };
+    assert.equal(body.qdrant_configured, true);
+  });
+
+  it("/api/memory/search returns 400 when q is missing", async () => {
+    fs.writeFileSync(CONFIG_PATH, "{}");
+    _resetConfig();
+    const app = createApp();
+
+    const res = await app.fetch(new Request("http://localhost/api/memory/search"));
+    assert.equal(res.status, 400);
+    const body = await res.json() as { error: string };
+    assert.match(body.error, /Missing query/);
+  });
+
+  it("maps QdrantNotConfiguredError to 503 with NOT_CONFIGURED code", async () => {
+    fs.writeFileSync(CONFIG_PATH, "{}"); // no qdrant creds
+    _resetConfig();
+    const app = createApp();
+
+    // /api/memory/browse hits createQdrantClient() which throws QdrantNotConfiguredError
+    const res = await app.fetch(new Request("http://localhost/api/memory/browse"));
+    assert.equal(res.status, 503);
+    const body = await res.json() as { error: string; code: string };
+    assert.equal(body.code, "NOT_CONFIGURED");
+    assert.match(body.error, /Qdrant not configured/);
+  });
+
+  it("returns a non-API response for unknown paths (SPA fallback or 404)", async () => {
+    fs.writeFileSync(CONFIG_PATH, "{}");
+    _resetConfig();
+    const app = createApp();
+
+    const res = await app.fetch(new Request("http://localhost/non-existent-page"));
+    // Either the SPA fallback (200 + text) or 404 — both acceptable when public/ may or may not exist.
+    assert.ok([200, 404].includes(res.status), `unexpected status ${res.status}`);
+  });
+});

--- a/src/daemon/staleness.test.ts
+++ b/src/daemon/staleness.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for the staleness scanner.
+ *
+ * Uses dependency injection (StaleDeps) — no Qdrant or filesystem required.
+ */
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { scanStaleFacts, setLogger, _resetDedup, type StaleDeps } from "./staleness.js";
+import { CONFIG_DEFAULTS, type BikkyConfig } from "../config.js";
+import type { QdrantScrollResult } from "./qdrant.js";
+
+function makeConfig(overrides: Partial<BikkyConfig["daemon"]> = {}): BikkyConfig {
+  return {
+    ...CONFIG_DEFAULTS,
+    daemon: { ...CONFIG_DEFAULTS.daemon, ...overrides },
+  };
+}
+
+function makeFact(id: string, content = "x", category = "infrastructure"): QdrantScrollResult {
+  return {
+    id,
+    content,
+    category,
+    domain: "work",
+    kind: "fact",
+    entities: [],
+    last_reinforced_at: "2020-01-01T00:00:00.000Z",
+    created_at: "2020-01-01T00:00:00.000Z",
+  } as unknown as QdrantScrollResult;
+}
+
+describe("daemon/staleness", () => {
+  let logs: Array<{ level: string; msg: string }>;
+
+  beforeEach(() => {
+    logs = [];
+    setLogger(((level: string, ...args: unknown[]) => {
+      logs.push({ level, msg: args.map(String).join(" ") });
+    }) as unknown as Parameters<typeof setLogger>[0]);
+    _resetDedup();
+  });
+
+  it("skips and logs DEBUG when Qdrant is not ready", async () => {
+    let scrollCalls = 0;
+    const deps: StaleDeps = {
+      isReady: () => false,
+      scrollFacts: async () => { scrollCalls++; return []; },
+    };
+
+    await scanStaleFacts(makeConfig(), deps);
+
+    assert.equal(scrollCalls, 0);
+    assert.ok(logs.some(l => l.level === "DEBUG" && /not ready/.test(l.msg)));
+  });
+
+  it("logs every stale fact and a summary line", async () => {
+    const deps: StaleDeps = {
+      isReady: () => true,
+      scrollFacts: async () => [makeFact("a"), makeFact("b")],
+    };
+
+    await scanStaleFacts(makeConfig(), deps);
+
+    const stale = logs.filter(l => /^Stale fact/.test(l.msg));
+    assert.equal(stale.length, 2);
+    assert.ok(logs.some(l => /found 2 stale fact/.test(l.msg)));
+  });
+
+  it("dedupes when the same set of stale facts appears twice", async () => {
+    const deps: StaleDeps = {
+      isReady: () => true,
+      scrollFacts: async () => [makeFact("a"), makeFact("b")],
+    };
+
+    await scanStaleFacts(makeConfig(), deps);
+    logs.length = 0;
+    await scanStaleFacts(makeConfig(), deps);
+
+    assert.equal(logs.filter(l => /^Stale fact/.test(l.msg)).length, 0);
+    assert.ok(logs.some(l => /skipping duplicate log/.test(l.msg)));
+  });
+
+  it("re-logs when the set of stale facts changes", async () => {
+    let call = 0;
+    const deps: StaleDeps = {
+      isReady: () => true,
+      scrollFacts: async () => {
+        call++;
+        return call === 1 ? [makeFact("a")] : [makeFact("a"), makeFact("c")];
+      },
+    };
+
+    await scanStaleFacts(makeConfig(), deps);
+    logs.length = 0;
+    await scanStaleFacts(makeConfig(), deps);
+
+    assert.equal(logs.filter(l => /^Stale fact/.test(l.msg)).length, 2);
+  });
+
+  it("resets dedup state when no stale facts are found", async () => {
+    let call = 0;
+    const deps: StaleDeps = {
+      isReady: () => true,
+      scrollFacts: async () => {
+        call++;
+        if (call === 1) return [makeFact("a")];
+        if (call === 2) return [];
+        return [makeFact("a")];
+      },
+    };
+
+    await scanStaleFacts(makeConfig(), deps);
+    await scanStaleFacts(makeConfig(), deps);
+    logs.length = 0;
+    await scanStaleFacts(makeConfig(), deps);
+
+    // Third call should re-log the same fact since dedup state was reset
+    assert.ok(logs.some(l => /^Stale fact/.test(l.msg)));
+  });
+
+  it("swallows scroll errors with a WARN log", async () => {
+    const deps: StaleDeps = {
+      isReady: () => true,
+      scrollFacts: async () => { throw new Error("network down"); },
+    };
+
+    await scanStaleFacts(makeConfig(), deps);
+
+    assert.ok(logs.some(l => l.level === "WARN" && /network down/.test(l.msg)));
+  });
+
+  it("uses the configured staleness_threshold_days", async () => {
+    let receivedFilters: { olderThan?: string } | undefined;
+    const deps: StaleDeps = {
+      isReady: () => true,
+      scrollFacts: async (filters) => {
+        receivedFilters = filters as { olderThan?: string };
+        return [];
+      },
+    };
+
+    await scanStaleFacts(makeConfig({ staleness_threshold_days: 7 }), deps);
+
+    assert.ok(receivedFilters?.olderThan, "should pass an olderThan cutoff");
+    const cutoff = new Date(receivedFilters!.olderThan!).getTime();
+    const now = Date.now();
+    const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+    // Cutoff should be ~7 days ago (allow 60s slop)
+    assert.ok(Math.abs((now - cutoff) - sevenDaysMs) < 60_000);
+  });
+});

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for daemon lifecycle PID-file management.
+ *
+ * Backs up and restores the real PID file at ~/.bikky/state/daemon.pid so
+ * we don't clobber an actual running daemon during the test run.
+ */
+
+import { describe, it, before, after, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { getDaemonStatus, killDaemon } from "./lifecycle.js";
+import { PID_PATH } from "./config.js";
+
+let backup: string | null = null;
+
+describe("lifecycle (PID file)", () => {
+  before(() => {
+    if (fs.existsSync(PID_PATH)) {
+      backup = fs.readFileSync(PID_PATH, "utf-8");
+    }
+  });
+
+  after(() => {
+    if (backup !== null) {
+      fs.mkdirSync(path.dirname(PID_PATH), { recursive: true });
+      fs.writeFileSync(PID_PATH, backup);
+    } else if (fs.existsSync(PID_PATH)) {
+      fs.unlinkSync(PID_PATH);
+    }
+  });
+
+  beforeEach(() => {
+    if (fs.existsSync(PID_PATH)) fs.unlinkSync(PID_PATH);
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(PID_PATH)) fs.unlinkSync(PID_PATH);
+  });
+
+  it("returns running:false when no PID file exists", () => {
+    const status = getDaemonStatus();
+    assert.deepEqual(status, { running: false, pid: null });
+  });
+
+  it("returns running:true when PID belongs to a live process", () => {
+    fs.mkdirSync(path.dirname(PID_PATH), { recursive: true });
+    fs.writeFileSync(PID_PATH, String(process.pid));
+
+    const status = getDaemonStatus();
+    assert.equal(status.running, true);
+    assert.equal(status.pid, process.pid);
+  });
+
+  it("returns running:false and cleans up a stale PID file", () => {
+    // PID 999999 is virtually guaranteed not to exist
+    fs.mkdirSync(path.dirname(PID_PATH), { recursive: true });
+    fs.writeFileSync(PID_PATH, "999999");
+
+    const status = getDaemonStatus();
+    assert.deepEqual(status, { running: false, pid: null });
+    assert.ok(!fs.existsSync(PID_PATH), "stale PID file should be removed");
+  });
+
+  it("treats unparseable PID file as 'no daemon'", () => {
+    fs.mkdirSync(path.dirname(PID_PATH), { recursive: true });
+    fs.writeFileSync(PID_PATH, "not-a-number\n");
+
+    const status = getDaemonStatus();
+    assert.equal(status.running, false);
+    assert.equal(status.pid, null);
+  });
+
+  it("killDaemon returns false when no PID file exists", () => {
+    assert.equal(killDaemon(), false);
+  });
+
+  it("killDaemon removes the PID file even for a stale entry", () => {
+    fs.mkdirSync(path.dirname(PID_PATH), { recursive: true });
+    fs.writeFileSync(PID_PATH, "999999");
+
+    const result = killDaemon();
+    assert.equal(result, true);
+    assert.ok(!fs.existsSync(PID_PATH));
+  });
+});

--- a/src/llm/telemetry.test.ts
+++ b/src/llm/telemetry.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for LLM telemetry — JSONL append, rotation, error swallowing.
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import { estimateTokens, writeTelemetry, type LLMTelemetryRecord } from "./telemetry.js";
+
+describe("llm/telemetry", () => {
+  let dir: string;
+  let file: string;
+  const noopLog = (): void => undefined;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-telemetry-"));
+    file = path.join(dir, "llm.jsonl");
+    process.env.BIKKY_LLM_LOG = file;
+    delete process.env.BIKKY_LLM_LOG_MAX_BYTES;
+  });
+
+  afterEach(() => {
+    delete process.env.BIKKY_LLM_LOG;
+    delete process.env.BIKKY_LLM_LOG_MAX_BYTES;
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function makeRecord(overrides: Partial<LLMTelemetryRecord> = {}): LLMTelemetryRecord {
+    return {
+      ts: new Date().toISOString(),
+      prompt: "extraction",
+      model: "gpt-4o-mini",
+      provider: "openai",
+      ok: true,
+      latency_ms: 123,
+      tokens_in_est: 10,
+      tokens_out_est: 20,
+      ...overrides,
+    };
+  }
+
+  describe("estimateTokens", () => {
+    it("returns ceil(len/4) for non-empty input", () => {
+      assert.equal(estimateTokens(""), 0);
+      assert.equal(estimateTokens("abcd"), 1);
+      assert.equal(estimateTokens("abcde"), 2);
+      assert.equal(estimateTokens("a".repeat(100)), 25);
+    });
+  });
+
+  describe("writeTelemetry", () => {
+    it("appends a JSONL record to the configured log path", async () => {
+      await writeTelemetry(makeRecord({ prompt: "first" }), noopLog);
+      await writeTelemetry(makeRecord({ prompt: "second" }), noopLog);
+
+      const lines = fs.readFileSync(file, "utf-8").trim().split("\n");
+      assert.equal(lines.length, 2);
+      const first = JSON.parse(lines[0]!) as LLMTelemetryRecord;
+      const second = JSON.parse(lines[1]!) as LLMTelemetryRecord;
+      assert.equal(first.prompt, "first");
+      assert.equal(second.prompt, "second");
+      assert.equal(first.provider, "openai");
+    });
+
+    it("creates the parent directory if missing", async () => {
+      const nested = path.join(dir, "a", "b", "c", "llm.jsonl");
+      process.env.BIKKY_LLM_LOG = nested;
+
+      await writeTelemetry(makeRecord(), noopLog);
+      assert.ok(fs.existsSync(nested));
+    });
+
+    it("rotates to .1 when the file exceeds max bytes", async () => {
+      process.env.BIKKY_LLM_LOG_MAX_BYTES = "200";
+      // Seed an oversize file
+      fs.writeFileSync(file, "x".repeat(500));
+
+      await writeTelemetry(makeRecord(), noopLog);
+
+      assert.ok(fs.existsSync(`${file}.1`), "rotated file should exist");
+      const active = fs.readFileSync(file, "utf-8");
+      // Active file should only contain the new record after rotation
+      assert.equal(active.trim().split("\n").length, 1);
+    });
+
+    it("never throws when the path is unwritable; warns once via the logger", async () => {
+      // Point at a path that cannot be created (parent is a file, not a dir)
+      const blocker = path.join(dir, "blocker");
+      fs.writeFileSync(blocker, "not-a-dir");
+      process.env.BIKKY_LLM_LOG = path.join(blocker, "llm.jsonl");
+
+      const warnings: string[] = [];
+      const log = (_level: string, msg: unknown): void => { warnings.push(String(msg)); };
+
+      await writeTelemetry(makeRecord(), log);
+      await writeTelemetry(makeRecord(), log);
+
+      // Module-level `warned` flag may already be set from a previous test;
+      // assert at most one warning was added in this call sequence.
+      assert.ok(warnings.length <= 1, "should warn at most once per process");
+    });
+  });
+});

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for the rotating file logger.
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import { createLogger } from "./logger.js";
+
+describe("logger", () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-logger-"));
+    file = path.join(dir, "nested", "test.log");
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("creates the parent directory and writes a line", () => {
+    const log = createLogger("svc", file);
+    log("INFO", "hello", { a: 1 });
+
+    const contents = fs.readFileSync(file, "utf-8");
+    assert.match(contents, /\[svc\] INFO: hello \{"a":1\}/);
+    assert.match(contents, /^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\]/);
+  });
+
+  it("respects all log levels", () => {
+    const log = createLogger("svc", file);
+    log("DEBUG", "d");
+    log("INFO", "i");
+    log("WARN", "w");
+    log("ERROR", "e");
+
+    const lines = fs.readFileSync(file, "utf-8").trim().split("\n");
+    assert.equal(lines.length, 4);
+    assert.match(lines[0]!, /DEBUG: d$/);
+    assert.match(lines[1]!, /INFO: i$/);
+    assert.match(lines[2]!, /WARN: w$/);
+    assert.match(lines[3]!, /ERROR: e$/);
+  });
+
+  it("rotates when the file exceeds maxSize", () => {
+    const log = createLogger("svc", file, { maxSize: 200, maxFiles: 3 });
+    for (let i = 0; i < 20; i++) log("INFO", "x".repeat(40));
+
+    assert.ok(fs.existsSync(file), "active log file exists");
+    assert.ok(fs.existsSync(`${file}.1`), "rotated file .1 exists");
+    // Active file is smaller than the rotated one (was reset on rotate)
+    const active = fs.statSync(file).size;
+    const rotated = fs.statSync(`${file}.1`).size;
+    assert.ok(active <= rotated);
+  });
+
+  it("caps the number of rotated files at maxFiles", () => {
+    const log = createLogger("svc", file, { maxSize: 100, maxFiles: 2 });
+    for (let i = 0; i < 50; i++) log("INFO", "x".repeat(40));
+
+    // maxFiles=2 → keep .1 only (the active file plus one rotation slot)
+    assert.ok(fs.existsSync(`${file}.1`));
+    assert.ok(!fs.existsSync(`${file}.3`), "should not keep .3");
+  });
+
+  it("appends to an existing log file", () => {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, "PREEXISTING\n");
+
+    const log = createLogger("svc", file);
+    log("INFO", "after");
+
+    const contents = fs.readFileSync(file, "utf-8");
+    assert.ok(contents.startsWith("PREEXISTING\n"));
+    assert.match(contents, /INFO: after/);
+  });
+
+  it("serialises non-string args via JSON.stringify", () => {
+    const log = createLogger("svc", file);
+    log("INFO", "msg", [1, 2], { x: "y" }, 42);
+
+    const contents = fs.readFileSync(file, "utf-8");
+    assert.match(contents, /msg \[1,2\] \{"x":"y"\} 42/);
+  });
+});

--- a/src/mcp/api.test.ts
+++ b/src/mcp/api.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for the MCP api helpers — Qdrant REST wrapper and ensureCollection.
+ * Mocks global fetch so no real Qdrant is hit.
+ */
+
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  qdrantReq,
+  ensureCollection,
+  getCollection,
+  setCollection,
+  setQdrantUrl,
+  setQdrantApiKey,
+  setReady,
+  initEmbedding,
+} from "./api.js";
+
+interface MockCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+const realFetch = globalThis.fetch;
+
+function installMock(handler: (call: MockCall) => Response | Promise<Response>): MockCall[] {
+  const calls: MockCall[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const headers = (init?.headers as Record<string, string>) ?? {};
+    const body = init?.body ? JSON.parse(String(init.body)) : null;
+    const call: MockCall = { url, method: init?.method ?? "GET", headers, body };
+    calls.push(call);
+    return handler(call);
+  }) as typeof fetch;
+  return calls;
+}
+
+describe("mcp/api", () => {
+  before(() => {
+    setQdrantUrl("https://qdrant.test:6333");
+    setQdrantApiKey("test-key");
+    setCollection("bikky-test");
+    initEmbedding({
+      provider: "ollama",
+      baseUrl: "http://localhost:11434",
+      model: "test-model",
+      dimensions: 8,
+      apiKey: null,
+    });
+  });
+
+  after(() => {
+    globalThis.fetch = realFetch;
+    setQdrantUrl(null);
+    setQdrantApiKey(null);
+    setReady(false);
+  });
+
+  beforeEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  describe("collection setters", () => {
+    it("getCollection round-trips via setCollection", () => {
+      setCollection("foo");
+      assert.equal(getCollection(), "foo");
+      setCollection("bikky-test");
+    });
+  });
+
+  describe("qdrantReq", () => {
+    it("builds the URL, sends the api-key header, and serialises the body", async () => {
+      const calls = installMock(() =>
+        new Response(JSON.stringify({ result: { ok: true } }), { status: 200 }),
+      );
+
+      const result = await qdrantReq<{ result: { ok: boolean } }>("POST", "/foo", { x: 1 });
+
+      assert.deepEqual(result, { result: { ok: true } });
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0]!.url, "https://qdrant.test:6333/foo");
+      assert.equal(calls[0]!.method, "POST");
+      assert.equal(calls[0]!.headers["api-key"], "test-key");
+      assert.equal(calls[0]!.headers["Content-Type"], "application/json");
+      assert.deepEqual(calls[0]!.body, { x: 1 });
+    });
+
+    it("omits the body for GET-style requests", async () => {
+      const calls = installMock(() =>
+        new Response(JSON.stringify({}), { status: 200 }),
+      );
+
+      await qdrantReq("GET", "/x");
+      assert.equal(calls[0]!.body, null);
+    });
+
+    it("throws with status + body when the response is not ok", async () => {
+      installMock(() =>
+        new Response("boom", { status: 500 }),
+      );
+
+      await assert.rejects(
+        qdrantReq("GET", "/fail"),
+        /Qdrant GET \/fail failed \(500\): boom/,
+      );
+    });
+  });
+
+  describe("ensureCollection", () => {
+    it("does nothing if the collection already exists", async () => {
+      const calls = installMock((call) => {
+        if (call.method === "GET" && call.url.endsWith("/collections/bikky-test")) {
+          return new Response(JSON.stringify({ result: { name: "bikky-test" } }), { status: 200 });
+        }
+        // Index creation calls
+        if (call.url.endsWith("/index")) {
+          return new Response(JSON.stringify({ result: { ok: true } }), { status: 200 });
+        }
+        return new Response("unexpected", { status: 500 });
+      });
+
+      await ensureCollection([{ field_name: "category", field_schema: "keyword" }]);
+
+      // 1 GET (existence check) + 1 PUT (index)
+      assert.equal(calls.length, 2);
+      assert.equal(calls[0]!.method, "GET");
+      assert.equal(calls[1]!.method, "PUT");
+      assert.ok(calls[1]!.url.endsWith("/index"));
+    });
+
+    it("creates the collection when GET returns 404", async () => {
+      const calls = installMock((call) => {
+        if (call.method === "GET" && call.url.endsWith("/collections/bikky-test")) {
+          return new Response("not found (404)", { status: 404 });
+        }
+        return new Response(JSON.stringify({ result: { ok: true } }), { status: 200 });
+      });
+
+      await ensureCollection([]);
+
+      assert.equal(calls[0]!.method, "GET");
+      assert.equal(calls[1]!.method, "PUT");
+      assert.equal(calls[1]!.url, "https://qdrant.test:6333/collections/bikky-test");
+      assert.ok(calls[1]!.body && typeof calls[1]!.body === "object");
+    });
+
+    it("propagates non-404 errors from the existence check", async () => {
+      installMock((call) => {
+        if (call.method === "GET") return new Response("auth failed", { status: 401 });
+        return new Response("{}", { status: 200 });
+      });
+
+      await assert.rejects(ensureCollection([]), /401/);
+    });
+
+    it("swallows index creation errors with a warning", async () => {
+      installMock((call) => {
+        if (call.method === "GET") {
+          return new Response(JSON.stringify({ result: { name: "bikky-test" } }), { status: 200 });
+        }
+        if (call.url.endsWith("/index")) {
+          return new Response("index already exists", { status: 400 });
+        }
+        return new Response("{}", { status: 200 });
+      });
+
+      // Must NOT throw — index errors are warned and swallowed
+      await ensureCollection([
+        { field_name: "category", field_schema: "keyword" },
+        { field_name: "domain", field_schema: "keyword" },
+      ]);
+    });
+  });
+});

--- a/src/mcp/tools.integration.itest.ts
+++ b/src/mcp/tools.integration.itest.ts
@@ -1,0 +1,208 @@
+/**
+ * End-to-end integration test against a real Qdrant Cloud collection.
+ *
+ * **OPT-IN.** This file uses the `.itest.ts` extension so the default
+ * `dist/**\/*.test.js` glob does NOT pick it up. Run explicitly with:
+ *
+ *   BIKKY_INTEGRATION=1 npm run test:integration
+ *
+ * Required env (or in ~/.bikky/config.json — loadConfig merges env):
+ *   - BIKKY_INTEGRATION=1   (master gate)
+ *   - QDRANT_URL            (Qdrant Cloud REST URL)
+ *   - QDRANT_API_KEY        (Qdrant Cloud API key)
+ *   - embedding provider config (defaults from ~/.bikky/config.json)
+ *
+ * Behaviour:
+ *   - Creates a uuid-suffixed throwaway collection (`bikky-it-<short>`).
+ *   - Drops it in `after()` regardless of pass/fail.
+ *   - Exercises the real handlers from registerTools() against live Qdrant +
+ *     real embeddings — validating filter shapes, payload indexes, vector
+ *     dimensions, and the dedup similarity thresholds for real.
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+
+import { registerTools } from "./tools.js";
+import {
+  setQdrantUrl,
+  setQdrantApiKey,
+  setReady,
+  setCollection,
+  initEmbedding,
+  ensureCollection,
+  qdrantReq,
+} from "./api.js";
+import { QDRANT_INDEXES } from "./taxonomy.js";
+import { loadConfig } from "../config.js";
+
+const enabled =
+  process.env.BIKKY_INTEGRATION === "1" &&
+  Boolean(process.env.QDRANT_URL || loadConfig().qdrant_url) &&
+  Boolean(process.env.QDRANT_API_KEY || loadConfig().qdrant_api_key);
+
+type Handler = (args: Record<string, unknown>) => Promise<{ content: Array<{ type: string; text: string }> }>;
+
+interface FakeServer {
+  tool(name: string, desc: string, schema: unknown, handler: Handler): void;
+}
+
+function makeFakeServer(): { server: FakeServer; handlers: Map<string, Handler> } {
+  const handlers = new Map<string, Handler>();
+  const server: FakeServer = {
+    tool(name, _desc, _schema, handler) {
+      handlers.set(name, handler);
+    },
+  };
+  return { server, handlers };
+}
+
+let handlers: Map<string, Handler>;
+let collectionName: string;
+
+function textOf(result: { content: Array<{ type: string; text: string }> }): string {
+  return result.content[0]?.text ?? "";
+}
+
+async function invoke(name: string, args: Record<string, unknown>): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const h = handlers.get(name);
+  if (!h) throw new Error(`Handler '${name}' not registered`);
+  return h(args);
+}
+
+describe("mcp/tools — Qdrant integration", { skip: !enabled }, () => {
+  before(async () => {
+    const cfg = loadConfig();
+    const url = process.env.QDRANT_URL ?? cfg.qdrant_url;
+    const apiKey = process.env.QDRANT_API_KEY ?? cfg.qdrant_api_key;
+    if (!url || !apiKey) throw new Error("Qdrant URL / API key missing");
+
+    collectionName = `bikky-it-${randomUUID().slice(0, 8)}`;
+    setQdrantUrl(url);
+    setQdrantApiKey(apiKey);
+    setCollection(collectionName);
+
+    initEmbedding({
+      provider: cfg.embedding.provider,
+      baseUrl: cfg.embedding.base_url,
+      model: cfg.embedding.model,
+      dimensions: cfg.embedding.dimensions,
+      apiKey: cfg.embedding.api_key,
+    });
+
+    await ensureCollection(QDRANT_INDEXES);
+    setReady(true);
+
+    const fake = makeFakeServer();
+    registerTools(fake.server as unknown as Parameters<typeof registerTools>[0]);
+    handlers = fake.handlers;
+  });
+
+  after(async () => {
+    try {
+      if (collectionName) {
+        await qdrantReq("DELETE", `/collections/${collectionName}`);
+      }
+    } finally {
+      setReady(false);
+      setQdrantUrl(null);
+      setQdrantApiKey(null);
+    }
+  });
+
+  // Shared state across the ordered scenarios below.
+  let fact1Id: string;
+  let fact2Id: string;
+
+  it("inserts two distinct facts", async () => {
+    const r1 = JSON.parse(textOf(await invoke("memory_store", {
+      content: "Qdrant Cloud free tier provides 1GB storage with no credit card required",
+      category: "infrastructure",
+      entities: ["qdrant", "qdrant-cloud"],
+    })));
+    assert.equal(r1.action, "inserted");
+    fact1Id = r1.fact_id;
+
+    const r2 = JSON.parse(textOf(await invoke("memory_store", {
+      content: "OpenAI text-embedding-3-small produces 1536-dimensional vectors",
+      category: "infrastructure",
+      entities: ["openai", "embeddings"],
+    })));
+    assert.equal(r2.action, "inserted");
+    fact2Id = r2.fact_id;
+
+    assert.notEqual(fact1Id, fact2Id);
+  });
+
+  it("reinforces on exact content-hash match", async () => {
+    const r = JSON.parse(textOf(await invoke("memory_store", {
+      content: "Qdrant Cloud free tier provides 1GB storage with no credit card required",
+      category: "infrastructure",
+      entities: ["qdrant"],
+    })));
+    assert.equal(r.action, "reinforced");
+    assert.equal(r.fact_id, fact1Id);
+    assert.ok(r.reinforcement_count >= 2);
+  });
+
+  it("reinforces on a near-duplicate via real-vector similarity", async () => {
+    // Paraphrase of fact 1 — same meaning, different wording.
+    const r = JSON.parse(textOf(await invoke("memory_store", {
+      content: "Qdrant Cloud's free plan offers 1GB of storage and does not require a credit card",
+      category: "infrastructure",
+      entities: ["qdrant"],
+    })));
+    // Either reinforced (preferred — proves the 0.92 threshold) or inserted
+    // with a similar_facts entry pointing at fact1 (proves we're at least in
+    // the related band). The first case is the strong assertion; we log if it
+    // falls through so a maintainer can re-tune thresholds per embedding model.
+    if (r.action === "reinforced") {
+      assert.equal(r.fact_id, fact1Id);
+    } else {
+      assert.equal(r.action, "inserted", `unexpected action: ${r.action}`);
+      const similar = (r.similar_facts ?? []) as Array<{ id: string; score: number }>;
+      const match = similar.find((s) => s.id === fact1Id);
+      assert.ok(
+        match,
+        `expected paraphrase to reinforce or appear in similar_facts; got ${JSON.stringify(r)}`,
+      );
+      // eslint-disable-next-line no-console
+      console.warn(`[integration] paraphrase landed in related band (score=${match!.score}) — consider tuning THRESHOLD_DUPLICATE for this embedding model`);
+    }
+  });
+
+  it("recalls a stored fact via semantic search", async () => {
+    const result = await invoke("memory_recall", {
+      query: "What does the Qdrant free tier include?",
+      limit: 5,
+    });
+    const text = textOf(result);
+    assert.match(text, /1GB|free tier/i);
+  });
+
+  it("aggregates facts about an entity", async () => {
+    const result = await invoke("memory_entity", { name: "qdrant" });
+    const text = textOf(result);
+    assert.match(text, /Facts about qdrant/);
+    assert.match(text, /1GB|free tier/i);
+  });
+
+  it("forgets a fact and excludes it from subsequent recall", async () => {
+    const forgetResult = JSON.parse(textOf(await invoke("memory_forget", {
+      fact_id: fact2Id,
+      reason: "integration-test cleanup",
+    })));
+    assert.equal(forgetResult.status, "forgotten");
+
+    // Recall something the forgotten fact would have matched.
+    const recallResult = await invoke("memory_recall", {
+      query: "OpenAI embedding dimensions",
+      limit: 10,
+    });
+    const text = textOf(recallResult);
+    // Fact 2 should not appear (it was the only one about embedding dimensions
+    // we inserted). A "no matching facts" response is acceptable.
+    assert.doesNotMatch(text, /1536-dimensional/);
+  });
+});

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -1,0 +1,544 @@
+/**
+ * Integration tests for the MCP tool handlers in tools.ts.
+ *
+ * tools.ts registers all tool handlers inside `registerTools(mcp)`. To exercise
+ * them without a live MCP server we use a minimal fake McpServer that captures
+ * each `tool(name, desc, schema, handler)` registration into a map. Tests then
+ * invoke handlers directly with mocked fetch responses for Qdrant + embedding.
+ *
+ * Covers the data-integrity + recall surface:
+ *   - memory_store: hash dedup, vector dedup, supersedes, relation insertion
+ *   - memory_recall: filter passthrough, graph_depth=1 traversal, ranking
+ *   - memory_entity: facts + relations aggregation with dedup
+ *   - memory_forget: marks fact as superseded with reason
+ */
+
+import { describe, it, before, beforeEach, after } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerTools } from "./tools.js";
+import {
+  setQdrantUrl,
+  setQdrantApiKey,
+  setReady,
+  setCollection,
+  initEmbedding,
+} from "./api.js";
+import { THRESHOLD_DUPLICATE, THRESHOLD_RELATED } from "./taxonomy.js";
+
+// ---------------------------------------------------------------------------
+// Fake McpServer — captures `tool(name, desc, schema, handler)` registrations.
+// ---------------------------------------------------------------------------
+
+type Handler = (args: Record<string, unknown>) => Promise<unknown>;
+
+interface FakeServer {
+  tool(name: string, desc: string, schema: unknown, handler: Handler): void;
+}
+
+function makeFakeServer(): { server: FakeServer; handlers: Map<string, Handler> } {
+  const handlers = new Map<string, Handler>();
+  const server: FakeServer = {
+    tool(name, _desc, _schema, handler) {
+      handlers.set(name, handler);
+    },
+  };
+  return { server, handlers };
+}
+
+// ---------------------------------------------------------------------------
+// Fetch mock — script per-URL responses, record calls.
+// ---------------------------------------------------------------------------
+
+interface MockCall {
+  url: string;
+  method: string;
+  body: Record<string, unknown> | null;
+}
+
+type Responder = (call: MockCall) => unknown;
+
+const realFetch = globalThis.fetch;
+let calls: MockCall[];
+let responders: Array<{ match: RegExp | string; respond: Responder }>;
+
+function installFetchMock(): void {
+  calls = [];
+  responders = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const body = init?.body ? JSON.parse(String(init.body)) : null;
+    const call: MockCall = { url, method: init?.method ?? "GET", body };
+    calls.push(call);
+
+    for (const r of responders) {
+      const matches = typeof r.match === "string" ? url.includes(r.match) : r.match.test(url);
+      if (matches) {
+        const data = r.respond(call);
+        return new Response(JSON.stringify(data), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    }
+    // Default: empty success.
+    return new Response(JSON.stringify({ status: "ok", result: null }), { status: 200 });
+  }) as typeof fetch;
+}
+
+function on(match: RegExp | string, respond: Responder): void {
+  responders.push({ match, respond });
+}
+
+function callsTo(match: RegExp | string): MockCall[] {
+  return calls.filter((c) =>
+    typeof match === "string" ? c.url.includes(match) : match.test(c.url),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Suite setup
+// ---------------------------------------------------------------------------
+
+let handlers: Map<string, Handler>;
+
+async function invoke(name: string, args: Record<string, unknown>): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const h = handlers.get(name);
+  if (!h) throw new Error(`Handler '${name}' not registered`);
+  return h(args) as Promise<{ content: Array<{ type: string; text: string }> }>;
+}
+
+function textOf(result: { content: Array<{ type: string; text: string }> }): string {
+  return result.content[0]?.text ?? "";
+}
+
+describe("mcp/tools handlers", () => {
+  before(() => {
+    setQdrantUrl("https://qdrant.test:6333");
+    setQdrantApiKey("test-key");
+    setCollection("bikky-test");
+    setReady(true);
+    initEmbedding({
+      provider: "ollama",
+      baseUrl: "http://embed.test:11434",
+      model: "test-model",
+      dimensions: 4,
+      apiKey: null,
+    });
+
+    const fake = makeFakeServer();
+    // The real registerTools expects an McpServer; the only methods used are
+    // `tool(...)` so the fake is structurally compatible at runtime.
+    registerTools(fake.server as unknown as Parameters<typeof registerTools>[0]);
+    handlers = fake.handlers;
+  });
+
+  beforeEach(() => {
+    installFetchMock();
+    // Always provide an embedding for any embed() call.
+    on("/v1/embeddings", () => ({ data: [{ embedding: [0.1, 0.2, 0.3, 0.4] }] }));
+  });
+
+  after(() => {
+    globalThis.fetch = realFetch;
+    setReady(false);
+    setQdrantUrl(null);
+    setQdrantApiKey(null);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Tool registration sanity
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it("registers all expected memory tools", () => {
+    for (const name of [
+      "memory_store",
+      "memory_recall",
+      "memory_entity",
+      "memory_relations",
+      "memory_forget",
+      "memory_verify",
+      "memory_review",
+      "memory_session_summary",
+      "memory_distill",
+      "memory_heartbeat",
+    ]) {
+      assert.ok(handlers.has(name), `expected handler '${name}' to be registered`);
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // memory_store — dedup + insertion pipeline
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe("memory_store", () => {
+    it("reinforces an exact content-hash match without re-embedding", async () => {
+      on("/points/scroll", () => ({
+        result: {
+          points: [{
+            id: "existing-1",
+            payload: { content: "x", category: "infrastructure", reinforcement_count: 2 },
+          }],
+        },
+      }));
+      let setPayloadBody: Record<string, unknown> | null = null;
+      on("/points/payload", (call) => {
+        setPayloadBody = call.body;
+        return { status: "ok" };
+      });
+
+      const result = await invoke("memory_store", {
+        content: "qdrant runs on port 6333",
+        category: "infrastructure",
+        entities: ["qdrant"],
+      });
+
+      const parsed = JSON.parse(textOf(result));
+      assert.equal(parsed.action, "reinforced");
+      assert.equal(parsed.fact_id, "existing-1");
+      assert.equal(parsed.reinforcement_count, 3);
+      assert.deepEqual((setPayloadBody as unknown as { points: string[] }).points, ["existing-1"]);
+      // Hash dedup hits before embedding.
+      assert.equal(callsTo("/v1/embeddings").length, 0);
+      // Hash dedup hits before semantic search.
+      assert.equal(callsTo("/points/search").length, 0);
+    });
+
+    it("reinforces when semantic similarity exceeds THRESHOLD_DUPLICATE", async () => {
+      on("/points/scroll", () => ({ result: { points: [] } })); // no hash hit
+      on("/points/search", () => ({
+        result: [{
+          id: "near-dup",
+          score: THRESHOLD_DUPLICATE + 0.01,
+          payload: { content: "near", category: "infrastructure", reinforcement_count: 1 },
+        }],
+      }));
+      on("/points/payload", () => ({ status: "ok" }));
+
+      const result = await invoke("memory_store", {
+        content: "qdrant listens on 6333",
+        category: "infrastructure",
+        entities: ["qdrant"],
+      });
+
+      const parsed = JSON.parse(textOf(result));
+      assert.equal(parsed.action, "reinforced");
+      assert.equal(parsed.fact_id, "near-dup");
+      assert.equal(parsed.reinforcement_count, 2);
+      assert.ok(parsed.similarity > THRESHOLD_DUPLICATE);
+      // Should not insert a new point.
+      assert.equal(callsTo(/\/points$/).length, 0);
+    });
+
+    it("inserts a new point when no duplicates are found", async () => {
+      on("/points/scroll", () => ({ result: { points: [] } }));
+      on("/points/search", () => ({ result: [] }));
+      let upsertBody: Record<string, unknown> | null = null;
+      on(/\/points$/, (call) => {
+        if (call.method === "PUT") upsertBody = call.body;
+        return { status: "ok" };
+      });
+
+      const result = await invoke("memory_store", {
+        content: "platform is on AWS",
+        category: "infrastructure",
+        entities: ["Platform"],
+        importance: 0.7,
+      });
+
+      const parsed = JSON.parse(textOf(result));
+      assert.equal(parsed.action, "inserted");
+      assert.ok(parsed.fact_id, "should return a generated fact_id");
+      assert.ok(upsertBody, "expected an upsert PUT to /points");
+      const pt = (upsertBody as { points: Array<{ payload: Record<string, unknown> }> }).points[0];
+      assert.equal(pt.payload.content, "platform is on AWS");
+      assert.deepEqual(pt.payload.entities, ["platform"]); // lowercased
+      assert.equal(pt.payload.reinforcement_count, 1);
+      assert.equal(pt.payload.importance, 0.7);
+      assert.ok(pt.payload.content_hash, "content_hash should be set");
+      assert.equal(pt.payload.superseded_by, null);
+    });
+
+    it("flags potential conflicts when similarity is in the related band with shared entities", async () => {
+      on("/points/scroll", () => ({ result: { points: [] } }));
+      const related = (THRESHOLD_RELATED + THRESHOLD_DUPLICATE) / 2;
+      on("/points/search", () => ({
+        result: [{
+          id: "related-1",
+          score: related,
+          payload: {
+            content: "old fact about platform",
+            category: "infrastructure",
+            entities: ["platform"],
+          },
+        }],
+      }));
+      on(/\/points$/, () => ({ status: "ok" }));
+
+      const result = await invoke("memory_store", {
+        content: "new fact about platform",
+        category: "infrastructure",
+        entities: ["platform"],
+      });
+
+      const parsed = JSON.parse(textOf(result));
+      assert.equal(parsed.action, "inserted");
+      assert.ok(Array.isArray(parsed.similar_facts) && parsed.similar_facts.length === 1);
+      assert.ok(Array.isArray(parsed.potential_conflicts) && parsed.potential_conflicts.length === 1);
+      assert.deepEqual(parsed.potential_conflicts[0].shared_entities, ["platform"]);
+      assert.ok(parsed.conflict_hint, "conflict_hint should be present");
+    });
+
+    it("supersedes the prior fact when supersedes is provided", async () => {
+      on("/points/scroll", () => ({ result: { points: [] } }));
+      on("/points/search", () => ({ result: [] }));
+      const payloadCalls: Array<Record<string, unknown>> = [];
+      on("/points/payload", (call) => {
+        payloadCalls.push(call.body as Record<string, unknown>);
+        return { status: "ok" };
+      });
+      on(/\/points$/, () => ({ status: "ok" }));
+
+      const result = await invoke("memory_store", {
+        content: "qdrant now on 7000",
+        category: "infrastructure",
+        entities: ["qdrant"],
+        supersedes: "old-fact-id",
+      });
+
+      const parsed = JSON.parse(textOf(result));
+      assert.equal(parsed.action, "inserted");
+      assert.equal(payloadCalls.length, 1);
+      const supersedeCall = payloadCalls[0]! as { points: string[]; payload: Record<string, unknown> };
+      assert.deepEqual(supersedeCall.points, ["old-fact-id"]);
+      assert.equal(supersedeCall.payload.superseded_by, parsed.fact_id);
+      assert.ok(supersedeCall.payload.superseded_at);
+    });
+
+    it("inserts a relation point alongside the fact when relation is provided", async () => {
+      on("/points/scroll", () => ({ result: { points: [] } }));
+      on("/points/search", () => ({ result: [] }));
+      const upserts: Array<Record<string, unknown>> = [];
+      on(/\/points$/, (call) => {
+        if (call.method === "PUT") upserts.push(call.body as Record<string, unknown>);
+        return { status: "ok" };
+      });
+
+      const result = await invoke("memory_store", {
+        content: "saber owns platform",
+        category: "team",
+        entities: ["saber", "platform"],
+        relation: { from: "Saber", type: "Owns", to: "Platform" },
+      });
+
+      const parsed = JSON.parse(textOf(result));
+      assert.equal(parsed.action, "inserted");
+      assert.ok(parsed.relation_id, "relation_id should be returned");
+      // First upsert is the fact, second is the relation.
+      assert.equal(upserts.length, 2);
+      const relPt = (upserts[1] as { points: Array<{ payload: Record<string, unknown> }> }).points[0];
+      assert.equal(relPt.payload.kind, "relation");
+      assert.equal(relPt.payload.from_entity, "saber");
+      assert.equal(relPt.payload.to_entity, "platform");
+      assert.equal(relPt.payload.relation_type, "owns");
+      assert.deepEqual(relPt.payload.entities, ["saber", "platform"]);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // memory_recall — filter composition + graph_depth
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe("memory_recall", () => {
+    it("returns 'No matching facts found' when search returns no results", async () => {
+      on("/points/search", () => ({ result: [] }));
+      const result = await invoke("memory_recall", { query: "nothing" });
+      assert.match(textOf(result), /No matching facts found/);
+    });
+
+    it("passes category, domain, kind, entity, since, until, and metadata into the Qdrant filter", async () => {
+      let searchBody: Record<string, unknown> | null = null;
+      on("/points/search", (call) => {
+        searchBody = call.body as Record<string, unknown>;
+        return { result: [] };
+      });
+
+      await invoke("memory_recall", {
+        query: "q",
+        category: "infrastructure",
+        domain: "work",
+        kind: "fact",
+        entity: "Qdrant",
+        since: "2025-01-01T00:00:00Z",
+        until: "2025-12-31T00:00:00Z",
+        metadata_filter: { project: "bikky" },
+      });
+
+      assert.ok(searchBody);
+      const filter = (searchBody as { filter: { must: Array<Record<string, unknown>> } }).filter;
+      const must = filter.must;
+      // excludeSuperseded → adds `is_null` condition into `must`.
+      assert.ok(
+        must.some((c) => (c as { is_null?: { key: string } }).is_null?.key === "superseded_by"),
+        "expected an is_null:superseded_by condition in must",
+      );
+      // Field filters present in `must`.
+      const keys = must.map((c) => (c.key as string) ?? "").filter(Boolean);
+      for (const k of ["category", "domain", "kind", "entities", "created_at", "metadata.project"]) {
+        assert.ok(keys.includes(k), `expected filter.must to contain key=${k}; got ${keys.join(",")}`);
+      }
+      // Entity is lowercased.
+      const entityCond = must.find((c) => c.key === "entities") as { match: { value: string } };
+      assert.equal(entityCond.match.value, "qdrant");
+    });
+
+    it("ranks results by combined score and slices to limit", async () => {
+      // Three points: low score should win after combined weighting only if
+      // freshness/reinforcement compensate; we just verify deterministic order
+      // with three scores and limit=2.
+      on("/points/search", () => ({
+        result: [
+          { id: "a", score: 0.6, payload: { content: "A", category: "infrastructure", entities: [], reinforcement_count: 1, confidence: 0.9, importance: 0.5, created_at: new Date().toISOString() } },
+          { id: "b", score: 0.9, payload: { content: "B", category: "infrastructure", entities: [], reinforcement_count: 1, confidence: 0.9, importance: 0.5, created_at: new Date().toISOString() } },
+          { id: "c", score: 0.75, payload: { content: "C", category: "infrastructure", entities: [], reinforcement_count: 1, confidence: 0.9, importance: 0.5, created_at: new Date().toISOString() } },
+        ],
+      }));
+
+      const result = await invoke("memory_recall", { query: "q", limit: 2 });
+      const text = textOf(result);
+      const lines = text.split("\n").filter(Boolean);
+      assert.equal(lines.length, 2, "should slice to limit=2");
+      // 'B' has highest vector score → highest combined score → first.
+      assert.match(lines[0]!, /\bB\b/);
+      assert.match(lines[1]!, /\bC\b/);
+    });
+
+    it("appends 1-hop related facts when graph_depth=1", async () => {
+      // Primary search returns one fact mentioning entity 'a'.
+      on("/points/search", () => ({
+        result: [{
+          id: "p1",
+          score: 0.9,
+          payload: { content: "primary", category: "infrastructure", entities: ["a"], reinforcement_count: 1 },
+        }],
+      }));
+      // Scroll mock dispatches based on filter shape inside the body.
+      on("/points/scroll", (call) => {
+        const body = call.body as { filter: { must: Array<Record<string, unknown>> } };
+        const conditions = body.filter.must;
+        const fromCond = conditions.find((c) => c.key === "from_entity") as { match: { value: string } } | undefined;
+        const toCond = conditions.find((c) => c.key === "to_entity") as { match: { value: string } } | undefined;
+        const entitiesCond = conditions.find((c) => c.key === "entities") as { match: { value: string } } | undefined;
+
+        // graphTraversal queries: outgoing(from_entity=a), incoming(to_entity=a), then entities=b.
+        if (fromCond?.match.value === "a") {
+          return { result: { points: [{
+            id: "rel1",
+            payload: { content: "a -> b", category: "team", entities: ["a", "b"], from_entity: "a", to_entity: "b", relation_type: "uses", reinforcement_count: 1 },
+          }] } };
+        }
+        if (toCond?.match.value === "a") {
+          return { result: { points: [] } };
+        }
+        if (entitiesCond?.match.value === "b") {
+          return { result: { points: [{
+            id: "neighbor",
+            payload: { content: "b is interesting", category: "infrastructure", entities: ["b"], reinforcement_count: 1 },
+          }] } };
+        }
+        return { result: { points: [] } };
+      });
+
+      const result = await invoke("memory_recall", { query: "q", graph_depth: 1, limit: 5 });
+      const text = textOf(result);
+      assert.match(text, /primary/);
+      assert.match(text, /Related \(1-hop\)/);
+      assert.match(text, /b is interesting/);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // memory_entity — facts + relations aggregation
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe("memory_entity", () => {
+    it("aggregates facts mentioning the entity plus from/to relations and dedups", async () => {
+      on("/points/scroll", (call) => {
+        const body = call.body as { filter: { must: Array<Record<string, unknown>> } };
+        const cond = body.filter.must[0] as { key: string; match: { value: string } };
+
+        if (cond.key === "entities" && cond.match.value === "platform") {
+          return { result: { points: [
+            { id: "f1", payload: { content: "platform fact", category: "infrastructure", entities: ["platform"], reinforcement_count: 1 } },
+          ] } };
+        }
+        if (cond.key === "from_entity" && cond.match.value === "platform") {
+          return { result: { points: [
+            { id: "r1", payload: { content: "platform uses qdrant", category: "team", from_entity: "platform", to_entity: "qdrant", relation_type: "uses" } },
+          ] } };
+        }
+        if (cond.key === "to_entity" && cond.match.value === "platform") {
+          // Same relation appears as 'to' lookup too — must be deduped by id.
+          return { result: { points: [
+            { id: "r1", payload: { content: "platform uses qdrant", category: "team", from_entity: "platform", to_entity: "qdrant", relation_type: "uses" } },
+            { id: "r2", payload: { content: "saber owns platform", category: "team", from_entity: "saber", to_entity: "platform", relation_type: "owns" } },
+          ] } };
+        }
+        return { result: { points: [] } };
+      });
+
+      const result = await invoke("memory_entity", { name: "Platform" });
+      const text = textOf(result);
+      assert.match(text, /Facts about Platform \(1\)/);
+      assert.match(text, /platform fact/);
+      assert.match(text, /Relations \(2\)/); // r1 deduped, r1+r2 unique
+      assert.match(text, /platform --\[uses\]--> qdrant/);
+      assert.match(text, /saber --\[owns\]--> platform/);
+    });
+
+    it("returns a friendly message when nothing is found", async () => {
+      on("/points/scroll", () => ({ result: { points: [] } }));
+      const result = await invoke("memory_entity", { name: "ghost" });
+      assert.match(textOf(result), /No facts or relations found for 'ghost'/);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // memory_forget — supersession marker
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe("memory_forget", () => {
+    it("marks the fact as superseded with reason and timestamp", async () => {
+      let body: Record<string, unknown> | null = null;
+      on("/points/payload", (call) => {
+        body = call.body as Record<string, unknown>;
+        return { status: "ok" };
+      });
+
+      const result = await invoke("memory_forget", { fact_id: "victim", reason: "outdated" });
+      const parsed = JSON.parse(textOf(result));
+      assert.equal(parsed.status, "forgotten");
+      assert.equal(parsed.fact_id, "victim");
+      assert.equal(parsed.reason, "outdated");
+
+      assert.ok(body);
+      const b = body as { points: string[]; payload: Record<string, unknown> };
+      assert.deepEqual(b.points, ["victim"]);
+      assert.equal(b.payload.superseded_by, "forgotten:outdated");
+      assert.ok(b.payload.superseded_at);
+      assert.ok(b.payload.updated_at);
+    });
+
+    it("returns a graceful error string when Qdrant rejects the call", async () => {
+      // No matcher → default 200 OK; replace with explicit failure.
+      responders = [];
+      globalThis.fetch = (async () =>
+        new Response("nope", { status: 500 })
+      ) as typeof fetch;
+
+      const result = await invoke("memory_forget", { fact_id: "x", reason: "y" });
+      const text = textOf(result);
+      assert.match(text, /^Error: /);
+    });
+  });
+});

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -159,8 +159,6 @@ describe("mcp/tools handlers", () => {
       "memory_forget",
       "memory_verify",
       "memory_review",
-      "memory_session_summary",
-      "memory_distill",
       "memory_heartbeat",
     ]) {
       assert.ok(handlers.has(name), `expected handler '${name}' to be registered`);
@@ -297,7 +295,14 @@ describe("mcp/tools handlers", () => {
         payloadCalls.push(call.body as Record<string, unknown>);
         return { status: "ok" };
       });
-      on(/\/points$/, () => ({ status: "ok" }));
+      on(/\/points$/, (call) => {
+        // POST without `points` key = qdrantGetPoints (lookup of supersedes target)
+        const body = call.body as { points?: unknown; ids?: unknown };
+        if (call.method === "POST" && !body.points) {
+          return { result: [{ id: "old-fact-id", payload: { content: "old fact" } }] };
+        }
+        return { status: "ok" };
+      });
 
       const result = await invoke("memory_store", {
         content: "qdrant now on 7000",
@@ -465,19 +470,23 @@ describe("mcp/tools handlers", () => {
     it("aggregates facts mentioning the entity plus from/to relations and dedups", async () => {
       on("/points/scroll", (call) => {
         const body = call.body as { filter: { must: Array<Record<string, unknown>> } };
-        const cond = body.filter.must[0] as { key: string; match: { value: string } };
+        // Filter may contain workspace_id conditions first; scan all conditions for the entity-shaped one.
+        const conds = body.filter.must as Array<{ key?: string; match?: { value?: string } }>;
+        const entityCond = conds.find((c) => c.key === "entities" && c.match?.value === "platform");
+        const fromCond = conds.find((c) => c.key === "from_entity" && c.match?.value === "platform");
+        const toCond = conds.find((c) => c.key === "to_entity" && c.match?.value === "platform");
 
-        if (cond.key === "entities" && cond.match.value === "platform") {
+        if (entityCond) {
           return { result: { points: [
             { id: "f1", payload: { content: "platform fact", category: "infrastructure", entities: ["platform"], reinforcement_count: 1 } },
           ] } };
         }
-        if (cond.key === "from_entity" && cond.match.value === "platform") {
+        if (fromCond) {
           return { result: { points: [
             { id: "r1", payload: { content: "platform uses qdrant", category: "team", from_entity: "platform", to_entity: "qdrant", relation_type: "uses" } },
           ] } };
         }
-        if (cond.key === "to_entity" && cond.match.value === "platform") {
+        if (toCond) {
           // Same relation appears as 'to' lookup too — must be deduped by id.
           return { result: { points: [
             { id: "r1", payload: { content: "platform uses qdrant", category: "team", from_entity: "platform", to_entity: "qdrant", relation_type: "uses" } },
@@ -512,6 +521,14 @@ describe("mcp/tools handlers", () => {
       let body: Record<string, unknown> | null = null;
       on("/points/payload", (call) => {
         body = call.body as Record<string, unknown>;
+        return { status: "ok" };
+      });
+      // memory_forget first calls qdrantGetPoints (POST /points with {ids,...}) for the workspace check.
+      on(/\/points$/, (call) => {
+        const callBody = call.body as { ids?: unknown };
+        if (call.method === "POST" && callBody.ids) {
+          return { result: [{ id: "victim", payload: { content: "to be forgotten" } }] };
+        }
         return { status: "ok" };
       });
 


### PR DESCRIPTION
Supersedes #9. Rewrites the test-harness work cleanly on top of current main (now includes prompt-registry from #18 and render-cli from #19).

## What

Adds a focused, fast unit-test harness for core + UI, plus an opt-in Qdrant integration smoke test.

### Unit tests (always run with `npm test`)
- `src/lifecycle.test.ts` — PID file lifecycle
- `src/logger.test.ts` — logger with temp dir
- `src/llm/telemetry.test.ts` — JSONL llm logger
- `src/daemon/staleness.test.ts` — daemon scheduler with DI
- `src/mcp/api.test.ts` — Qdrant client with mocked fetch
- `src/mcp/tools.test.ts` — memory_store/recall/entity/forget handlers (data integrity)
- UI: `packages/ui/src/lib/{config,embed,qdrant}.test.ts`, `server.test.ts`, `routes/memory.test.ts`

### Integration test (opt-in)
- `src/mcp/tools.integration.itest.ts` — real Qdrant + real embeddings smoke test
- Run via: `BIKKY_INTEGRATION=1 npm run test:integration`
- Catches filter-shape rejections, payload-index mismatches, vector-dimension drift, dedup threshold mis-tuning

### Other
- `CONTRIBUTING.md` — merged repo-layout/testing guide with the existing provider-contribution section
- `packages/ui/src/lib/config.ts` — `_resetConfig()` test helper

## Adaptations during cherry-pick
`tools.test.ts` (originally written against an earlier tools.ts) needed 3 small updates to match current main:
- registration test no longer expects `memory_session_summary` / `memory_distill` (not yet implemented on main)
- supersedes / forget tests now mock the workspace-aware `qdrantGetPoints` lookup
- `memory_entity` test now scans all `filter.must` conditions (workspace_id is now prepended)

## Tests
**370/370 pass** (was 323 before this PR; +47 net new).