### PR TITLE
feat(daemon): harden watcher path config + extraction health metric (#58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ export QDRANT_URL="http://localhost:6333"
 # export QDRANT_API_KEY="…"   # only for Qdrant Cloud / authenticated self-hosted
 ```
 
+> 💡 **Tip:** Set `BIKKY_HOME` to relocate the config dir (defaults to `~/.bikky/`). Useful for tests, multiple profiles, or sandboxed setups.
+
 > 📖 **Full configuration reference** — providers, models, daemon settings, env vars, copy-paste examples for every stack: **[docs/configuration.md](docs/configuration.md)**
 >
 > 🛠 Want to add a new embedding or LLM provider (Vertex, OpenRouter, etc.)? See **[CONTRIBUTING.md](CONTRIBUTING.md)** — it's a single-file change.

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,16 +1,22 @@
 /**
  * Tests for the config system.
  *
- * Strategy: we backup/restore ~/.bikky/config.json around file-based tests
- * and use env var overrides + resetConfig() for env-var tests.
+ * Uses BIKKY_HOME to point at an isolated tempdir for the entire test file —
+ * this prevents saveConfig() from clobbering the user's real ~/.bikky/config.json
+ * if a test crashes mid-run (root cause of issue #58).
  */
 
 import { describe, it, before, after, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
+import os from "node:os";
 
-import {
+// Set BIKKY_HOME *before* importing config so all derived paths use it.
+const TEST_BIKKY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-home-config-"));
+process.env.BIKKY_HOME = TEST_BIKKY_HOME;
+
+const {
   loadConfig,
   resetConfig,
   saveConfig,
@@ -19,10 +25,10 @@ import {
   LOG_DIR,
   STATE_DIR,
   CONFIG_DEFAULTS,
-} from "./config.js";
+} = await import("./config.js");
 
 // ---------------------------------------------------------------------------
-// Helpers: backup & restore any existing config
+// Helpers: backup & restore any existing config (now scoped to BIKKY_HOME tempdir)
 // ---------------------------------------------------------------------------
 
 let originalConfig: string | null = null;
@@ -98,6 +104,7 @@ describe("config", () => {
   after(() => {
     restoreConfig();
     restoreEnv();
+    fs.rmSync(TEST_BIKKY_HOME, { recursive: true, force: true });
   });
 
   beforeEach(() => {
@@ -113,8 +120,8 @@ describe("config", () => {
   // ── Path exports ──────────────────────────────────────────────────────────
 
   describe("path exports", () => {
-    it("BIKKY_DIR is under home directory", () => {
-      assert.ok(BIKKY_DIR.includes(".bikky"));
+    it("BIKKY_DIR honours BIKKY_HOME env var", () => {
+      assert.strictEqual(BIKKY_DIR, TEST_BIKKY_HOME);
     });
 
     it("CONFIG_PATH is config.json inside BIKKY_DIR", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,11 +13,16 @@ import os from "node:os";
 // Paths
 // ---------------------------------------------------------------------------
 
-export const BIKKY_DIR = path.join(os.homedir(), ".bikky");
+// BIKKY_HOME env var lets tests (and advanced users) override the config dir
+// without touching the real ~/.bikky/. Tests MUST set this to an isolated
+// tempdir before importing this module — otherwise saveConfig() will write to
+// the user's real config file.
+export const BIKKY_DIR = process.env.BIKKY_HOME ?? path.join(os.homedir(), ".bikky");
 export const CONFIG_PATH = path.join(BIKKY_DIR, "config.json");
 export const LOG_DIR = path.join(BIKKY_DIR, "logs");
 export const STATE_DIR = path.join(BIKKY_DIR, "state");
 export const PID_PATH = path.join(STATE_DIR, "daemon.pid");
+export const EXTRACTION_HEALTH_PATH = path.join(STATE_DIR, "extraction-health.json");
 
 // ---------------------------------------------------------------------------
 // Config types

--- a/src/daemon/extraction.ts
+++ b/src/daemon/extraction.ts
@@ -12,7 +12,7 @@ import { createHash } from "node:crypto";
 import { join } from "node:path";
 import { glob } from "node:fs/promises";
 
-import { loadConfig, STATE_DIR } from "../config.js";
+import { loadConfig, STATE_DIR, EXTRACTION_HEALTH_PATH } from "../config.js";
 import type { BikkyConfig } from "../config.js";
 import * as qdrant from "./qdrant.js";
 import { chatCompletion } from "../llm/index.js";
@@ -822,6 +822,8 @@ export const tick = async (config: BikkyConfig): Promise<void> => {
     const aliveMappings = lockMappings.filter(m => isProcessAlive(m.pid));
     logFn("INFO", `Extraction tick: ${aliveMappings.length} active copilot session(s) with events.jsonl`);
 
+    writeExtractionHealth(aliveMappings.length, config);
+
     for (const mapping of aliveMappings) {
       await extractForUuid(mapping, minEvents, config);
     }
@@ -829,6 +831,39 @@ export const tick = async (config: BikkyConfig): Promise<void> => {
     logFn("ERROR", `Extraction tick failed: ${(e as Error).message}`);
   }
 };
+
+// ── Health metric ───────────────────────────────────────────────────────────
+
+export interface ExtractionHealth {
+  /** ISO timestamp of the most recent extraction tick that ran. */
+  last_tick_at: string;
+  /** ISO timestamp of the most recent tick that saw ≥1 active session. Null if never. */
+  last_active_session_at: string | null;
+  /** Active session count from the most recent tick. */
+  active_session_count: number;
+  /** Configured copilot watcher path at the time of the tick. */
+  watcher_path: string;
+}
+
+function writeExtractionHealth(activeCount: number, config: BikkyConfig): void {
+  try {
+    let existing: Partial<ExtractionHealth> = {};
+    if (existsSync(EXTRACTION_HEALTH_PATH)) {
+      try { existing = JSON.parse(readFileSync(EXTRACTION_HEALTH_PATH, "utf-8")); } catch { /* ignore */ }
+    }
+    const now = new Date().toISOString();
+    const health: ExtractionHealth = {
+      last_tick_at: now,
+      last_active_session_at: activeCount > 0 ? now : (existing.last_active_session_at ?? null),
+      active_session_count: activeCount,
+      watcher_path: config.watchers.copilot.path,
+    };
+    mkdirSync(STATE_DIR, { recursive: true });
+    writeFileSync(EXTRACTION_HEALTH_PATH, JSON.stringify(health, null, 2) + "\n");
+  } catch (e) {
+    logFn("DEBUG", `Failed to write extraction health: ${(e as Error).message}`);
+  }
+}
 
 /**
  * Extract facts for a single Copilot session identified by UUID.

--- a/src/daemon/loop.ts
+++ b/src/daemon/loop.ts
@@ -14,6 +14,7 @@ import { tick as consolidationTick, setLogger as setConsolidationLogger } from "
 import { tick as relationsTick, setLogger as setRelationsLogger } from "./relations.js";
 import { tick as entityTypingTick, setLogger as setEntityTypingLogger } from "./entity-typing.js";
 import { scanStaleFacts, setLogger as setStalenessLogger } from "./staleness.js";
+import { inspectWatcherPaths, formatIssue } from "./watcher-health.js";
 
 // createLogger returns (LogLevel, ...args) but daemon modules accept (string, ...args).
 // The daemon only calls with valid LogLevel values, so the cast is safe.
@@ -26,6 +27,12 @@ let intervalHandle: ReturnType<typeof setInterval> | null = null;
 export async function startDaemon(): Promise<void> {
   const cfg = loadConfig();
   log("INFO", `Starting bikky daemon (PID ${process.pid})`);
+
+  // Sanity-check watcher paths — warn loudly if any look broken so users
+  // don't end up with a silently-idle daemon (issue #58).
+  for (const issue of inspectWatcherPaths(cfg)) {
+    log("WARN", formatIssue(issue));
+  }
 
   // Wire up loggers for all daemon sub-modules
   qdrantClient.setLogger(log);

--- a/src/daemon/watcher-health.test.ts
+++ b/src/daemon/watcher-health.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for watcher-health (issue #58).
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { looksLikeTempdir, inspectWatcherPaths, formatIssue } from "./watcher-health.js";
+import { CONFIG_DEFAULTS } from "../config.js";
+
+describe("looksLikeTempdir", () => {
+  it("flags /tmp paths", () => {
+    assert.strictEqual(looksLikeTempdir("/tmp/foo"), true);
+  });
+  it("flags /var/folders paths (macOS)", () => {
+    assert.strictEqual(looksLikeTempdir("/var/folders/0z/abc/T/bikky-test-sessions-XYZ"), true);
+  });
+  it("flags os.tmpdir() prefixed paths", () => {
+    assert.strictEqual(looksLikeTempdir(path.join(os.tmpdir(), "anything")), true);
+  });
+  it("flags bikky-test-* names anywhere", () => {
+    assert.strictEqual(looksLikeTempdir("/Users/x/bikky-test-sessions-foo"), true);
+  });
+  it("does not flag canonical home paths", () => {
+    assert.strictEqual(looksLikeTempdir(path.join(os.homedir(), ".copilot", "session-state")), false);
+  });
+  it("returns false for empty string", () => {
+    assert.strictEqual(looksLikeTempdir(""), false);
+  });
+});
+
+describe("inspectWatcherPaths", () => {
+  it("returns empty when both watchers point at canonical defaults", () => {
+    const cfg = structuredClone(CONFIG_DEFAULTS);
+    const issues = inspectWatcherPaths(cfg);
+    assert.strictEqual(issues.length, 0);
+  });
+
+  it("flags non-default tempdir paths", () => {
+    const cfg = structuredClone(CONFIG_DEFAULTS);
+    cfg.watchers.copilot.path = "/var/folders/0z/abc/T/bikky-test-sessions-XYZ/mixed-sessions";
+    const issues = inspectWatcherPaths(cfg);
+    assert.strictEqual(issues.length, 1);
+    assert.strictEqual(issues[0].watcher, "copilot");
+    assert.ok(issues[0].reasons.some(r => r.includes("tempdir")));
+  });
+
+  it("flags non-default missing paths", () => {
+    const cfg = structuredClone(CONFIG_DEFAULTS);
+    cfg.watchers.copilot.path = "/nonexistent/path/for/test/abc123xyz";
+    const issues = inspectWatcherPaths(cfg);
+    assert.strictEqual(issues.length, 1);
+    assert.ok(issues[0].reasons.some(r => r.includes("does not exist")));
+  });
+
+  it("does NOT flag a non-default but valid path", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-valid-"));
+    try {
+      const cfg = structuredClone(CONFIG_DEFAULTS);
+      // Custom path that exists — but it IS a tempdir, so it WILL be flagged.
+      // To test the "valid" case, pick a real homedir path.
+      cfg.watchers.copilot.path = path.join(os.homedir());
+      const issues = inspectWatcherPaths(cfg);
+      assert.strictEqual(issues.length, 0);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores disabled watchers", () => {
+    const cfg = structuredClone(CONFIG_DEFAULTS);
+    cfg.watchers.copilot.enabled = false;
+    cfg.watchers.copilot.path = "/var/folders/whatever/bikky-test-bad";
+    const issues = inspectWatcherPaths(cfg);
+    assert.strictEqual(issues.length, 0);
+  });
+
+  it("does NOT flag missing default paths (e.g. user without Claude installed)", () => {
+    const cfg = structuredClone(CONFIG_DEFAULTS);
+    // Both default paths — claude almost certainly absent in CI; that's fine.
+    const issues = inspectWatcherPaths(cfg);
+    for (const i of issues) {
+      assert.notStrictEqual(i.watcher, "claude", `claude default path should not be flagged: ${JSON.stringify(i)}`);
+    }
+  });
+});
+
+describe("formatIssue", () => {
+  it("includes path, reasons, default, and fix instruction", () => {
+    const msg = formatIssue({
+      watcher: "copilot",
+      configuredPath: "/tmp/bad",
+      reasons: ["a", "b"],
+      canonicalDefault: "/Users/x/.copilot/session-state",
+    });
+    assert.ok(msg.includes("/tmp/bad"));
+    assert.ok(msg.includes("a; b"));
+    assert.ok(msg.includes("/Users/x/.copilot/session-state"));
+    assert.ok(msg.includes("fix:"));
+  });
+});

--- a/src/daemon/watcher-health.ts
+++ b/src/daemon/watcher-health.ts
@@ -1,0 +1,91 @@
+/**
+ * Watcher path sanity check — flags configurations that will silently
+ * produce no extraction work (vanished tempdirs, missing dirs, paths that
+ * look like leftover test fixtures).
+ *
+ * The fix lives outside the watcher itself so daemon startup can warn
+ * even before the first extraction tick runs.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { BikkyConfig } from "../config.js";
+
+export interface WatcherPathIssue {
+  watcher: string;
+  configuredPath: string;
+  reasons: string[];
+  canonicalDefault: string;
+}
+
+const TEMPDIR_PREFIXES = [
+  os.tmpdir(),
+  "/tmp/",
+  "/var/folders/",
+  "/private/var/folders/",
+  "/private/tmp/",
+];
+
+const TEMPDIR_NAME_PATTERNS = [
+  /bikky-test-/i,
+  /\/T\/TemporaryItems\//,
+];
+
+export function looksLikeTempdir(p: string): boolean {
+  if (!p) return false;
+  const norm = path.resolve(p);
+  if (TEMPDIR_PREFIXES.some(prefix => norm.startsWith(prefix))) return true;
+  if (TEMPDIR_NAME_PATTERNS.some(re => re.test(norm))) return true;
+  return false;
+}
+
+function canonicalDefault(watcher: "copilot" | "claude"): string {
+  if (watcher === "copilot") return path.join(os.homedir(), ".copilot", "session-state");
+  return path.join(os.homedir(), ".claude", "projects");
+}
+
+export function inspectWatcherPaths(cfg: BikkyConfig): WatcherPathIssue[] {
+  const issues: WatcherPathIssue[] = [];
+  const entries: Array<["copilot" | "claude", { enabled: boolean; path: string }]> = [
+    ["copilot", cfg.watchers.copilot],
+    ["claude", cfg.watchers.claude],
+  ];
+
+  for (const [name, w] of entries) {
+    if (!w.enabled) continue;
+    const reasons: string[] = [];
+    const def = canonicalDefault(name);
+    const isDefault = path.resolve(w.path) === path.resolve(def);
+
+    if (looksLikeTempdir(w.path)) {
+      reasons.push("path is under an OS tempdir — likely leftover from a test run");
+    }
+    if (!fs.existsSync(w.path)) {
+      reasons.push("path does not exist on disk");
+    }
+
+    // Only flag as an issue if the path is non-default. A missing default path
+    // is normal (e.g. user doesn't use Claude) and not worth warning about.
+    if (reasons.length > 0 && !isDefault) {
+      issues.push({
+        watcher: name,
+        configuredPath: w.path,
+        reasons,
+        canonicalDefault: def,
+      });
+    }
+  }
+
+  return issues;
+}
+
+/** Format an issue as a multi-line WARN log message. */
+export function formatIssue(issue: WatcherPathIssue): string {
+  return [
+    `Watcher '${issue.watcher}' path looks broken: ${issue.configuredPath}`,
+    `  reasons: ${issue.reasons.join("; ")}`,
+    `  canonical default: ${issue.canonicalDefault}`,
+    `  fix: edit ~/.bikky/config.json watchers.${issue.watcher}.path, or delete that key to fall back to the default`,
+  ].join("\n");
+}

--- a/src/daemon/watcher.test.ts
+++ b/src/daemon/watcher.test.ts
@@ -1,8 +1,9 @@
 /**
  * Tests for the session watcher.
  *
- * Creates a temporary directory structure mimicking ~/.copilot/session-state/
- * and verifies discoverSessions() behavior.
+ * Uses BIKKY_HOME to point bikky at an isolated tempdir for the entire test
+ * file — this prevents saveConfig() from clobbering the user's real
+ * ~/.bikky/config.json if a test crashes mid-run (root cause of issue #58).
  */
 
 import { describe, it, before, after, beforeEach } from "node:test";
@@ -11,15 +12,18 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
-import { resetConfig, loadConfig, saveConfig, CONFIG_DEFAULTS } from "../config.js";
-import { discoverSessions } from "./watcher.js";
+// Set BIKKY_HOME *before* importing config so all derived paths use it.
+const TEST_BIKKY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-home-watcher-"));
+process.env.BIKKY_HOME = TEST_BIKKY_HOME;
+
+const { resetConfig, loadConfig, saveConfig, CONFIG_DEFAULTS } = await import("../config.js");
+const { discoverSessions } = await import("./watcher.js");
 
 // ---------------------------------------------------------------------------
 // Test directory setup
 // ---------------------------------------------------------------------------
 
 let testDir: string;
-let savedConfig: string | null = null;
 
 function createTestDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "bikky-test-sessions-"));
@@ -27,25 +31,12 @@ function createTestDir(): string {
 
 describe("discoverSessions", () => {
   before(() => {
-    // Save existing config state
-    const configPath = path.join(os.homedir(), ".bikky", "config.json");
-    if (fs.existsSync(configPath)) {
-      savedConfig = fs.readFileSync(configPath, "utf-8");
-    }
     testDir = createTestDir();
   });
 
   after(() => {
-    // Clean up test directory
     fs.rmSync(testDir, { recursive: true, force: true });
-
-    // Restore original config
-    const configPath = path.join(os.homedir(), ".bikky", "config.json");
-    if (savedConfig !== null) {
-      fs.writeFileSync(configPath, savedConfig);
-    } else if (fs.existsSync(configPath)) {
-      fs.unlinkSync(configPath);
-    }
+    fs.rmSync(TEST_BIKKY_HOME, { recursive: true, force: true });
     resetConfig();
   });
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -61,7 +61,9 @@ import {
   qdrantSetPayload,
   qdrantGetPoints,
 } from "./api.js";
-import { saveConfig, loadConfig } from "../config.js";
+import { saveConfig, loadConfig, EXTRACTION_HEALTH_PATH } from "../config.js";
+import { existsSync, readFileSync } from "node:fs";
+import { inspectWatcherPaths, formatIssue } from "../daemon/watcher-health.js";
 
 // ---------------------------------------------------------------------------
 // Runtime state
@@ -291,6 +293,48 @@ export function registerTools(mcp: McpServer): void {
         await embed("test");
         status["embedding_connected"] = true;
       } catch { /* ignore */ }
+
+      // Watcher / extraction health (issue #58)
+      const warnings: string[] = [];
+      try {
+        const cfg = loadConfig();
+        status["watcher_path"] = cfg.watchers.copilot.path;
+        for (const issue of inspectWatcherPaths(cfg)) {
+          warnings.push(formatIssue(issue));
+        }
+      } catch { /* ignore */ }
+
+      try {
+        if (existsSync(EXTRACTION_HEALTH_PATH)) {
+          const health = JSON.parse(readFileSync(EXTRACTION_HEALTH_PATH, "utf-8")) as {
+            last_tick_at?: string;
+            last_active_session_at?: string | null;
+            active_session_count?: number;
+            watcher_path?: string;
+          };
+          status["extraction_last_tick_at"] = health.last_tick_at ?? null;
+          status["extraction_last_active_session_at"] = health.last_active_session_at ?? null;
+          status["extraction_active_session_count"] = health.active_session_count ?? 0;
+          if (health.last_active_session_at) {
+            const hours = (Date.now() - Date.parse(health.last_active_session_at)) / 3_600_000;
+            status["extraction_hours_since_active_session"] = Math.round(hours * 10) / 10;
+            if (hours > 6) {
+              warnings.push(
+                `Watcher has not seen any active Copilot sessions for ${Math.round(hours)}h — ` +
+                `check watcher_path (${health.watcher_path ?? "unknown"}) and that the daemon is running.`,
+              );
+            }
+          } else {
+            status["extraction_hours_since_active_session"] = null;
+            warnings.push("Daemon has never observed an active Copilot session — extraction may be stalled.");
+          }
+        } else {
+          status["extraction_last_tick_at"] = null;
+          status["extraction_last_active_session_at"] = null;
+          status["extraction_hours_since_active_session"] = null;
+        }
+      } catch { /* ignore */ }
+      if (warnings.length > 0) status["warnings"] = warnings;
 
       if (!status["ready"] && missing.length > 0) {
         status["setup_instructions"] =


### PR DESCRIPTION
Closes #58.

## What this changes

Three changes that together prevent the silent-extraction failure mode where a stale watcher path (a vanished test tempdir written into `~/.bikky/config.json`) leaves the daemon ticking forever with zero active sessions.

### 1. Watcher path sanity check at daemon startup
New `src/daemon/watcher-health.ts`. `startDaemon()` now logs a `WARN` if any enabled watcher's configured path is non-default and either looks like an OS tempdir or doesn't exist:

```
WARN Watcher 'copilot' path looks broken: /var/folders/0z/x/T/bikky-test-sessions-XYZ/mixed-sessions
  reasons: path is under an OS tempdir — likely leftover from a test run; path does not exist on disk
  canonical default: /Users/saber/.copilot/session-state
  fix: edit ~/.bikky/config.json watchers.copilot.path, or delete that key to fall back to the default
```

Default paths that are simply absent (e.g. user without Claude installed) are NOT flagged.

### 2. Extraction-health metric on `get_setup_status`
- `extraction.ts:tick` writes `~/.bikky/state/extraction-health.json` per tick (last_tick_at, last_active_session_at, active_session_count, watcher_path).
- `get_setup_status` surfaces `extraction_last_tick_at`, `extraction_last_active_session_at`, `extraction_hours_since_active_session`, `watcher_path`.
- If >6h since the last active session, a `warnings[]` entry is added — visible to both humans and LLM agents.
- `get_setup_status` also runs `inspectWatcherPaths` so misconfigured paths show up in `warnings` without needing to grep daemon.log.

### 3. `BIKKY_HOME` env var for test isolation
- `src/config.ts` honours `process.env.BIKKY_HOME` (default `~/.bikky`). All derived paths flow from `BIKKY_DIR`.
- `watcher.test.ts` and `config.test.ts` set `BIKKY_HOME` to an isolated tempdir before importing config.
- This is the actual root cause of the silent failure that motivated this issue: the watcher tests previously called `saveConfig()` which wrote tempdir paths directly into the user's REAL `~/.bikky/config.json`. A crashed test = persistent bad config = stalled extraction.
- README documents `BIKKY_HOME`.

## Tests
`npm test`: **478 pass**, 0 fail. Added 13 new tests in `src/daemon/watcher-health.test.ts` covering tempdir detection, default-path tolerance, disabled-watcher skip, formatter output.

## Manual smoke
Confirmed the WARN renders cleanly for the exact tempdir path that broke local bikky. The fact this would have caught the original failure within seconds of daemon startup was the whole point.

## Out of scope
- Auto-discovery of canonical Copilot dir during `bikky configure` — already correct in the default path; the bug came from tests, not configure.
- Relation-inference 0% accept rate (separate issue #60).