### PR TITLE
docs: move ontology to README; enable claude watcher by default; drop codex refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,30 @@ Restart your editor — memory tools appear automatically.
 
 ---
 
+## Memory ontology
+
+New daemon captures use ontology v2:
+
+```text
+workspace -> domain -> repo/project/surface -> workstream -> episode -> memory objects
+```
+
+`domain` is an activity/knowledge profile. The initial canonical domains are:
+
+| Domain | Purpose |
+|--------|---------|
+| `software_engineering` | Default for coding-agent captures: repos, code, infrastructure, releases, incidents |
+| `product_strategy` | Roadmap, positioning, experiments, customer insight, product decisions |
+| `business_operations` | Company processes, vendors, compliance, obligations, recurring workflows |
+| `research` | Source-backed investigation, hypotheses, contradictions, synthesis |
+| `personal_productivity` | Individual goals, routines, preferences, projects, habits |
+
+For `software_engineering`, canonical categories are `codebase`, `infrastructure`, `operations`, `decisions`, `product_domain`, `projects`, `people`, `preferences`, and `observations`.
+
+`kind` stays small (`fact`, `summary`, `distilled`, `relation`, `telemetry`). More specific shape lives in `memory_subtype`, such as `codebase_map`, `architecture_decision`, `episode`, `workstream`, or `failure_mode`.
+
+---
+
 ## Self-curation
 
 Raw fact accumulation creates noise. bikky keeps the knowledge store clean automatically:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,37 +201,15 @@ jq 'select(.provider=="openai" and .kind=="auth")' ~/.bikky/logs/mcp.log
 
 Stdout/stderr are reserved for the MCP stdio transport — bikky never logs to the terminal from the MCP process.
 
-## Memory ontology
-
-New daemon captures use ontology v2:
-
-```text
-workspace -> domain -> repo/project/surface -> workstream -> episode -> memory objects
-```
-
-`domain` is an activity/knowledge profile, not a work/personal flag. The initial canonical domains are:
-
-| Domain | Purpose |
-|--------|---------|
-| `software_engineering` | Default for coding-agent captures: repos, code, infrastructure, releases, incidents |
-| `product_strategy` | Roadmap, positioning, experiments, customer insight, product decisions |
-| `business_operations` | Company processes, vendors, compliance, obligations, recurring workflows |
-| `research` | Source-backed investigation, hypotheses, contradictions, synthesis |
-| `personal_productivity` | Individual goals, routines, preferences, projects, habits |
-
-For `software_engineering`, canonical categories are `codebase`, `infrastructure`, `operations`, `decisions`, `product_domain`, `projects`, `people`, `preferences`, and `observations`.
-
-`kind` stays small (`fact`, `summary`, `distilled`, `relation`, `telemetry`). More specific shape lives in `memory_subtype`, such as `codebase_map`, `architecture_decision`, `episode`, `workstream`, or `failure_mode`.
-
 ## Watcher settings
 
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `watchers.copilot.enabled` | `true` | Watch GitHub Copilot session logs |
 | `watchers.copilot.path` | `~/.copilot/session-state` | Path to Copilot session directory |
-| `watchers.claude.enabled` | `false` | Watch Claude Code project logs |
+| `watchers.claude.enabled` | `true` | Watch Claude Code project logs |
 | `watchers.claude.path` | `~/.claude/projects` | Path to Claude Code projects directory |
 
 ## Agent integration templates
 
-Run `bikky templates` to print all MCP client snippets, or `bikky templates cursor` / `bikky templates codex` for one target. See [docs/integrations.md](integrations.md).
+Run `bikky templates` to print all MCP client snippets, or `bikky templates cursor` for one target.

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "copilot",
     "claude-code",
     "cursor",
-    "codex",
     "agentic",
     "ai-coding",
     "ai-power-user",

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -207,10 +207,10 @@ describe("config", () => {
       assert.strictEqual(cfg.watchers.copilot.enabled, true);
     });
 
-    it("watchers.claude.enabled defaults to false", () => {
+    it("watchers.claude.enabled defaults to true", () => {
       if (fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
       const cfg = loadConfig();
-      assert.strictEqual(cfg.watchers.claude.enabled, false);
+      assert.strictEqual(cfg.watchers.claude.enabled, true);
     });
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -133,7 +133,7 @@ const DEFAULTS: BikkyConfig = {
   },
   watchers: {
     copilot: { enabled: true, path: path.join(os.homedir(), ".copilot", "session-state") },
-    claude: { enabled: false, path: path.join(os.homedir(), ".claude", "projects") },
+    claude: { enabled: true, path: path.join(os.homedir(), ".claude", "projects") },
   },
   qdrant_client: {
     timeout_ms: 10_000,


### PR DESCRIPTION
Four small cleanups requested in conversation:

- **Move 'Memory ontology' section to README.** It's first-encounter context, not config reference. Now sits between 'How it works' and 'Self-curation' on the landing page.
- **Drop 'not a work/personal flag' phrasing.** `domain` is described as 'an activity/knowledge profile' — no need to disclaim what it isn't.
- **Enable the Claude Code watcher by default** (`watchers.claude.enabled = true`) alongside Copilot. Updated the `config.test.ts` default assertion.
- **Remove Codex references** (not supported yet): dropped from `package.json` keywords and from the `bikky templates` example in `docs/configuration.md`.

389/389 tests passing.