### PR TITLE
fix(ui): exclude entity_type sidecar points from search/browse

### DIFF
--- a/packages/ui/src/lib/qdrant.ts
+++ b/packages/ui/src/lib/qdrant.ts
@@ -50,6 +50,7 @@ export interface FilterCondition {
 
 export interface QdrantFilter {
   must: FilterCondition[];
+  must_not?: FilterCondition[];
 }
 
 interface ScrollResult {
@@ -153,8 +154,10 @@ export function buildFilter(opts: {
   since?: string;
   until?: string;
   excludeSuperseded?: boolean;
+  excludeEntityType?: boolean;
 }): QdrantFilter {
   const must: FilterCondition[] = [];
+  const must_not: FilterCondition[] = [];
   if (opts.excludeSuperseded === true) must.push({ is_null: { key: "superseded_by" } });
   if (opts.category) must.push({ key: "category", match: { value: opts.category } });
   if (opts.domain) must.push({ key: "domain", match: { value: opts.domain } });
@@ -163,7 +166,11 @@ export function buildFilter(opts: {
   if (opts.source) must.push({ key: "source", match: { value: opts.source } });
   if (opts.since) must.push({ key: "created_at", range: { gte: opts.since } });
   if (opts.until) must.push({ key: "created_at", range: { lte: opts.until } });
-  return { must };
+  // Phase 5a entity_type sidecar points are not user-facing facts; opt-in to exclude.
+  if (opts.excludeEntityType === true && opts.kind !== "entity_type") {
+    must_not.push({ key: "kind", match: { value: "entity_type" } });
+  }
+  return must_not.length > 0 ? { must, must_not } : { must };
 }
 
 // --- Factory ---

--- a/packages/ui/src/routes/memory.ts
+++ b/packages/ui/src/routes/memory.ts
@@ -64,10 +64,12 @@ memoryRoutes.get("/search", async (c) => {
     domain: c.req.query("domain"),
     kind: c.req.query("kind"),
     entity: c.req.query("entity"),
+    excludeEntityType: true,
   });
 
   const limit = Math.min(parseInt(c.req.query("limit") || "20", 10), 100);
-  const points = await qdrant.search(vector, filter.must.length > 0 ? filter : undefined, limit);
+  const hasFilter = filter.must.length > 0 || (filter.must_not?.length ?? 0) > 0;
+  const points = await qdrant.search(vector, hasFilter ? filter : undefined, limit);
 
   return c.json({ results: points.map(formatPoint), count: points.length });
 });
@@ -84,6 +86,7 @@ memoryRoutes.get("/browse", async (c) => {
     source: c.req.query("source"),
     since: c.req.query("since"),
     until: c.req.query("until"),
+    excludeEntityType: true,
   });
 
   const limit = Math.min(parseInt(c.req.query("limit") || "20", 10), 100);


### PR DESCRIPTION
## Bug

Phase 5a entity_type sidecar points (kind=`entity_type`) were leaking into `/api/memory/search` and `/api/memory/browse`. They lack the standard fact payload, causing FactCard.tsx to crash with:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'length')
```

## Fix

- Extend `QdrantFilter` with optional `must_not`
- Add opt-in `excludeEntityType: true` flag to `buildFilter`
- Apply on `/search` and `/browse` routes (entity-type lookups in `/entity-types` and `/entities/:name` keep the original behaviour)

## Verified

- `node --test dist/lib/qdrant.test.js` → 19 pass
- Local UI restarted; `curl /api/memory/browse?sort=newest` now returns `kind=fact` only