### PR TITLE
feat(extraction): structural grounding gate + volatility coherence (Phase 2 of #46)

### DIFF
--- a/src/daemon/capture-policy.ts
+++ b/src/daemon/capture-policy.ts
@@ -117,7 +117,10 @@ export const DEFAULT_CAPTURE_CONTEXT = {
   domain: DEFAULT_DOMAIN,
   source: "daemon",
   reviewStatus: "candidate",
-  volatility: "medium",
+  // Default fallback volatility when the LLM does not self-judge. Storage path
+  // overrides this with the LLM's value (or the volatility verifier's
+  // synthesised value) — see daemon/extraction.ts storeFacts.
+  volatility: "evolving",
 } as const;
 
 export function promptVersionForSubtype(subtype: MemorySubtype): string {

--- a/src/daemon/extraction-rules.test.ts
+++ b/src/daemon/extraction-rules.test.ts
@@ -81,3 +81,147 @@ test("compareSubtype: agree (no flip) when scores are close — small margin", (
     assert.ok(a.margin >= 0.6, `margin ${a.margin} should be >= 0.6 to disagree`);
   }
 });
+
+// ── Phase 2: grounding + volatility coherence verifiers ─────────────────────
+
+import {
+  hasTypedToken,
+  subjectResolves,
+  verifyGrounding,
+  verifyVolatilityCoherence,
+} from "./extraction-rules.js";
+
+test("hasTypedToken: detects file paths with extensions", () => {
+  assert.ok(hasTypedToken("Smoke tests live in packages/ui/tests/smoke.spec.ts."));
+});
+
+test("hasTypedToken: detects URLs", () => {
+  assert.ok(hasTypedToken("See https://example.com/docs for more."));
+});
+
+test("hasTypedToken: detects backtick code spans", () => {
+  assert.ok(hasTypedToken("Use the `BIKKY_COLLECTION` env var."));
+});
+
+test("hasTypedToken: detects kebab-case identifiers", () => {
+  assert.ok(hasTypedToken("The dbt-run-cronjob-v100 schedules nightly runs."));
+});
+
+test("hasTypedToken: detects camelCase identifiers", () => {
+  assert.ok(hasTypedToken("The factQualitySignals function lives in extraction.ts."));
+});
+
+test("hasTypedToken: rejects pure prose", () => {
+  assert.equal(hasTypedToken("the pipeline uses pre-built images for deployment"), false);
+});
+
+test("subjectResolves: matches by entity inclusion", () => {
+  assert.ok(subjectResolves("the foo cronjob", ["foo"]));
+});
+
+test("subjectResolves: matches when subject is a typed token", () => {
+  assert.ok(subjectResolves("packages/ui/tests/smoke.spec.ts", []));
+});
+
+test("subjectResolves: rejects bare common nouns with no entity match", () => {
+  assert.equal(subjectResolves("the pipeline", ["bikky"]), false);
+});
+
+test("verifyGrounding: rejects ungrounded prose with vague subject", () => {
+  // EX1 from prompt: "The pipeline uses pre-built Docker images pulled from ECR."
+  // No typed token, generic subject — should be REJECTED.
+  const r = verifyGrounding({
+    content: "The pipeline uses pre-built Docker images pulled from ECR.",
+    subject: "the pipeline",
+    subject_specificity: 0.2,
+    self_contained: false,
+    entities: ["docker", "ecr"],
+  });
+  assert.equal(r.verdict, "ungrounded");
+});
+
+test("verifyGrounding: accepts well-grounded fact with typed subject", () => {
+  const r = verifyGrounding({
+    content: "The CI workflow .github/workflows/release.yml builds Docker images.",
+    subject: ".github/workflows/release.yml",
+    subject_specificity: 0.95,
+    self_contained: true,
+    entities: ["bikky-dev/bikky"],
+  });
+  assert.equal(r.verdict, "grounded");
+});
+
+test("verifyGrounding: rejects 'Step 2' style episode-relative subject", () => {
+  // EX3 from prompt: "Step 2 is part of the dbt cronjob."
+  const r = verifyGrounding({
+    content: "Step 2 is part of the dbt cronjob.",
+    subject: "Step 2",
+    subject_specificity: 0.0,
+    self_contained: false,
+    entities: ["dbt"],
+  });
+  assert.equal(r.verdict, "ungrounded");
+});
+
+test("verifyGrounding: downgrades to ambiguous when LLM is mid-confident", () => {
+  // typed token rescues, but LLM only rates 0.4 on subject_specificity.
+  const r = verifyGrounding({
+    content: "The deploy.sh script is the entry point.",
+    subject: "deploy.sh",
+    subject_specificity: 0.4,
+    self_contained: false,
+    entities: [],
+  });
+  // Has typed token (deploy.sh) so not ungrounded; self_contained=false → ambiguous.
+  assert.equal(r.verdict, "ambiguous");
+});
+
+test("verifyVolatilityCoherence: transient gets 30d expiry and observations category", () => {
+  const r = verifyVolatilityCoherence({
+    volatility: "transient",
+    as_of: "2026-04-28",
+    category: "infrastructure",
+  });
+  assert.equal(r.effective, "transient");
+  assert.equal(r.forcedCategory, "observations");
+  assert.equal(r.halfLifeMultiplier, 0.25);
+  assert.ok(r.expiresAt);
+  // 30 days after 2026-04-28 is 2026-05-28
+  assert.ok(r.expiresAt!.startsWith("2026-05-28"));
+});
+
+test("verifyVolatilityCoherence: ephemeral gets 7d expiry and observations category", () => {
+  const r = verifyVolatilityCoherence({
+    volatility: "ephemeral",
+    as_of: "2026-04-28",
+    category: "operations",
+  });
+  assert.equal(r.effective, "ephemeral");
+  assert.equal(r.forcedCategory, "observations");
+  assert.equal(r.halfLifeMultiplier, 0.1);
+  assert.ok(r.expiresAt!.startsWith("2026-05-05"));
+});
+
+test("verifyVolatilityCoherence: stable / evolving leave category alone with no expiry", () => {
+  const stable = verifyVolatilityCoherence({ volatility: "stable", category: "codebase" });
+  assert.equal(stable.expiresAt, null);
+  assert.equal(stable.forcedCategory, null);
+  assert.equal(stable.halfLifeMultiplier, 1.0);
+
+  const evolving = verifyVolatilityCoherence({ volatility: "evolving", category: "infrastructure" });
+  assert.equal(evolving.expiresAt, null);
+  assert.equal(evolving.forcedCategory, null);
+});
+
+test("verifyVolatilityCoherence: synthesises as_of when missing for transient", () => {
+  const r = verifyVolatilityCoherence({ volatility: "transient", category: "observations" });
+  assert.equal(r.effective, "transient");
+  assert.ok(r.expiresAt);
+  assert.ok(r.notes.some((n) => n.includes("as_of synthesised")));
+});
+
+test("verifyVolatilityCoherence: missing volatility defaults to evolving (not stable)", () => {
+  const r = verifyVolatilityCoherence({ category: "codebase" });
+  assert.equal(r.effective, "evolving");
+  assert.ok(r.notes.some((n) => n.includes("defaulted to 'evolving'")));
+});

--- a/src/daemon/extraction-rules.ts
+++ b/src/daemon/extraction-rules.ts
@@ -160,3 +160,271 @@ export const compareSubtype = (
   }
   return { verdict: "agree", ruleSubtype: score.subtype, ruleScore: score.score, margin };
 };
+
+// ── Phase 2: structural grounding + volatility coherence verifiers ──────────
+//
+// These verifiers translate the LLM's self-judged fields (subject_specificity,
+// volatility, self_contained, as_of) into store-time decisions. They are
+// SHAPE-BASED, not vocabulary-based — no hand-curated lists of "vague words"
+// or "transient markers". The detection criteria are:
+//
+//   - typed token shape (path, URL, code-formatted span, identifier shape)
+//   - subject resolution against the entities array
+//   - structural coherence (transient ⇒ as_of present, ephemeral ⇒ observations)
+//
+// The LLM remains source of truth — we only DOWNGRADE/REJECT/FLAG, never
+// silently rewrite content.
+
+export type GroundingVerdict = "grounded" | "ambiguous" | "ungrounded";
+
+export interface GroundingResult {
+  verdict: GroundingVerdict;
+  reason: string;
+  hasTypedToken: boolean;
+  subjectResolves: boolean;
+}
+
+/**
+ * Shape-based typed-token detector. A "typed token" is any substring that an
+ * engineer could plausibly grep for and find a unique referent: file paths,
+ * URLs, code-formatted spans, version strings, issue/PR refs, identifier-shaped
+ * names (kebab-case / snake_case / dotted / camelCase ≥ 3 chars).
+ *
+ * Intentionally shape-only — no hardcoded tool/service vocabulary.
+ */
+export const hasTypedToken = (content: string): boolean => {
+  const text = content || "";
+  return Boolean(
+    // Backtick-quoted code spans
+    /`[^`\n]{2,}`/.test(text) ||
+    // URLs
+    /\bhttps?:\/\/\S+/.test(text) ||
+    // File paths (slash-separated with at least one segment containing a dot OR ≥ 3 segments)
+    /(?:^|[\s(])(?:[\w.-]+\/){1,}[\w.-]+\.[a-z0-9]{1,8}(?=[\s),.;:]|$)/i.test(text) ||
+    /(?:^|[\s(])(?:[\w.-]+\/){2,}[\w.-]+(?=[\s),.;:]|$)/.test(text) ||
+    // Filenames with extension (no slash)
+    /\b[\w.-]+\.(?:[a-z]{1,4}|ya?ml|toml|json|sql|md)\b/i.test(text) ||
+    // Issue / PR refs
+    /(?:^|[\s(])#\d{2,}\b/.test(text) ||
+    /\b(?:issue|pr|pull[- ]request)\s*#?\d+\b/i.test(text) ||
+    // Version strings (semver-ish or hash-ish)
+    /\bv?\d+\.\d+(?:\.\d+)?(?:[-+][\w.]+)?\b/.test(text) ||
+    /\b[0-9a-f]{7,40}\b/.test(text) ||
+    // Constant-case identifiers (≥ 3 chars)
+    /\b[A-Z][A-Z0-9_]{2,}\b/.test(text) ||
+    // Dotted identifiers (a.b.c) — service names, package paths
+    /\b[a-z][\w-]*(?:\.[\w-]+){2,}\b/.test(text) ||
+    // Kebab/snake identifiers ≥ 8 chars containing a digit OR ≥ 2 separators
+    // (filters out plain English compounds like "pre-built", "high-quality")
+    /\b[a-z][a-z0-9]*[-_][a-z0-9-_]{4,}\b(?=.*\d|.*[-_].*[-_])/.test(text) ||
+    // CamelCase identifiers (≥ 2 humps)
+    /\b[A-Z][a-z0-9]+[A-Z][A-Za-z0-9]+\b/.test(text),
+  );
+};
+
+/**
+ * Returns true iff `subject` either:
+ *   - looks like a typed token itself, OR
+ *   - matches (case-insensitively) one of the entities the LLM extracted, OR
+ *   - is a substring of one of the entities (or vice versa) — handles
+ *     "the foo cronjob" vs entity "foo".
+ *
+ * Intentionally permissive — we want to catch the ungrounded cases, not
+ * second-guess every wording choice.
+ */
+export const subjectResolves = (
+  subject: string | null | undefined,
+  entities: ReadonlyArray<string>,
+): boolean => {
+  const s = (subject || "").trim();
+  if (!s) return false;
+  if (hasTypedToken(s)) return true;
+
+  const sLower = s.toLowerCase();
+  for (const entity of entities) {
+    const e = entity.toLowerCase();
+    if (!e) continue;
+    if (sLower === e) return true;
+    if (sLower.includes(e) && e.length >= 3) return true;
+    if (e.includes(sLower) && sLower.length >= 3) return true;
+  }
+  return false;
+};
+
+export interface GroundingInput {
+  content: string;
+  subject?: string | null;
+  subject_specificity?: number | null;
+  self_contained?: boolean | null;
+  entities: ReadonlyArray<string>;
+}
+
+/**
+ * Structural grounding gate. Combines:
+ *   - typed-token presence in `content`
+ *   - subject resolution against typed tokens or entities
+ *   - LLM's own subject_specificity self-grade
+ *   - LLM's own self_contained self-grade
+ *
+ * Verdict semantics (consumed by storeFacts):
+ *   - grounded   → no action, store as-is
+ *   - ambiguous  → keep, but lower confidence and flag in metadata
+ *   - ungrounded → drop entirely
+ */
+export const verifyGrounding = (input: GroundingInput): GroundingResult => {
+  const typed = hasTypedToken(input.content);
+  const subjectOk = subjectResolves(input.subject, input.entities);
+  const specificity = typeof input.subject_specificity === "number"
+    ? input.subject_specificity
+    : null;
+  const selfContained = input.self_contained;
+
+  // Hard reject conditions:
+  //   1. The fact carries no typed token AND its subject does not resolve.
+  //   2. The LLM rated subject_specificity below 0.3 AND the subject does not
+  //      resolve to entities — a typed token elsewhere in `content` is NOT
+  //      enough to rescue a vague subject (the subject is what the fact is
+  //      ABOUT, the rest of the content is supporting detail).
+  //   3. The LLM said the fact is not self-contained AND nothing rescues it.
+  if (!typed && !subjectOk) {
+    return {
+      verdict: "ungrounded",
+      reason: "no typed token and subject does not resolve to entities",
+      hasTypedToken: typed,
+      subjectResolves: subjectOk,
+    };
+  }
+  if (specificity !== null && specificity < 0.3 && !subjectOk) {
+    return {
+      verdict: "ungrounded",
+      reason: `LLM self-rated subject_specificity=${specificity}; subject does not resolve to entities`,
+      hasTypedToken: typed,
+      subjectResolves: subjectOk,
+    };
+  }
+  if (selfContained === false && !subjectOk) {
+    return {
+      verdict: "ungrounded",
+      reason: "LLM marked self_contained=false and subject does not resolve to entities",
+      hasTypedToken: typed,
+      subjectResolves: subjectOk,
+    };
+  }
+
+  // Soft downgrade: subject resolves but LLM is not confident.
+  if (specificity !== null && specificity < 0.5) {
+    return {
+      verdict: "ambiguous",
+      reason: `LLM self-rated subject_specificity=${specificity}`,
+      hasTypedToken: typed,
+      subjectResolves: subjectOk,
+    };
+  }
+  if (selfContained === false) {
+    return {
+      verdict: "ambiguous",
+      reason: "LLM marked self_contained=false but subject resolves to entities",
+      hasTypedToken: typed,
+      subjectResolves: subjectOk,
+    };
+  }
+
+  return {
+    verdict: "grounded",
+    reason: "typed token present and/or subject resolves",
+    hasTypedToken: typed,
+    subjectResolves: subjectOk,
+  };
+};
+
+export type Volatility = "stable" | "evolving" | "transient" | "ephemeral";
+
+export interface VolatilityInput {
+  volatility?: Volatility | null;
+  as_of?: string | null;
+  category?: string | null;
+}
+
+export interface VolatilityCoherenceResult {
+  /** Effective volatility after coherence checks (may be downgraded). */
+  effective: Volatility;
+  /** Effective category after coherence checks (may be forced to observations). */
+  forcedCategory: string | null;
+  /** Computed expires_at ISO timestamp, or null for stable/evolving. */
+  expiresAt: string | null;
+  /** valid_from anchor — `as_of` if supplied, else now. */
+  validFrom: string;
+  /** Half-life multiplier consumed by the recall ranker (Phase 3). */
+  halfLifeMultiplier: number;
+  /** Reasons applied during coherence checks, for metadata audit. */
+  notes: string[];
+}
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const isoDateOnly = (d: Date): string => d.toISOString().slice(0, 10);
+
+const addDaysIso = (anchor: string, days: number): string => {
+  const base = ISO_DATE_RE.test(anchor) ? new Date(`${anchor}T00:00:00Z`) : new Date();
+  return new Date(base.getTime() + days * DAY_MS).toISOString();
+};
+
+/**
+ * Translate the LLM's self-judged volatility into structural decisions:
+ *   - transient  → expires_at = as_of + 30d, force category=observations,
+ *                  half-life × 0.25
+ *   - ephemeral  → expires_at = as_of + 7d, force category=observations,
+ *                  half-life × 0.1
+ *   - stable     → no expiry, half-life × 1.0
+ *   - evolving   → no expiry, half-life × 1.0 (default)
+ *
+ * If the LLM emitted no volatility, defaults to "evolving" (NOT "stable") —
+ * we err on the side of letting decay do its job.
+ *
+ * If volatility >= transient and `as_of` is missing, we fall back to today
+ * and note the synthesis in the audit metadata.
+ */
+export const verifyVolatilityCoherence = (input: VolatilityInput): VolatilityCoherenceResult => {
+  const notes: string[] = [];
+  const effective: Volatility = input.volatility ?? "evolving";
+  if (!input.volatility) notes.push("volatility defaulted to 'evolving' (LLM omitted)");
+
+  let asOf = input.as_of && ISO_DATE_RE.test(input.as_of) ? input.as_of : null;
+  if ((effective === "transient" || effective === "ephemeral") && !asOf) {
+    asOf = isoDateOnly(new Date());
+    notes.push(`as_of synthesised to ${asOf} (LLM omitted but volatility=${effective})`);
+  }
+  const validFrom = asOf
+    ? new Date(`${asOf}T00:00:00Z`).toISOString()
+    : new Date().toISOString();
+
+  let expiresAt: string | null = null;
+  let halfLifeMultiplier = 1.0;
+  let forcedCategory: string | null = null;
+
+  if (effective === "transient") {
+    expiresAt = addDaysIso(asOf ?? isoDateOnly(new Date()), 30);
+    halfLifeMultiplier = 0.25;
+    if (input.category && input.category !== "observations") {
+      forcedCategory = "observations";
+      notes.push(`category forced to observations (was ${input.category}) — volatility=transient`);
+    }
+  } else if (effective === "ephemeral") {
+    expiresAt = addDaysIso(asOf ?? isoDateOnly(new Date()), 7);
+    halfLifeMultiplier = 0.1;
+    if (input.category && input.category !== "observations") {
+      forcedCategory = "observations";
+      notes.push(`category forced to observations (was ${input.category}) — volatility=ephemeral`);
+    }
+  }
+
+  return {
+    effective,
+    forcedCategory,
+    expiresAt,
+    validFrom,
+    halfLifeMultiplier,
+    notes,
+  };
+};

--- a/src/daemon/extraction.ts
+++ b/src/daemon/extraction.ts
@@ -38,7 +38,7 @@ import {
   subtypeForCategory,
 } from "./capture-policy.js";
 import { shouldSummarizeEvents, updateSessionSummary } from "./session-summary.js";
-import { compareSubtype } from "./extraction-rules.js";
+import { compareSubtype, hasTypedToken, verifyGrounding, verifyVolatilityCoherence } from "./extraction-rules.js";
 
 // ── Module state ─────────────────────────────────────────────────────────────
 
@@ -385,18 +385,12 @@ const clamp01 = (value: number): number => Math.max(0, Math.min(1, value));
 
 const textWordCount = (text: string): number => text.trim().split(/\s+/).filter(Boolean).length;
 
+// Shape-based "anchor" check used by the quality-signals score. Delegates to
+// the typed-token detector in extraction-rules.ts (no hardcoded tool/service
+// vocabulary). The legacy entity-count rescue is preserved as a structural
+// signal (≥ 2 entities = likely well-grounded).
 const hasDurableAnchor = (content: string, entities: string[]): boolean => {
-  const text = content.trim();
-  return Boolean(
-    /(?:^|\s)(?:[\w.-]+\/)+[\w./-]+/.test(text) ||
-    /`[^`]+`/.test(text) ||
-    /\b(?:npm|pnpm|yarn|node|git|gh|docker|kubectl|make|go|python|pip|cargo|terraform|aws|curl)\b/.test(text) ||
-    /https?:\/\/\S+/.test(text) ||
-    /\b[A-Z][A-Z0-9_]{2,}\b/.test(text) ||
-    /\b[\w.-]+\.(?:ts|tsx|js|jsx|mjs|cjs|py|go|rs|java|kt|rb|php|json|ya?ml|toml|md|sql|sh)\b/.test(text) ||
-    /\b(?:issue|pr|pull request)\s*#?\d+\b/i.test(text) ||
-    entities.length >= 2,
-  );
+  return hasTypedToken(content) || entities.length >= 2;
 };
 
 const isStatusOnlyContent = (content: string, entities: string[]): boolean => {
@@ -643,11 +637,39 @@ const storeFacts = async (
       const subtype = validateMemorySubtype("fact", sanitizedFact.memory_subtype)
         ?? subtypeForCategory(normalizeCategory(sanitizedFact.category));
 
-      // Verifier: rule-table check on subtype. If rule table is confident in
-      // a *different* subtype with a margin >= 0.6, treat the LLM as suspect:
-      // keep its choice (LLM is still source of truth) but lower confidence
-      // and stash the disagreement in metadata for human review.
-      const subtypeAgreement = compareSubtype(sanitizedFact.content, subtype);
+      // Phase 2 verifier: structural grounding gate. Translates the LLM's
+      // self-judgment into a hard verdict using shape-based checks (typed
+      // tokens, entity resolution) — no vocabulary lists.
+      const grounding = verifyGrounding({
+        content: sanitizedFact.content,
+        subject: sanitizedFact.subject,
+        subject_specificity: sanitizedFact.subject_specificity,
+        self_contained: sanitizedFact.self_contained,
+        entities: sanitizedFact.entities,
+      });
+
+      if (grounding.verdict === "ungrounded") {
+        logFn(
+          "DEBUG",
+          `Extraction: dropping ungrounded fact: "${sanitizedFact.content.slice(0, 80)}…" — ${grounding.reason}`,
+        );
+        continue;
+      }
+
+      // Phase 2 verifier: volatility coherence. Translates the LLM's
+      // self-judged volatility + as_of into expires_at, valid_from, and
+      // category-force decisions.
+      const volatility = verifyVolatilityCoherence({
+        volatility: sanitizedFact.volatility,
+        as_of: sanitizedFact.as_of,
+        category: sanitizedFact.category,
+      });
+      const effectiveCategory = volatility.forcedCategory ?? sanitizedFact.category;
+      const effectiveSubtype = volatility.forcedCategory
+        ? subtypeForCategory(normalizeCategory(volatility.forcedCategory))
+        : subtype;
+
+      const subtypeAgreement = compareSubtype(sanitizedFact.content, effectiveSubtype);
       const factMeta: Record<string, string | number | boolean | null> = { ...baseMeta };
       let effectiveConfidence = fact.confidence;
       if (sanitizedFact.subtype_reason) {
@@ -659,8 +681,7 @@ const storeFacts = async (
         effectiveConfidence = clamp01(effectiveConfidence - 0.15);
       }
 
-      // Phase 1: persist self-judgment fields in metadata. The Phase 2 verifier
-      // wires these into structural decisions (downgrade, expiry, category force).
+      // Persist self-judgment fields in metadata for audit / future training.
       if (sanitizedFact.subject) factMeta.subject = sanitizedFact.subject;
       if (typeof sanitizedFact.subject_specificity === "number") {
         factMeta.subject_specificity = Math.round(sanitizedFact.subject_specificity * 100) / 100;
@@ -669,24 +690,41 @@ const storeFacts = async (
       if (typeof sanitizedFact.self_contained === "boolean") {
         factMeta.self_contained = sanitizedFact.self_contained;
       }
+      if (sanitizedFact.as_of) factMeta.as_of = sanitizedFact.as_of;
+      factMeta.has_typed_token = grounding.hasTypedToken;
+      factMeta.subject_resolves = grounding.subjectResolves;
+      factMeta.half_life_multiplier = volatility.halfLifeMultiplier;
+      if (volatility.notes.length > 0) {
+        factMeta.volatility_notes = volatility.notes.join("; ");
+      }
+
+      let reviewStatus: string = DEFAULT_CAPTURE_CONTEXT.reviewStatus;
+      if (grounding.verdict === "ambiguous") {
+        effectiveConfidence = clamp01(effectiveConfidence - 0.2);
+        factMeta.grounding_verdict = "ambiguous";
+        factMeta.grounding_reason = grounding.reason;
+        reviewStatus = "candidate";
+      }
 
       const storePayload: StoreFact = {
         content: sanitizedFact.content,
-        category: sanitizedFact.category,
+        category: effectiveCategory,
         domain: DEFAULT_CAPTURE_CONTEXT.domain,
-        memory_subtype: subtype,
+        memory_subtype: effectiveSubtype,
         entities: sanitizedFact.entities,
         source: "daemon",
         kind: "fact",
         confidence: effectiveConfidence,
         importance: fact.importance,
         content_hash: hash,
-        prompt_version: promptVersionForSubtype(subtype),
+        prompt_version: promptVersionForSubtype(effectiveSubtype),
         capture_policy_version: CAPTURE_POLICY_VERSION,
         quality_score: fact.quality_score ?? factQualitySignals(fact).computedQualityScore,
         confidence_reason: fact.confidence_reason,
-        review_status: DEFAULT_CAPTURE_CONTEXT.reviewStatus,
-        volatility: DEFAULT_CAPTURE_CONTEXT.volatility,
+        review_status: reviewStatus,
+        volatility: volatility.effective,
+        valid_from: volatility.validFrom,
+        expires_at: volatility.expiresAt,
         repo: fact.repo,
         branch: fact.branch,
         task_key: fact.task_key,


### PR DESCRIPTION
Phase 2 of #46 — stacked on #47.

## What

Adds two new structural verifiers in `src/daemon/extraction-rules.ts` and wires them into `storeFacts`:

### `verifyGrounding`
Decides whether a candidate fact is concrete enough to store, using **shape-based** signals only — no hardcoded vocabulary:
- `hasTypedToken` — backtick spans, URLs, file paths with extensions, version strings, hex IDs, CONST_CASE, dotted identifiers, kebab/snake (≥8 chars with digit OR ≥2 separators), CamelCase
- `subjectResolves` — whether the LLM-supplied subject is itself a typed token, exact-matches an entity, or substring-matches one
- Verdict: `grounded` | `ambiguous` (-0.2 confidence + candidate) | `ungrounded` (drop)

### `verifyVolatilityCoherence`
For `transient` / `ephemeral` facts: synthesises an `as_of` if missing, sets an `expires_at` (T+30d / T+7d), and forces `category=observations` so they don't pollute durable categories.

## Design constraint honored
Per @saberzrelli's guidance: zero hardcoded keyword lists. The previous `hasDurableAnchor` had `(npm|kubectl|docker|...)` — replaced with the shape detector.

## Tests
462 passing (+18 verifier cases). Notable: kebab gate had to require a digit OR ≥2 separators so plain compounds like `pre-built` don't false-positive as typed tokens.

Refs #46.