### PR TITLE
feat(extraction): self-judgment fields (Phase 1 of #46)

### DIFF
--- a/src/daemon/extraction.test.ts
+++ b/src/daemon/extraction.test.ts
@@ -123,3 +123,107 @@ describe("isHighQualityExtractedFact", () => {
     })), false);
   });
 });
+
+describe("normalizeExtractedFact — self-judgment fields (prompt v2026-04-28-1)", () => {
+  it("parses subject, subject_specificity, volatility, self_contained, as_of", () => {
+    const fact = normalizeExtractedFact({
+      content: "The bikky-dev/bikky CI workflow .github/workflows/release.yml builds Docker images and pushes to ECR.",
+      category: "infrastructure",
+      memory_subtype: "infra_topology",
+      entities: ["bikky-dev/bikky", "ecr"],
+      confidence: 0.9,
+      importance: 0.8,
+      quality_score: 0.85,
+      subject: ".github/workflows/release.yml",
+      subject_specificity: 0.95,
+      volatility: "stable",
+      volatility_reason: "CI workflow file location is durable.",
+      self_contained: true,
+      repo: "bikky-dev/bikky",
+    });
+
+    assert.ok(fact);
+    assert.strictEqual(fact.subject, ".github/workflows/release.yml");
+    assert.strictEqual(fact.subject_specificity, 0.95);
+    assert.strictEqual(fact.volatility, "stable");
+    assert.strictEqual(fact.volatility_reason, "CI workflow file location is durable.");
+    assert.strictEqual(fact.self_contained, true);
+    assert.strictEqual(fact.as_of, null);
+    assert.strictEqual(fact.repo, "bikky-dev/bikky");
+  });
+
+  it("clamps subject_specificity to [0,1] and rejects unknown volatility values", () => {
+    const fact = normalizeExtractedFact({
+      content: "The dbt-run-cronjob-v100-29617080 cronjob is currently running the old image.",
+      category: "observations",
+      memory_subtype: "troubleshooting_gotcha",
+      entities: ["dbt-run-cronjob-v100-29617080"],
+      confidence: 0.8,
+      importance: 0.6,
+      quality_score: 0.7,
+      subject: "dbt-run-cronjob-v100-29617080",
+      subject_specificity: 1.5,
+      volatility: "VERY_TRANSIENT",
+      self_contained: true,
+      as_of: "2026-04-28",
+    });
+
+    assert.ok(fact);
+    assert.strictEqual(fact.subject_specificity, 1);
+    assert.strictEqual(fact.volatility, null, "unknown volatility values normalize to null");
+    assert.strictEqual(fact.as_of, "2026-04-28");
+  });
+
+  it("ignores malformed as_of and missing self-judgment fields without dropping the fact", () => {
+    const fact = normalizeExtractedFact({
+      content: "The UI smoke tests live in packages/ui/tests/smoke.spec.ts and run with npm run test:e2e.",
+      category: "codebase",
+      memory_subtype: "codebase_map",
+      entities: ["packages/ui"],
+      confidence: 0.9,
+      importance: 0.7,
+      quality_score: 0.8,
+      as_of: "yesterday",
+    });
+
+    assert.ok(fact, "fact without self-judgment fields should still be accepted");
+    assert.strictEqual(fact.subject, null);
+    assert.strictEqual(fact.subject_specificity, null);
+    assert.strictEqual(fact.volatility, null);
+    assert.strictEqual(fact.self_contained, null);
+    assert.strictEqual(fact.as_of, null, "malformed as_of must be dropped");
+  });
+});
+
+describe("factQualitySignals — self-judgment integration", () => {
+  function baseFact(overrides: Partial<ExtractedFact> = {}): ExtractedFact {
+    return {
+      content: "The UI smoke tests live in packages/ui/tests/smoke.spec.ts and run with npm run test:e2e.",
+      category: "codebase",
+      memory_subtype: "codebase_map",
+      entities: ["packages/ui"],
+      confidence: 0.9,
+      importance: 0.7,
+      quality_score: 0.8,
+      ...overrides,
+    };
+  }
+
+  it("boosts the quality score when subject_specificity is high", () => {
+    const high = factQualitySignals(baseFact({ subject_specificity: 0.95 }));
+    const baseline = factQualitySignals(baseFact());
+    assert.ok(high.computedQualityScore >= baseline.computedQualityScore);
+  });
+
+  it("penalizes the quality score when subject_specificity is very low", () => {
+    const low = factQualitySignals(baseFact({ subject_specificity: 0.1 }));
+    const baseline = factQualitySignals(baseFact());
+    assert.ok(low.computedQualityScore < baseline.computedQualityScore);
+  });
+
+  it("penalizes the quality score when self_contained is false", () => {
+    const notSelf = factQualitySignals(baseFact({ self_contained: false }));
+    const baseline = factQualitySignals(baseFact());
+    assert.ok(notSelf.computedQualityScore < baseline.computedQualityScore);
+  });
+});

--- a/src/daemon/extraction.ts
+++ b/src/daemon/extraction.ts
@@ -339,6 +339,17 @@ const buildTranscript = (events: ParsedEvent[]): string => {
 
 // ── LLM extraction ──────────────────────────────────────────────────────────
 
+export type Volatility = "stable" | "evolving" | "transient" | "ephemeral";
+
+const VOLATILITY_VALUES: ReadonlySet<Volatility> = new Set([
+  "stable",
+  "evolving",
+  "transient",
+  "ephemeral",
+]);
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
 export interface ExtractedFact {
   content: string;
   category: string;
@@ -353,6 +364,13 @@ export interface ExtractedFact {
   branch?: string | null;
   task_key?: string | null;
   workstream_key?: string | null;
+  // Self-judgment fields (prompt v2026-04-28-1+)
+  subject?: string | null;
+  subject_specificity?: number | null;
+  volatility?: Volatility | null;
+  volatility_reason?: string | null;
+  self_contained?: boolean | null;
+  as_of?: string | null;
 }
 
 export interface FactQualitySignals {
@@ -408,6 +426,15 @@ export const factQualitySignals = (fact: ExtractedFact): FactQualitySignals => {
   if ((fact.importance ?? 0) >= 0.7) score += 0.1;
   if (statusOnly) score -= 0.4;
 
+  // Phase 1: fold the LLM's self-judged subject_specificity into the score so
+  // the verifier in Phase 2 can act on it. The verifier itself remains the
+  // structural backstop — this is just a smooth signal.
+  if (typeof fact.subject_specificity === "number") {
+    if (fact.subject_specificity >= 0.7) score += 0.1;
+    else if (fact.subject_specificity < 0.3) score -= 0.2;
+  }
+  if (fact.self_contained === false) score -= 0.15;
+
   return {
     wordCount,
     hasDurableAnchor: durableAnchor,
@@ -440,6 +467,24 @@ export const normalizeExtractedFact = (raw: Record<string, unknown>): ExtractedF
     ? normalizeEntities(raw.entities.map((entity) => String(entity)))
     : [];
 
+  // Self-judgment fields (prompt v2026-04-28-1+)
+  const subject = typeof raw.subject === "string" && raw.subject.trim().length > 0
+    ? raw.subject.trim()
+    : null;
+  const subjectSpecificity = typeof raw.subject_specificity === "number"
+    ? clamp01(raw.subject_specificity)
+    : null;
+  const rawVolatility = typeof raw.volatility === "string" ? raw.volatility.trim().toLowerCase() : null;
+  const volatility: Volatility | null = rawVolatility && VOLATILITY_VALUES.has(rawVolatility as Volatility)
+    ? (rawVolatility as Volatility)
+    : null;
+  const volatilityReason = typeof raw.volatility_reason === "string" && raw.volatility_reason.trim().length > 0
+    ? raw.volatility_reason.trim()
+    : null;
+  const selfContained = typeof raw.self_contained === "boolean" ? raw.self_contained : null;
+  const rawAsOf = typeof raw.as_of === "string" ? raw.as_of.trim() : null;
+  const asOf = rawAsOf && ISO_DATE_RE.test(rawAsOf) ? rawAsOf : null;
+
   const fact: ExtractedFact = {
     content: raw.content.trim(),
     category,
@@ -450,10 +495,16 @@ export const normalizeExtractedFact = (raw: Record<string, unknown>): ExtractedF
     importance,
     quality_score: qualityScore,
     confidence_reason: typeof raw.confidence_reason === "string" ? raw.confidence_reason.trim() : null,
-    repo: typeof raw.repo === "string" ? raw.repo.trim() : null,
+    repo: typeof raw.repo === "string" && raw.repo.trim().length > 0 ? raw.repo.trim() : null,
     branch: typeof raw.branch === "string" ? raw.branch.trim() : null,
     task_key: typeof raw.task_key === "string" ? raw.task_key.trim() : null,
     workstream_key: typeof raw.workstream_key === "string" ? raw.workstream_key.trim() : null,
+    subject,
+    subject_specificity: subjectSpecificity,
+    volatility,
+    volatility_reason: volatilityReason,
+    self_contained: selfContained,
+    as_of: asOf,
   };
 
   return isHighQualityExtractedFact(fact) ? fact : null;
@@ -606,6 +657,17 @@ const storeFacts = async (
         factMeta.subtype_rule_disagreement = subtypeAgreement.ruleSubtype;
         factMeta.subtype_rule_margin = Math.round(subtypeAgreement.margin * 100) / 100;
         effectiveConfidence = clamp01(effectiveConfidence - 0.15);
+      }
+
+      // Phase 1: persist self-judgment fields in metadata. The Phase 2 verifier
+      // wires these into structural decisions (downgrade, expiry, category force).
+      if (sanitizedFact.subject) factMeta.subject = sanitizedFact.subject;
+      if (typeof sanitizedFact.subject_specificity === "number") {
+        factMeta.subject_specificity = Math.round(sanitizedFact.subject_specificity * 100) / 100;
+      }
+      if (sanitizedFact.volatility_reason) factMeta.volatility_reason = sanitizedFact.volatility_reason;
+      if (typeof sanitizedFact.self_contained === "boolean") {
+        factMeta.self_contained = sanitizedFact.self_contained;
       }
 
       const storePayload: StoreFact = {

--- a/src/prompts/extraction.ts
+++ b/src/prompts/extraction.ts
@@ -15,7 +15,7 @@ import { buildOpts, wrapData, type PromptDescriptor, type RenderedPrompt } from 
 
 export const EXTRACTION_PROMPT_DESCRIPTOR: PromptDescriptor = {
   id: "extraction",
-  version: "2026-04-27-1",
+  version: "2026-04-28-1",
 };
 
 const SUBTYPE_REASONING = `## Subtype reasoning (think step-by-step BEFORE picking memory_subtype)
@@ -61,6 +61,56 @@ Example 3 — domain_rule vs preference:
   → memory_subtype: preference (R4: 'I prefer' + 'my style')
   → subtype_reason: "Personal style → BUCKET C → R4 wins → preference."`;
 
+const SELF_JUDGMENT = `## Self-judgment (think step-by-step BEFORE emitting each fact)
+
+For every candidate fact, judge it on three axes. The verifier downstream USES these values, so be honest — bad self-judgment costs the fact its place in memory.
+
+AXIS 1 — subject_specificity (0.0–1.0)
+  Question: Could a future engineer search for the SUBJECT of this fact and find a unique referent in the codebase, infrastructure, or docs?
+  - 1.0 — subject is a typed identifier (file path, service name, env var, command, URL, ADR ref, version)
+  - 0.6 — subject is a named concept that resolves once you know the project (e.g. "the WA collector")
+  - 0.3 — subject is a common noun that needs context to disambiguate (e.g. "the pipeline", "the cronjob")
+  - 0.0 — subject is a pronoun or episode-relative reference (e.g. "Step 2", "this", "the process")
+
+AXIS 2 — volatility (one of: stable | evolving | transient | ephemeral)
+  Question: How long will this fact remain TRUE without re-verification?
+  - stable     — design decisions, conventions, file locations, ownership (years)
+  - evolving   — APIs, schemas, runbooks, configs that change with normal development (months)
+  - transient  — point-in-time state: image tags, "currently running", "in progress", deployed versions (days–weeks)
+  - ephemeral  — debug state, error counts, "PR is open", "the test failed yesterday" (hours)
+  Heuristic: if the truth of the fact depends on WHEN you read it, it is transient or worse.
+  If volatility >= transient you MUST emit "as_of" (today's date) and "category" must be "observations".
+
+AXIS 3 — self_contained (true | false)
+  Question: If a future engineer reads this fact ALONE, with no surrounding transcript, do they know what it refers to?
+  - true  — every noun resolves either to a typed token in the fact, an entity in the entities array, or to common knowledge
+  - false — depends on prior context ("Step 2", "the file mentioned above", "as discussed")
+
+Worked examples (study these — they cover the failure modes the verifier rejects):
+
+  EX1: "The pipeline uses pre-built Docker images pulled from ECR."
+       → subject="the pipeline", subject_specificity=0.2 (which pipeline?), volatility=evolving, self_contained=false
+       → Verifier will REJECT this — the subject does not resolve.
+       Better: "The bikky-dev/bikky CI workflow .github/workflows/release.yml builds Docker images and pushes to ECR."
+       → subject="bikky-dev/bikky/.github/workflows/release.yml", subject_specificity=1.0, self_contained=true.
+
+  EX2: "The correct image tag for the SCB init container should be 097873b."
+       → subject="SCB init container image tag", subject_specificity=0.7, volatility=transient, self_contained=true, as_of=today
+       → Verifier will DOWNGRADE to category=observations with expires_at = today + 30d.
+       Better (if you want it durable): record the SOURCE OF TRUTH instead — "The SCB init container image tag is set in apps/scb/values.yaml under image.tag."
+
+  EX3: "Step 2 is part of the dbt cronjob."
+       → subject="Step 2", subject_specificity=0.0, volatility=ephemeral, self_contained=false
+       → Verifier will REJECT this on both grounding and self-containment.
+
+  EX4: "The deployment process involves building locally, pushing to ECR, and restarting on EC2 via SSM."
+       → subject="the deployment process", subject_specificity=0.3 (whose deployment?), volatility=evolving, self_contained=false
+       → Verifier will REJECT unless you name the repo. Always identify the project: which repo does this deploy?
+
+  EX5: "The dbt-run-cronjob-v100-29617080 cronjob is running the old image."
+       → subject="dbt-run-cronjob-v100-29617080", subject_specificity=1.0, volatility=transient (state), self_contained=true, as_of=today
+       → Verifier will keep as observation with 30d expiry.`;
+
 const QUALITY_GATE = `## Quality gate (apply to EVERY candidate fact)
 A fact must pass AT LEAST ONE of these or it is noise — skip it:
 1. GREPPABLE — contains a file path, service name, config key, CLI flag, or symbol an engineer could search for
@@ -97,19 +147,33 @@ const FORMAT = `## Output format (JSON only — no prose, no markdown fences)
 {"facts": [
   {
     "content": "atomic single-sentence reference; include the specific file/service/command/decision",
+    "subject": "the noun this fact is ABOUT — typically a typed token or named entity",
     "category": "<one of: ${categoryValues().join(" | ")}>",
     "domain":   "<one of: ${domainValues().join(" | ")}>",
     "kind":     "fact",
     "memory_subtype": "<one of: ${memorySubtypeValuesForKind("fact").join(" | ")}>",
     "subtype_reason": "<one short sentence — the bucket walk + which disambiguation rule won>",
+    "subject_specificity": 0.0,
+    "volatility": "<one of: stable | evolving | transient | ephemeral>",
+    "volatility_reason": "<one short sentence — why you chose this volatility>",
+    "self_contained": true,
+    "as_of": "<YYYY-MM-DD — REQUIRED iff volatility is transient or ephemeral; otherwise omit>",
     "entities": ["lowercase", "identifiers"],
+    "repo": "<owner/repo if the fact pertains to a specific repo; otherwise omit>",
     "confidence": 0.9,
     "importance": 0.7
   }
 ]}
 
 Field guidance:
-- category: pick using the taxonomy section above and keep it aligned with memory_subtype. Use "observations" only when no narrower category fits.
+- subject: the principal noun the fact is about. Should appear in or be derivable from "content". For "The CI workflow .github/workflows/release.yml builds Docker images" the subject is ".github/workflows/release.yml". Pronouns and bare common nouns ("the pipeline", "the cronjob") are NOT acceptable subjects.
+- subject_specificity: judged using AXIS 1 above. Be honest — anything below 0.5 will be challenged by the verifier.
+- volatility: judged using AXIS 2 above. Default to "evolving" when unsure; never default to "stable".
+- volatility_reason: one sentence justifying the choice. Mention what would make the fact stop being true.
+- self_contained: judged using AXIS 3 above. If false, the verifier will reject the fact regardless of subject_specificity.
+- as_of: required iff volatility ∈ {transient, ephemeral}. ISO-8601 date only (YYYY-MM-DD).
+- repo: include WHENEVER the fact pertains to a specific codebase, deployment, CI/CD, runbook, or service that lives in a repo. Omit only for cross-repo decisions or pure preferences.
+- category: pick using the taxonomy section above and keep it aligned with memory_subtype. Use "observations" only when no narrower category fits OR when volatility ≥ transient (the verifier will force this anyway).
 - domain: default to "software_engineering" for coding-agent, repo, infra, ops, and developer workflow facts. Use "product_strategy", "business_operations", "research", or "personal_productivity" only when the transcript clearly belongs to that activity profile.
 - kind: always "fact" for this extraction prompt. Summaries, distilled patterns, relations, and telemetry are produced by separate lifecycle paths.
 - memory_subtype: choose the most specific fact subtype and use its default category:
@@ -149,6 +213,8 @@ const buildSystem = (): string => {
     SUBTYPE_REASONING,
     "",
     FEW_SHOTS,
+    "",
+    SELF_JUDGMENT,
     "",
     ALWAYS_SKIP,
     "",


### PR DESCRIPTION
Phase 1 of bikky-dev/bikky#46 fact-grounding plan.

## What

Bumps the daemon extraction prompt to v2026-04-28-1 and asks the LLM to self-judge each candidate fact:

- **subject** — the noun phrase the fact is *about* (e.g. `scb-init`, not `the pipeline`)
- **subject_specificity** — 0–1 confidence the subject is concrete enough to be useful out-of-context
- **volatility** — `stable` | `evolving` | `transient` | `ephemeral`
- **volatility_reason** — short rationale
- **self_contained** — whether the fact stands alone without surrounding context
- **as_of** — YYYY-MM-DD when the observation was captured

The prompt now contains a SELF_JUDGMENT chain-of-thought block + 5 worked examples drawn from the cited bad facts in the issue.

## What's NOT in this PR

The verifier that *acts* on these fields (drops ungrounded facts, expires transient ones, etc.) lands in Phase 2.

## Tests

444 → still green.

Refs #46.