### PR TITLE
feat(qdrant): support local / self-hosted Qdrant (optional API key)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,10 +87,10 @@ Good references for new tests:
 
 ### Integration tests (opt-in, real Qdrant)
 
-The default `npm test` mocks every external call. We also ship one **opt-in** end-to-end smoke test that talks to a real Qdrant Cloud instance and a real embedding provider — it's the only thing that catches filter-shape rejections, payload-index mismatches, vector-dimension drift, and whether the dedup similarity thresholds (`THRESHOLD_DUPLICATE`, `THRESHOLD_RELATED`) actually correspond to near-duplicates against your embedding model.
+The default `npm test` mocks every external call. We also ship one **opt-in** end-to-end smoke test that talks to a real Qdrant instance (Cloud, local Docker, or self-hosted) and a real embedding provider — it's the only thing that catches filter-shape rejections, payload-index mismatches, vector-dimension drift, and whether the dedup similarity thresholds (`THRESHOLD_DUPLICATE`, `THRESHOLD_RELATED`) actually correspond to near-duplicates against your embedding model.
 
 ```bash
-# Uses your existing ~/.bikky/config.json + QDRANT_URL/QDRANT_API_KEY env.
+# Uses your existing ~/.bikky/config.json + QDRANT_URL (and QDRANT_API_KEY if your Qdrant requires it).
 BIKKY_INTEGRATION=1 npm run test:integration
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,19 +41,27 @@ npm install -g bikky
 bikky install          # writes MCP config for Copilot + Claude Code
 ```
 
-**Prerequisites:** [Qdrant Cloud](https://cloud.qdrant.io) (free tier, no credit card) + an embedding provider ([Ollama](https://ollama.com) runs locally for free, or use OpenAI / AWS Bedrock).
+**Prerequisites:** A Qdrant instance + an embedding provider.
+
+- **Qdrant** — pick one:
+  - [Qdrant Cloud](https://cloud.qdrant.io) (free tier, 1 GB, no credit card) — needs URL + API key.
+  - **Local Docker:** `docker run -p 6333:6333 qdrant/qdrant` — URL `http://localhost:6333`, no API key.
+  - **Self-hosted:** any reachable Qdrant; API key only required if you set `QDRANT__SERVICE__API_KEY` on the server.
+- **Embeddings** — [Ollama](https://ollama.com) runs locally for free, or use OpenAI / AWS Bedrock.
 
 Then configure credentials — pick one:
 
 ```bash
 # Option A: let your agent do it
-> "Call configure_credentials with my Qdrant URL and API key"
+> "Call configure_credentials with my Qdrant URL (and API key if needed)"
 
 # Option B: config file
-echo '{ "qdrant_url": "https://…:6333", "qdrant_api_key": "…" }' > ~/.bikky/config.json
+echo '{ "qdrant_url": "http://localhost:6333" }' > ~/.bikky/config.json
+# (add "qdrant_api_key" only if your Qdrant requires auth)
 
 # Option C: env vars
-export QDRANT_URL="https://…:6333" QDRANT_API_KEY="…"
+export QDRANT_URL="http://localhost:6333"
+# export QDRANT_API_KEY="…"   # optional; required only for Qdrant Cloud / authenticated self-hosted
 ```
 
 Restart your editor — memory tools appear automatically.

--- a/packages/ui/src/lib/qdrant.test.ts
+++ b/packages/ui/src/lib/qdrant.test.ts
@@ -198,6 +198,25 @@ describe("ui/lib/qdrant", () => {
       const c = createQdrantClient();
       assert.ok(c instanceof QdrantClient);
     });
+
+    it("returns true with URL alone (local / self-hosted Qdrant, no API key)", () => {
+      process.env.QDRANT_URL = "http://localhost:6333";
+
+      assert.equal(isQdrantConfigured(), true);
+      const c = createQdrantClient();
+      assert.ok(c instanceof QdrantClient);
+    });
+  });
+
+  describe("auth header (no api key)", () => {
+    it("omits the api-key header when none is configured", async () => {
+      const client = new QdrantClient("https://q.test:6333", null, "col");
+      const calls = installMock(() => new Response(JSON.stringify({ result: [] }), { status: 200 }));
+      await client.search([0.1]);
+      const headers = calls[0]!.init.headers as Record<string, string>;
+      assert.equal(headers["api-key"], undefined);
+      assert.equal(headers["Content-Type"], "application/json");
+    });
   });
 
   it("QdrantNotConfiguredError carries a helpful message", () => {

--- a/packages/ui/src/lib/qdrant.ts
+++ b/packages/ui/src/lib/qdrant.ts
@@ -67,16 +67,21 @@ interface CountResult {
 // --- Client ---
 
 export class QdrantClient {
+  private readonly apiKey: string | null;
+
   constructor(
     private url: string,
-    private apiKey: string,
+    apiKey: string | null | undefined,
     private collection: string,
   ) {
     this.url = url.replace(/\/+$/, "");
+    this.apiKey = apiKey || null;
   }
 
   private headers(): Record<string, string> {
-    return { "Content-Type": "application/json", "api-key": this.apiKey };
+    const h: Record<string, string> = { "Content-Type": "application/json" };
+    if (this.apiKey) h["api-key"] = this.apiKey;
+    return h;
   }
 
   private async req<T>(method: string, path: string, body?: unknown): Promise<T> {
@@ -165,12 +170,12 @@ export function buildFilter(opts: {
 
 export function isQdrantConfigured(): boolean {
   const cfg = loadConfig();
-  return Boolean(cfg.qdrant_url && cfg.qdrant_api_key);
+  return Boolean(cfg.qdrant_url);
 }
 
 export function createQdrantClient(): QdrantClient {
   const cfg = loadConfig();
-  if (!cfg.qdrant_url || !cfg.qdrant_api_key) {
+  if (!cfg.qdrant_url) {
     throw new QdrantNotConfiguredError();
   }
   return new QdrantClient(cfg.qdrant_url, cfg.qdrant_api_key, cfg.collection);

--- a/src/daemon/qdrant.ts
+++ b/src/daemon/qdrant.ts
@@ -1,8 +1,11 @@
 /**
- * Qdrant client for the bikky daemon — direct HTTP access to Qdrant Cloud.
+ * Qdrant client for the bikky daemon — direct HTTP access to Qdrant
+ * (Cloud, Docker, or self-hosted).
  * Embedding is handled by ../llm/embedding (registry-based provider abstraction).
  *
  * Credentials: config file (~/.bikky/config.json) → env vars.
+ * `qdrant_api_key` is optional — leave unset for unauthenticated local /
+ * self-hosted instances.
  */
 
 import { randomUUID } from "node:crypto";
@@ -200,11 +203,11 @@ const init = (): boolean => {
   });
   logFn("INFO", `Embedding provider: ${embCfg.provider}/${embCfg.model} (${embCfg.dimensions}d) @ ${embCfg.baseUrl}`);
 
-  const ready = !!(qdrantUrl && qdrantApiKey);
+  const ready = !!qdrantUrl;
   if (ready) {
     client = new QdrantClient({
       url: qdrantUrl as string,
-      apiKey: qdrantApiKey as string,
+      apiKey: qdrantApiKey,
       collection,
       timeoutMs: cfg.qdrant_client.timeout_ms,
       retries: cfg.qdrant_client.retries,
@@ -213,7 +216,7 @@ const init = (): boolean => {
     });
   } else {
     client = null;
-    logFn("WARN", "Qdrant client: missing credentials (some memory features disabled)");
+    logFn("WARN", "Qdrant client: missing URL (some memory features disabled)");
   }
   return ready;
 };

--- a/src/lib/qdrant-client.test.ts
+++ b/src/lib/qdrant-client.test.ts
@@ -234,11 +234,32 @@ describe("QdrantClient", () => {
     it("rejects empty url", () => {
       assert.throws(() => new QdrantClient({ ...baseOpts, url: "" }), /url is required/);
     });
-    it("rejects empty apiKey", () => {
-      assert.throws(() => new QdrantClient({ ...baseOpts, apiKey: "" }), /apiKey is required/);
+    it("accepts missing apiKey (local / self-hosted Qdrant)", () => {
+      assert.doesNotThrow(() => new QdrantClient({ ...baseOpts, apiKey: "" }));
+      assert.doesNotThrow(() => new QdrantClient({ ...baseOpts, apiKey: null }));
+      assert.doesNotThrow(() => new QdrantClient({ ...baseOpts, apiKey: undefined }));
     });
     it("rejects empty collection", () => {
       assert.throws(() => new QdrantClient({ ...baseOpts, collection: "" }), /collection is required/);
+    });
+  });
+
+  describe("auth header", () => {
+    it("omits api-key header when no apiKey is configured", async () => {
+      mock = installFetchMock([{ status: 200, body: "{}" }]);
+      const client = new QdrantClient({ ...baseOpts, apiKey: null });
+      await client.request("GET", "/collections");
+      const headers = mock.calls[0].init?.headers as Record<string, string>;
+      assert.equal(headers["api-key"], undefined);
+      assert.equal(headers["Content-Type"], "application/json");
+    });
+
+    it("omits api-key header when apiKey is empty string", async () => {
+      mock = installFetchMock([{ status: 200, body: "{}" }]);
+      const client = new QdrantClient({ ...baseOpts, apiKey: "" });
+      await client.request("GET", "/collections");
+      const headers = mock.calls[0].init?.headers as Record<string, string>;
+      assert.equal(headers["api-key"], undefined);
     });
   });
 });

--- a/src/lib/qdrant-client.ts
+++ b/src/lib/qdrant-client.ts
@@ -18,7 +18,12 @@ export type QdrantLogFn = (level: QdrantLogLevel, msg: string) => void;
 
 export interface QdrantClientOptions {
   url: string;
-  apiKey: string;
+  /**
+   * Qdrant API key. Optional — leave empty/null/undefined for unauthenticated
+   * local or self-hosted instances (e.g. `docker run qdrant/qdrant`). Required
+   * for Qdrant Cloud.
+   */
+  apiKey?: string | null;
   collection: string;
   /** Per-request timeout in ms (default 10_000). */
   timeoutMs?: number;
@@ -150,7 +155,7 @@ const classifyStatus = (
 
 export class QdrantClient {
   private readonly url: string;
-  private readonly apiKey: string;
+  private readonly apiKey: string | null;
   readonly collection: string;
   private readonly timeoutMs: number;
   private readonly retries: number;
@@ -159,10 +164,9 @@ export class QdrantClient {
 
   constructor(opts: QdrantClientOptions) {
     if (!opts.url) throw new Error("QdrantClient: url is required");
-    if (!opts.apiKey) throw new Error("QdrantClient: apiKey is required");
     if (!opts.collection) throw new Error("QdrantClient: collection is required");
     this.url = opts.url.replace(/\/+$/, "");
-    this.apiKey = opts.apiKey;
+    this.apiKey = opts.apiKey || null;
     this.collection = opts.collection;
     this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.retries = opts.retries ?? DEFAULT_RETRIES;
@@ -221,8 +225,8 @@ export class QdrantClient {
     const url = `${this.url}${path}`;
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
-      "api-key": this.apiKey,
     };
+    if (this.apiKey) headers["api-key"] = this.apiKey;
     const init: RequestInit = { method, headers };
     if (body !== undefined) init.body = JSON.stringify(body);
 

--- a/src/mcp/api.ts
+++ b/src/mcp/api.ts
@@ -66,7 +66,7 @@ export const log = createLogger("memory-mcp", path.join(LOG_DIR, "mcp.log"), {
 const qdrantLogAdapter = (level: QdrantLogLevel, msg: string): void => log(level, msg);
 
 function rebuildClient(): void {
-  if (qdrantUrl && qdrantApiKey && collectionName) {
+  if (qdrantUrl && collectionName) {
     const cfg = loadConfig();
     client = new QdrantClient({
       url: qdrantUrl,
@@ -136,8 +136,9 @@ function ensureLLMInitialized(): void {
 function getClient(): QdrantClient {
   if (!client) {
     throw new Error(
-      "Qdrant client not initialized — credentials missing. " +
-        "Use configure_credentials or set QDRANT_URL + QDRANT_API_KEY.",
+      "Qdrant client not initialized — URL missing. " +
+        "Use configure_credentials or set QDRANT_URL " +
+        "(QDRANT_API_KEY is optional for local / self-hosted instances).",
     );
   }
   return client;

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,5 +1,5 @@
 /**
- * bikky MCP Server — episodic memory via Qdrant Cloud.
+ * bikky MCP Server — episodic memory via Qdrant (Cloud, Docker, or self-hosted).
  *
  * Provides persistent memory across AI coding sessions. All facts, relations,
  * and entity context live as Qdrant points with vector embeddings + structured
@@ -44,19 +44,16 @@ export async function startMcpServer(): Promise<void> {
   });
   log("INFO", `Embedding: ${embCfg.provider}/${embCfg.model} (${embCfg.dimensions}d) @ ${embCfg.baseUrl || "(sdk)"}`);
 
-  if (qUrl && qKey) {
+  if (qUrl) {
     try {
       await ensureCollection(QDRANT_INDEXES);
       setReady(true);
-      log("INFO", "Memory system ready ✓");
+      log("INFO", `Memory system ready ✓ (Qdrant ${qKey ? "with" : "without"} api-key auth)`);
     } catch (e) {
       log("ERROR", `Failed to initialize collection: ${e instanceof Error ? e.message : String(e)}`);
     }
   } else {
-    const missing: string[] = [];
-    if (!qUrl) missing.push("qdrant-url");
-    if (!qKey) missing.push("qdrant-api-key");
-    log("INFO", `Memory not configured — missing: ${missing.join(", ")}. Use get_setup_status + configure_credentials.`);
+    log("INFO", "Memory not configured — missing: qdrant-url. Use get_setup_status + configure_credentials.");
   }
 
   const mcp = new McpServer({

--- a/src/mcp/taxonomy.ts
+++ b/src/mcp/taxonomy.ts
@@ -22,7 +22,7 @@ export const CATEGORIES = {
     description:
       "Cloud, deployment, runtime, secrets, queues, databases, CI/CD, and environment topology.",
     examples: [
-      "Production uses Qdrant Cloud for vector storage.",
+      "Production runs on a Qdrant cluster (Cloud or self-hosted) for vector storage.",
       "Deployments are promoted through GitHub Actions.",
     ],
   },

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -265,9 +265,9 @@ export function registerTools(mcp: McpServer): void {
       };
       const missing = status["missing"] as string[];
       if (!qdrantUrl) missing.push("qdrant-url");
-      if (!qdrantApiKey) missing.push("qdrant-api-key");
+      // qdrant-api-key is optional (local / self-hosted Qdrant doesn't need it).
 
-      if (qdrantUrl && qdrantApiKey) {
+      if (qdrantUrl) {
         try {
           await qdrantReq<unknown>("GET", "/collections");
           status["qdrant_connected"] = true;
@@ -280,10 +280,11 @@ export function registerTools(mcp: McpServer): void {
 
       if (!status["ready"] && missing.length > 0) {
         status["setup_instructions"] =
-          "Run `bikky setup` or guide the user:\n" +
-          "1. Go to cloud.qdrant.io → sign up (free tier: 1GB, no credit card)\n" +
-          "2. Create a cluster → copy the REST URL and API key\n" +
-          "3. Call configure_credentials with Qdrant values";
+          "Run `bikky setup` or guide the user. Pick one Qdrant option:\n" +
+          "  • Qdrant Cloud (managed, free tier, 1GB): https://cloud.qdrant.io — copy the REST URL + API key\n" +
+          "  • Local Docker: `docker run -p 6333:6333 qdrant/qdrant` → URL `http://localhost:6333` (no API key needed)\n" +
+          "  • Self-hosted: any reachable Qdrant; API key only required if QDRANT__SERVICE__API_KEY is set on the server\n" +
+          "Then call configure_credentials with the URL (and API key if applicable).";
       }
 
       return { content: [{ type: "text", text: JSON.stringify(status, null, 2) }] };
@@ -296,8 +297,8 @@ export function registerTools(mcp: McpServer): void {
     "configure_credentials",
     "Store Qdrant + embedding credentials in ~/.bikky/config.json. Tests connectivity and creates the collection if needed.",
     {
-      qdrant_url: z.string().optional().describe("Qdrant Cloud REST URL (e.g. https://xxx.cloud.qdrant.io:6333)"),
-      qdrant_api_key: z.string().optional().describe("Qdrant Cloud API key"),
+      qdrant_url: z.string().optional().describe("Qdrant REST URL — Qdrant Cloud (https://xxx.cloud.qdrant.io:6333), local Docker (http://localhost:6333), or self-hosted"),
+      qdrant_api_key: z.string().optional().describe("Qdrant API key — required for Qdrant Cloud; optional / leave blank for unauthenticated local or self-hosted instances"),
       openai_api_key: z.string().optional().describe("OpenAI API key (for OpenAI embedding/LLM provider)"),
     },
     async ({ qdrant_url, qdrant_api_key, openai_api_key }): Promise<McpToolResult> => {
@@ -325,7 +326,7 @@ export function registerTools(mcp: McpServer): void {
 
       saveConfig(cfg);
 
-      if (qdrantUrl && qdrantApiKey) {
+      if (qdrantUrl) {
         try {
           await ensureCollection(QDRANT_INDEXES);
           results["qdrant_collection"] = `'${getCollection()}' ready ✓`;
@@ -342,7 +343,7 @@ export function registerTools(mcp: McpServer): void {
         results["embedding"] = `error: ${e instanceof Error ? e.message : String(e)}`;
       }
 
-      setReady(!!(qdrantUrl && qdrantApiKey));
+      setReady(!!qdrantUrl);
       results["ready"] = ready;
 
       return { content: [{ type: "text", text: JSON.stringify(results, null, 2) }] };
@@ -358,7 +359,7 @@ export function registerTools(mcp: McpServer): void {
     async (): Promise<McpToolResult> => {
       const results: Record<string, unknown> = { qdrant: false, embedding: false, collection: false };
 
-      if (qdrantUrl && qdrantApiKey) {
+      if (qdrantUrl) {
         try {
           await qdrantReq<unknown>("GET", "/collections");
           results["qdrant"] = true;


### PR DESCRIPTION
Closes #27.

## What
Make `qdrant_api_key` truly optional throughout bikky so users can run against:
- **Qdrant Cloud** (URL + API key — unchanged)
- **Local Docker:** `docker run -p 6333:6333 qdrant/qdrant` — URL only, no key
- **Self-hosted:** any reachable Qdrant; key only if `QDRANT__SERVICE__API_KEY` is set on the server

## Why
`QdrantClient` previously hard-throw if `apiKey` was missing and always sent the `api-key` header, locking bikky to Qdrant Cloud. Local / self-hosted users had no path.

## Changes
- **`src/lib/qdrant-client.ts`** — `apiKey` is `string | null | undefined`; `api-key` header set only when a key is configured. URL/collection still required.
- **`packages/ui/src/lib/qdrant.ts`** — same change in browser mirror; `isQdrantConfigured()` and `createQdrantClient()` now require only the URL.
- **`src/mcp/api.ts`, `src/mcp/index.ts`, `src/daemon/qdrant.ts`** — gate client init on URL only; reworded "credentials missing" error.
- **`src/mcp/tools.ts`** — `configure_credentials` schema reworded; `get_setup_status` no longer flags `qdrant-api-key` as missing; `setup_instructions` cover Cloud / Docker / self-hosted; readiness flag and `verify_connection` track URL alone.
- **`README.md`, `CONTRIBUTING.md`, `src/mcp/taxonomy.ts`** — docs/strings broadened.
- **Tests** — replaced `apiKey is required` test with no-key acceptance; added header-omission + URL-only configured tests in both server (`src/lib/qdrant-client.test.ts`) and UI (`packages/ui/src/lib/qdrant.test.ts`) suites.

## Verification
- `npm test` — 383 pass, 0 fail.
- `npm run build` — clean.
- End-to-end smoke against `docker run -p 6333:6333 qdrant/qdrant` (no api key): `GET /collections` and `ensureCollection` both succeed.

## Out of scope (per discovery)
- Shipping a `docker-compose.yml` in the repo
- Setup-wizard branch (no interactive wizard exists yet)