### PR TITLE
feat(ui): show entity types in list view + provenance metadata on detail page

### DIFF
--- a/packages/ui/app/src/components/FactCard.tsx
+++ b/packages/ui/app/src/components/FactCard.tsx
@@ -1,4 +1,5 @@
 import Badge from "./Badge";
+import { EntityChip } from "./EntityChip";
 import { relativeTime, truncate, CATEGORY_COLORS, KIND_COLORS } from "../lib/format";
 
 export interface Fact {
@@ -16,6 +17,12 @@ export interface Fact {
   relation_type?: string;
   to_entity?: string;
   score?: number | null;
+  session_id?: string;
+  workstream_key?: string;
+  task_key?: string;
+  episode_id?: string;
+  repo?: string;
+  branch?: string;
 }
 
 interface FactCardProps {
@@ -43,12 +50,7 @@ export default function FactCard({ fact, onClick }: FactCardProps) {
           <Badge label={fact.domain} color="green" />
         )}
         {fact.entities.map((e) => (
-          <span
-            key={e}
-            className="inline-flex items-center px-2 py-0.5 rounded text-xs text-zinc-400 bg-zinc-800"
-          >
-            {e}
-          </span>
+          <EntityChip key={e} name={e} link={false} />
         ))}
       </div>
 
@@ -56,7 +58,22 @@ export default function FactCard({ fact, onClick }: FactCardProps) {
         <span>{relativeTime(fact.created_at)}</span>
         <span>{Math.round(fact.confidence * 100)}% conf</span>
         {fact.score != null && <span>score {fact.score.toFixed(3)}</span>}
+        {fact.workstream_key && <ProvChip label="ws" value={fact.workstream_key} />}
+        {fact.task_key && <ProvChip label="task" value={fact.task_key} />}
+        {fact.repo && <ProvChip label="repo" value={fact.repo} />}
+        {fact.branch && <ProvChip label="branch" value={fact.branch} />}
+        {fact.session_id && <ProvChip label="session" value={fact.session_id.slice(0, 8)} />}
+        {fact.episode_id && <ProvChip label="episode" value={fact.episode_id.slice(0, 8)} />}
       </div>
     </button>
+  );
+}
+
+function ProvChip({ label, value }: { label: string; value: string }) {
+  return (
+    <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-zinc-800/60 text-zinc-400">
+      <span className="text-[10px] uppercase tracking-wide opacity-70">{label}</span>
+      <span className="font-mono text-[11px]">{value}</span>
+    </span>
   );
 }

--- a/packages/ui/app/src/pages/MemoryFact.tsx
+++ b/packages/ui/app/src/pages/MemoryFact.tsx
@@ -294,6 +294,50 @@ export default function MemoryFact() {
             <p className="text-zinc-500 font-mono text-xs truncate">{fact.id}</p>
           </div>
         </div>
+
+        <ProvenanceSection fact={fact} />
+      </div>
+    </div>
+  );
+}
+
+function ProvenanceSection({ fact }: { fact: Fact }) {
+  const fields: { label: string; value: string; render?: JSX.Element }[] = [];
+  if (fact.workstream_key) fields.push({ label: "Workstream", value: fact.workstream_key });
+  if (fact.task_key) fields.push({ label: "Task", value: fact.task_key });
+  if (fact.repo) {
+    const isGhRepo = /^[\w.-]+\/[\w.-]+$/.test(fact.repo);
+    fields.push({
+      label: "Repo",
+      value: fact.repo,
+      render: isGhRepo ? (
+        <a
+          href={`https://github.com/${fact.repo}`}
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-400 hover:underline font-mono text-xs"
+        >
+          {fact.repo}
+        </a>
+      ) : undefined,
+    });
+  }
+  if (fact.branch) fields.push({ label: "Branch", value: fact.branch });
+  if (fact.episode_id) fields.push({ label: "Episode", value: fact.episode_id });
+  if (fact.session_id) fields.push({ label: "Session", value: fact.session_id });
+
+  if (fields.length === 0) return null;
+
+  return (
+    <div className="mt-6 pt-4 border-t border-zinc-800">
+      <p className="text-xs text-zinc-500 mb-2">Provenance</p>
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 text-sm">
+        {fields.map((f) => (
+          <div key={f.label}>
+            <p className="text-xs text-zinc-500">{f.label}</p>
+            {f.render ?? <p className="text-zinc-300 font-mono text-xs break-all">{f.value}</p>}
+          </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #56

## Changes
- **FactCard**: replace plain entity spans with `<EntityChip>` (colored, type-aware). Add a small chip row for any populated provenance field (workstream/task/repo/branch/session/episode); session & episode IDs truncated to 8 chars.
- **MemoryFact**: add a Provenance section below the Metadata grid. Repo shaped `owner/name` becomes a GitHub link.
- Section/chips render only when fields are populated — no "None" clutter.

## Verified
- `npm run build` succeeds (tsc + vite)