### PR TITLE
docs: remove logo from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-<p align="center">
-  <img src="assets/bikky-tp.png" alt="bikky logo" width="180" />
-</p>
-
 <h1 align="center">bikky</h1>
 
 <p align="center"><b>Persistent memory for AI coding agents — for solo power users and teams.</b></p>


### PR DESCRIPTION
Removes the bikky logo image block at the top of the README per request.