### PR TITLE
docs: fix README/configuration coherence (drop Codex, fix CLI references)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 <p align="center"><b>Persistent memory for AI coding agents — for solo power users and teams.</b></p>
 
-bikky gives AI coding agents (GitHub Copilot, Claude Code, Cursor, Codex, and other MCP clients) long-term memory that persists across sessions, across tools, and — when you want it — across your whole team. Whether you're a solo power dev running a dozen agentic sessions a day, or a team that wants every engineer's agent to start from the same knowledge base, bikky captures what's learned *during* sessions so future sessions start smarter.
+bikky gives AI coding agents (GitHub Copilot, Claude Code, Cursor, and other MCP clients) long-term memory that persists across sessions, across tools, and — when you want it — across your whole team. Whether you're a solo power dev running a dozen agentic sessions a day, or a team that wants every engineer's agent to start from the same knowledge base, bikky captures what's learned *during* sessions so future sessions start smarter.
 
 ### Who it's for
 
 | | |
 |---|---|
-| 🧑‍💻 **Solo AI power devs** | You run multiple Cursor / Claude Code / Copilot / Codex sessions every day and you're tired of re-explaining the codebase, the conventions, and last week's decisions to each new agent. bikky remembers across every session and every tool. |
+| 🧑‍💻 **Solo AI power devs** | You run multiple Cursor / Claude Code / Copilot sessions every day and you're tired of re-explaining the codebase, the conventions, and last week's decisions to each new agent. bikky remembers across every session and every tool. |
 | 👥 **Teams & software factories** | What one engineer's agent learns today, every agent on the team can recall tomorrow. Shared memory turns institutional knowledge into something queryable instead of tribal. |
 
 <p align="center">
@@ -38,7 +38,7 @@ The most valuable things you and your agents learn — why a config value exists
 
 ```bash
 npm install -g bikky
-bikky install          # writes MCP config for Copilot + Claude Code
+bikky setup            # writes MCP config for Copilot + Claude Code, then starts the daemon
 ```
 
 **Prerequisites:** A Qdrant instance + an embedding provider.
@@ -155,14 +155,14 @@ The UI reads from your existing `~/.bikky/config.json` — no extra configuratio
 
 ```bash
 bikky mcp       # start MCP server (stdio) — used by editors
-bikky setup     # interactive setup wizard
+bikky setup     # install MCP configs for Copilot + Claude Code, then start the daemon
+bikky start     # alias for setup
+bikky stop      # stop the background daemon
+bikky daemon    # run the daemon in the foreground
 bikky status    # check memory system health
-bikky install   # write MCP config for Copilot + Claude Code
-bikky templates # print config snippets for Copilot, Claude Code, Cursor, and Codex
+bikky ui        # launch the local web dashboard
 bikky render    # render a prompt to JSON (for eval harnesses & debugging)
 ```
-
-See **[docs/integrations.md](docs/integrations.md)** for copy-paste MCP templates.
 
 ### `bikky render` — inspect prompts
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ Config lives at `~/.bikky/config.json`. Resolution order: **defaults → config 
 
 ## Ontology scope fields
 
-Bikky's ontology includes optional scope payload fields such as `workspace_id`, `repo`, `branch`, `task_key`, `workstream_key`, and `episode_id`. These fields can be supplied through MCP calls or daemon-generated records where available; task 243 does not add workspace, redaction, or telemetry configuration sections.
+Bikky's ontology includes optional scope payload fields such as `workspace_id`, `repo`, `branch`, `task_key`, `workstream_key`, and `episode_id`. These fields can be supplied through MCP calls or filled in by the daemon when it has enough context.
 
 ## Embedding & LLM providers
 
@@ -240,7 +240,3 @@ Stdout/stderr are reserved for the MCP stdio transport — bikky never logs to t
 | `watchers.copilot.path` | `~/.copilot/session-state` | Path to Copilot session directory |
 | `watchers.claude.enabled` | `true` | Watch Claude Code project logs |
 | `watchers.claude.path` | `~/.claude/projects` | Path to Claude Code projects directory |
-
-## Agent integration templates
-
-Run `bikky templates` to print all MCP client snippets, or `bikky templates cursor` for one target.


### PR DESCRIPTION
Cleanup pass after PRs #28/#30/#32/#33 landed. All findings from a coherence review:

### Broken references
- README claimed `bikky install` writes MCP configs — that subcommand does **not** exist. Replaced with `bikky setup` (the actual command, per `src/cli.ts`).
- README listed `bikky templates` and linked to `docs/integrations.md`. Neither exists. Removed both.
- Removed the trailing `Agent integration templates` section from `docs/configuration.md` for the same reason.

### Codex consistency (PR #33 follow-through)
PR #33 dropped Codex refs from configuration.md, but two stale mentions survived in README:
- Opening sentence (supported MCP clients list).
- "Who it's for" table.

Removed both.

### Internal task language leaking into user docs
`docs/configuration.md` had "task 243 does not add workspace, redaction, or telemetry configuration sections" inside the ontology scope section. Rewrote in user-facing language.

### CLI list expanded
The README's `bikky` subcommand list now matches `src/cli.ts` exactly: `mcp / setup / start / stop / daemon / status / ui / render`.

Docs-only, no code paths touched, no version bump needed.