### PR TITLE
docs: use relative image paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ bikky gives AI coding agents (GitHub Copilot, Claude Code, Cursor, Codex, and ot
 | 👥 **Teams & software factories** | What one engineer's agent learns today, every agent on the team can recall tomorrow. Shared memory turns institutional knowledge into something queryable instead of tribal. |
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/bikky-dev/bikky/main/docs/diagrams/team-memory.svg" alt="Memory — facts flow from individual sessions into a self-curating knowledge store, shared with your team or kept just for you" width="720" />
+  <img src="docs/diagrams/team-memory.svg" alt="Memory — facts flow from individual sessions into a self-curating knowledge store, shared with your team or kept just for you" width="720" />
 </p>
 
 <p align="center"><i>Knowledge flows from every session into a store that curates itself over time — deduplicating, distilling, and decaying stale facts — so every future session starts smarter. Use it solo, or share the workspace across a team.</i></p>
@@ -67,7 +67,7 @@ Restart your editor — memory tools appear automatically.
 ## How it works
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/bikky-dev/bikky/main/docs/diagrams/architecture.svg" alt="Architecture" width="600" />
+  <img src="docs/diagrams/architecture.svg" alt="Architecture" width="600" />
 </p>
 
 **MCP Server** — tools your agent calls directly:
@@ -103,17 +103,17 @@ bikky-ui              # opens http://localhost:1422
 ```
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/bikky-dev/bikky/main/docs/screenshots/dashboard.png" alt="Dashboard — overview stats, category breakdown, recent facts" width="720" />
+  <img src="docs/screenshots/dashboard.png" alt="Dashboard — overview stats, category breakdown, recent facts" width="720" />
 </p>
 <p align="center"><i>Dashboard — memory stats, category breakdown, and recent facts at a glance</i></p>
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/bikky-dev/bikky/main/docs/screenshots/memory.png" alt="Memory browser — search, filter, and browse all stored facts" width="720" />
+  <img src="docs/screenshots/memory.png" alt="Memory browser — search, filter, and browse all stored facts" width="720" />
 </p>
 <p align="center"><i>Memory browser — search, filter by category/kind/source, and browse all stored facts</i></p>
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/bikky-dev/bikky/main/docs/screenshots/graph.png" alt="Entity graph — interactive visualization of entity relationships" width="720" />
+  <img src="docs/screenshots/graph.png" alt="Entity graph — interactive visualization of entity relationships" width="720" />
 </p>
 <p align="center"><i>Entity graph — interactive visualization of how concepts, people, and services relate</i></p>
 


### PR DESCRIPTION
Switches the 5 image refs in README.md from `raw.githubusercontent.com/bikky-dev/bikky/main/...` absolute URLs to repo-relative paths.

**Why:** the README didn't render images when viewed locally (e.g. in an editor preview or via `grip` offline) because absolute raw URLs require network + a pushed commit. Relative paths render both locally and on github.com — GitHub resolves them against the current branch.

**Files affected:** README.md only. No image files moved.

Verified locally that all 5 referenced files exist at the relative paths:
- docs/diagrams/team-memory.svg
- docs/diagrams/architecture.svg
- docs/screenshots/dashboard.png
- docs/screenshots/memory.png
- docs/screenshots/graph.png