### PR TITLE
feat(extraction): bad-exemplar centroid via memory_forget (Phase 4 of #46)

### DIFF
--- a/src/daemon/extraction.ts
+++ b/src/daemon/extraction.ts
@@ -706,6 +706,28 @@ const storeFacts = async (
         reviewStatus = "candidate";
       }
 
+      // Phase 4: bad-exemplar centroid check. Compares against facts the
+      // user has previously called memory_forget on — if cosine ≥ 0.85,
+      // we've seen something like this before and the user rejected it.
+      // Downgrade to candidate with reduced confidence rather than dropping
+      // outright: similarity is a soft signal, not a hard reject.
+      try {
+        const badMatch = await qdrant.badExemplarCheck(sanitizedFact.content);
+        if (badMatch && badMatch.score >= 0.85) {
+          effectiveConfidence = clamp01(effectiveConfidence - 0.2);
+          reviewStatus = "candidate";
+          factMeta.bad_exemplar_match_id = badMatch.exemplarId;
+          factMeta.bad_exemplar_score = Math.round(badMatch.score * 1000) / 1000;
+          if (badMatch.reason) factMeta.bad_exemplar_reason = badMatch.reason;
+          logFn(
+            "DEBUG",
+            `Extraction: bad-exemplar match (score=${badMatch.score.toFixed(3)}) for "${sanitizedFact.content.slice(0, 60)}..."`,
+          );
+        }
+      } catch (e) {
+        logFn("WARN", `Extraction: bad-exemplar check failed: ${(e as Error).message}`);
+      }
+
       const storePayload: StoreFact = {
         content: sanitizedFact.content,
         category: effectiveCategory,

--- a/src/daemon/qdrant.ts
+++ b/src/daemon/qdrant.ts
@@ -516,6 +516,45 @@ const dedupCheck = async (
   }
 };
 
+/**
+ * Check whether incoming content is similar to any fact previously marked as a
+ * bad exemplar (via memory_forget). Returns the top similarity score, or null
+ * if no bad exemplars are nearby.
+ *
+ * Bad exemplars act as a data-driven "what we've already rejected" centroid.
+ * No hardcoded vocabulary — purely embedding-similarity based, and the
+ * exemplar set grows organically every time a user calls memory_forget.
+ */
+const badExemplarCheck = async (
+  content: string,
+  workspaceId?: string,
+): Promise<{ score: number; exemplarId: string; reason?: string } | null> => {
+  try {
+    const vector = await embed(content);
+    const must: Record<string, unknown>[] = [
+      { key: "is_bad_exemplar", match: { value: true } },
+    ];
+    if (workspaceId) must.push({ key: "workspace_id", match: { value: workspaceId } });
+    const result = await qdrantRequest("POST", `/collections/${collection}/points/search`, {
+      vector,
+      filter: { must },
+      limit: 1,
+      with_payload: true,
+    }) as { result?: Array<{ id: string; score: number; payload?: Partial<QdrantPayload> }> };
+    const top = result.result?.[0];
+    if (!top) return null;
+    return {
+      score: top.score,
+      exemplarId: top.id,
+      reason: (top.payload as { bad_exemplar_reason?: string } | undefined)?.bad_exemplar_reason,
+    };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    logFn("WARN", `Qdrant bad-exemplar check failed: ${msg}`);
+    return null; // fail open
+  }
+};
+
 // ---------------------------------------------------------------------------
 // Exports
 // ---------------------------------------------------------------------------
@@ -534,5 +573,6 @@ export {
   supersedeFact,
   reinforceFact,
   dedupCheck,
+  badExemplarCheck,
   collection,
 };

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1042,6 +1042,13 @@ export function registerTools(mcp: McpServer): void {
           superseded_by: `forgotten:${redactedReason.text}`,
           superseded_at: now,
           updated_at: now,
+          // Mark this fact's vector as a bad-exemplar centroid: future
+          // candidates with high cosine similarity will be auto-flagged
+          // for review. Forgotten facts keep their original vector — the
+          // is_bad_exemplar payload flag opts them into the centroid set
+          // without requiring a new point.
+          is_bad_exemplar: true,
+          bad_exemplar_reason: redactedReason.text,
         });
         return { content: [{ type: "text", text: JSON.stringify({
           status: "forgotten",


### PR DESCRIPTION
Phase 4 of #46 — stacked on #49.

## What

Turns every `memory_forget` call into a learning signal:

- When a fact is forgotten, we now also flip `is_bad_exemplar=true` and store `bad_exemplar_reason` on its existing Qdrant point — no new vector inserted, we reuse the embedding we already have.
- New `badExemplarCheck` in `daemon/qdrant.ts` runs a vector search filtered to `is_bad_exemplar=true`. If a new candidate fact has cosine similarity ≥ 0.85 to any forgotten fact, it gets -0.2 confidence and is routed to `candidate` (not auto-stored).

This is the **data-driven** alternative to a hardcoded "bad pattern" list — the user explicitly rejected wordlists like `[this, that, pipeline, process, deployment]`. Instead, the system *learns* what bad looks like from real human forget actions.

## Tests
465 passing.

Refs #46.