### PR TITLE
Remove ontology version label

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,17 +118,28 @@ export QDRANT_URL="http://localhost:6333"
 
 `memory_store` · `memory_recall` · `memory_entity` · `memory_relations` · `memory_forget` · `memory_verify` · `memory_heartbeat` · `memory_review` · `configure_credentials` · `verify_connection`
 
-**Daemon** — background process that passively watches session logs, extracts ontology-v2 facts, writes lightweight session indexes, captures coherent episode summaries, updates current-state workstream summaries, infers entity relationships, and runs the consolidation pipeline. Lifecycle memory is daemon-owned so agents do not need to remember summary/distillation tool calls.
+**Daemon** — background process that passively watches session logs, extracts structured facts, writes lightweight session indexes, captures coherent episode summaries, updates current-state workstream summaries, infers entity relationships, and runs the consolidation pipeline. Lifecycle memory is daemon-owned so agents do not need to remember summary/distillation tool calls.
 
 ---
 
 ## Memory ontology
 
-New daemon captures use ontology v2:
+New daemon captures use a layered memory ontology. At a high level, bikky structures memory like this:
 
 ```text
-workspace -> domain -> repo/project/surface -> workstream -> episode -> memory objects
+Workspace
+  Domain
+    Project / repo / surface
+      Workstream
+        Episodes
+          Facts, decisions, preferences, operational notes
+        Current-state summaries
+          What matters now, open questions, blockers
+    Cross-cutting memory
+      Durable patterns, entity relationships, telemetry
 ```
+
+This gives each memory enough context to be recalled precisely without forcing every note into a rigid project hierarchy.
 
 `domain` is an activity/knowledge profile. The initial canonical domains are:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -195,7 +195,7 @@ payload that now includes a human-readable `setup_error` field:
 
 ## Daemon settings
 
-The daemon owns memory lifecycle work: it extracts ontology-v2 facts, writes lightweight session indexes, captures coherent episode summaries, and distills longer-lived patterns when consolidation is enabled.
+The daemon owns memory lifecycle work: it extracts structured facts, writes lightweight session indexes, captures coherent episode summaries, and distills longer-lived patterns when consolidation is enabled.
 
 | Setting | Default | Description |
 |---------|---------|-------------|

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bikky",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bikky",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bikky",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Shared memory for AI coding sessions — MCP server + background daemon",
   "type": "module",
   "license": "AGPL-3.0-or-later",

--- a/src/daemon/capture-policy.test.ts
+++ b/src/daemon/capture-policy.test.ts
@@ -14,7 +14,7 @@ import {
 } from "./capture-policy.js";
 
 describe("daemon/capture-policy", () => {
-  it("uses ontology v2 and software_engineering defaults", () => {
+  it("uses memory ontology and software_engineering defaults", () => {
     assert.strictEqual(CAPTURE_POLICY_VERSION, "capture-policy-v2");
     assert.strictEqual(DEFAULT_CAPTURE_CONTEXT.domain, "software_engineering");
     assert.strictEqual(DEFAULT_CAPTURE_CONTEXT.source, "daemon");

--- a/src/daemon/capture-policy.ts
+++ b/src/daemon/capture-policy.ts
@@ -1,5 +1,5 @@
 /**
- * Daemon-owned capture policy for ontology v2.
+ * Daemon-owned capture policy for the memory ontology.
  *
  * These constants define when Bikky should capture memory, how large each
  * generated object should be, and which prompt/capture versions are stored on

--- a/src/daemon/episode-summary.test.ts
+++ b/src/daemon/episode-summary.test.ts
@@ -18,7 +18,7 @@ const defaultScope: WorkspaceScope = {
 
 describe("daemon/episode-summary", () => {
   it("segments two unrelated user tasks in one session into two episodes", () => {
-    const transcript = `[USER] Implement ontology v2 in src/mcp/taxonomy.ts and add tests.
+    const transcript = `[USER] Implement the memory ontology in src/mcp/taxonomy.ts and add tests.
 
 [ASSISTANT] Updated src/mcp/taxonomy.ts with software_engineering domains and memory_subtype validation. Ran npm test for taxonomy.
 
@@ -34,7 +34,7 @@ describe("daemon/episode-summary", () => {
 
     assert.equal(segments.length, 2);
     assert.match(segments[0].episode_id, /^uuid:test-session:episode:/);
-    assert.match(segments[0].transcript, /ontology v2/);
+    assert.match(segments[0].transcript, /memory ontology/);
     assert.match(segments[1].transcript, /UI smoke tests/);
   });
 
@@ -58,7 +58,7 @@ describe("daemon/episode-summary", () => {
   it("parses episode summary drafts", () => {
     const draft = parseEpisodeSummaryDraft(`\`\`\`json
 {
-  "content": "Implemented ontology v2 extraction for src/daemon/extraction.ts.",
+  "content": "Implemented memory ontology extraction for src/daemon/extraction.ts.",
   "tasks_completed": ["ontology extraction"],
   "decisions_made": ["Use memory_subtype on daemon facts"],
   "open_questions": ["wire workstream summaries"],
@@ -68,7 +68,7 @@ describe("daemon/episode-summary", () => {
 }
 \`\`\``);
 
-    assert.equal(draft.content, "Implemented ontology v2 extraction for src/daemon/extraction.ts.");
+    assert.equal(draft.content, "Implemented memory ontology extraction for src/daemon/extraction.ts.");
     assert.deepEqual(draft.entities, ["bikky", "src/daemon/extraction.ts"]);
     assert.equal(draft.workstream_key, "243-bikky-data-capture-policy");
   });
@@ -92,7 +92,7 @@ describe("daemon/episode-summary", () => {
     ), false);
   });
 
-  it("builds ontology-v2 episode payloads", () => {
+  it("builds memory ontology episode payloads", () => {
     const { payload } = buildEpisodeSummaryPayload({
       draft: {
         content: "Implemented daemon episode summaries for src/daemon/episode-summary.ts.",

--- a/src/daemon/extraction.test.ts
+++ b/src/daemon/extraction.test.ts
@@ -10,7 +10,7 @@ import {
 } from "./extraction.js";
 
 describe("daemon/extraction prompt", () => {
-  it("describes ontology v2 fields and avoids legacy domain wording", () => {
+  it("describes memory ontology fields and avoids legacy domain wording", () => {
     assert.ok(DEFAULT_EXTRACTION_PROMPT.includes("software_engineering"));
     assert.ok(DEFAULT_EXTRACTION_PROMPT.includes("memory_subtype"));
     assert.ok(DEFAULT_EXTRACTION_PROMPT.includes("codebase_map"));

--- a/src/daemon/session-index.test.ts
+++ b/src/daemon/session-index.test.ts
@@ -45,7 +45,7 @@ describe("daemon/session-index", () => {
     ), false);
   });
 
-  it("builds ontology-v2 session index payloads", () => {
+  it("builds memory ontology session index payloads", () => {
     const draft = buildSessionIndexDraft({
       sessionId: "uuid:test-session",
       eventCount: 12,

--- a/src/daemon/workstream-summary.test.ts
+++ b/src/daemon/workstream-summary.test.ts
@@ -36,7 +36,7 @@ describe("daemon/workstream-summary", () => {
     const messages = buildWorkstreamSummaryMessages({
       workstreamKey: "task-a",
       existingSummary: "Old state",
-      episodeSummaries: ["Implemented ontology v2.", "Added tests."],
+      episodeSummaries: ["Implemented the memory ontology.", "Added tests."],
     });
 
     assert.match(messages[0].content, /current-state workstream summary/);
@@ -47,7 +47,7 @@ describe("daemon/workstream-summary", () => {
   it("parses workstream summary drafts", () => {
     const draft = parseWorkstreamSummaryDraft(`\`\`\`json
 {
-  "content": "Ontology v2 is implemented and extraction is being hardened.",
+  "content": "The memory ontology is implemented and extraction is being hardened.",
   "current_decisions": ["Use domain for activity profile"],
   "next_steps": ["Run full validation"],
   "blockers": ["None"],
@@ -56,7 +56,7 @@ describe("daemon/workstream-summary", () => {
 }
 \`\`\``);
 
-    assert.equal(draft.content, "Ontology v2 is implemented and extraction is being hardened.");
+    assert.equal(draft.content, "The memory ontology is implemented and extraction is being hardened.");
     assert.deepEqual(draft.current_decisions, ["Use domain for activity profile"]);
     assert.deepEqual(draft.entities, ["bikky", "qdrant"]);
   });
@@ -89,7 +89,7 @@ describe("daemon/workstream-summary", () => {
   it("builds one current-state payload per workstream", () => {
     const { payload } = buildWorkstreamSummaryPayload({
       draft: {
-        content: "Ontology v2 implementation is in validation.",
+        content: "Memory ontology implementation is in validation.",
         current_decisions: ["Use software_engineering as the default domain"],
         next_steps: ["Run npm test"],
         blockers: [],

--- a/src/mcp/taxonomy.test.ts
+++ b/src/mcp/taxonomy.test.ts
@@ -57,7 +57,7 @@ describe("ontology values", () => {
     ]);
   });
 
-  it("exposes only canonical ontology v2 categories", () => {
+  it("exposes only canonical memory ontology categories", () => {
     assert.deepStrictEqual(categoryValues(), canonicalCategoryValues());
     assert.ok(!categoryValues().includes("observation"));
     assert.ok(!categoryValues().includes("team"));
@@ -208,7 +208,7 @@ describe("decay policy", () => {
 });
 
 describe("QDRANT_INDEXES", () => {
-  it("includes ontology v2 query-critical payload indexes", () => {
+  it("includes memory ontology query-critical payload indexes", () => {
     const indexes = new Map(QDRANT_INDEXES.map((idx) => [idx.field_name, idx.field_schema]));
     assert.strictEqual(indexes.get("category"), "keyword");
     assert.strictEqual(indexes.get("domain"), "keyword");

--- a/src/mcp/taxonomy.ts
+++ b/src/mcp/taxonomy.ts
@@ -1,7 +1,7 @@
 /**
  * Bikky memory ontology.
  *
- * Ontology v2 separates ownership boundaries from semantic meaning:
+ * The memory ontology separates ownership boundaries from semantic meaning:
  * workspace -> domain -> repo/project/surface -> workstream -> episode -> memory objects.
  */
 
@@ -54,7 +54,7 @@ export const CATEGORIES = {
     description:
       "Project goals, milestones, current state, open questions, blockers, and active workstreams.",
     examples: [
-      "The capture-policy RPI is implementing ontology v2 first.",
+      "The capture-policy workstream is implementing the memory ontology first.",
       "The UI smoke suite is tracked in bikky-dev/bikky#13.",
     ],
   },

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -157,7 +157,7 @@ test("renderPrompt: episode-summary renders", () => {
 test("renderPrompt: workstream-summary renders", () => {
   const out = renderPrompt("workstream-summary", {
     workstreamKey: "231-bikky-evals-deepeval",
-    existingSummary: "Eval harness has ontology-v2 coverage.",
+    existingSummary: "Eval harness has memory ontology coverage.",
     episodeSummaries: ["Added episode-summary eval cases.", "Added workstream-summary eval cases."],
   });
   assert.match(out.promptName, /^workstream-summary@/);


### PR DESCRIPTION
## Summary
- remove user-facing `ontology v2` wording in favor of memory ontology / structured facts language
- replace the README memory ontology chain with a compact nested overview diagram
- bump package version to 0.3.4 for a follow-up npm publish

## Validation
- `git diff --check`
- `npm run build`
- `npm test` — 391 passed
- `npm pack --dry-run --json` confirms bikky@0.3.4 package contents