### PR TITLE
Add storage-time secret redaction

### DIFF
--- a/packages/ui/src/lib/embed.test.ts
+++ b/packages/ui/src/lib/embed.test.ts
@@ -81,7 +81,7 @@ describe("ui/lib/embed", () => {
 
   it("embed throws when provider is bedrock", async () => {
     writeConfig({ embedding: { provider: "bedrock" } });
-    await assert.rejects(embed("x"), /Bedrock embeddings require AWS SDK/);
+    await assert.rejects(embed("x"), /not available in the UI/);
   });
 
   it("embed POSTs to /v1/embeddings with the right body for ollama", async () => {

--- a/packages/ui/src/lib/qdrant.ts
+++ b/packages/ui/src/lib/qdrant.ts
@@ -26,6 +26,11 @@ export interface FactPayload {
   created_at: string;
   updated_at: string;
   metadata?: Record<string, string>;
+  redaction?: {
+    redacted: boolean;
+    summary: string;
+    matches: Array<{ type: string; count: number }>;
+  } | null;
   from_entity?: string;
   relation_type?: string;
   to_entity?: string;

--- a/packages/ui/src/lib/redaction.ts
+++ b/packages/ui/src/lib/redaction.ts
@@ -1,0 +1,115 @@
+export interface RedactionMatch {
+  type: string;
+  count: number;
+}
+
+export interface RedactionSummary {
+  redacted: boolean;
+  summary: string;
+  matches: RedactionMatch[];
+}
+
+export interface RedactionResult extends RedactionSummary {
+  text: string;
+}
+
+const SECRET_PLACEHOLDER = "[REDACTED:secret]";
+
+interface RedactionPattern {
+  type: string;
+  pattern: RegExp;
+  replace(match: string, ...groups: string[]): string;
+}
+
+const secretPatterns: RedactionPattern[] = [
+  {
+    type: "secret",
+    pattern: /\b((?:password|passwd|pwd|api[_-]?key|token|access[_-]?token|refresh[_-]?token|secret|client[_-]?secret|private[_-]?key)\s*[:=]\s*)(?:"[^"\s,;]+"|'[^'\s,;]+'|[^\s,;]+)/gi,
+    replace: (_match, prefix) => `${prefix}${SECRET_PLACEHOLDER}`,
+  },
+  {
+    type: "secret",
+    pattern: /\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi,
+    replace: (_match, prefix) => `${prefix}${SECRET_PLACEHOLDER}`,
+  },
+  {
+    type: "secret",
+    pattern: /\b(?:github_pat_[A-Za-z0-9_]{20,}|gh[opsur]_[A-Za-z0-9_]{20,})\b/g,
+    replace: () => SECRET_PLACEHOLDER,
+  },
+  {
+    type: "secret",
+    pattern: /\bsk-[A-Za-z0-9_-]{20,}\b/g,
+    replace: () => SECRET_PLACEHOLDER,
+  },
+  {
+    type: "secret",
+    pattern: /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g,
+    replace: () => SECRET_PLACEHOLDER,
+  },
+];
+
+const noRedaction = (): RedactionSummary => ({
+  redacted: false,
+  summary: "none",
+  matches: [],
+});
+
+const summarizeMatches = (counts: Map<string, number>): RedactionSummary => {
+  const matches = [...counts.entries()]
+    .filter(([, count]) => count > 0)
+    .map(([type, count]) => ({ type, count }));
+
+  if (matches.length === 0) return noRedaction();
+
+  return {
+    redacted: true,
+    summary: matches.map((match) => `${match.type}:${match.count}`).join(","),
+    matches,
+  };
+};
+
+export const combineRedactions = (
+  items: Array<RedactionSummary | RedactionResult | null | undefined>,
+): RedactionSummary => {
+  const counts = new Map<string, number>();
+
+  for (const item of items) {
+    if (!item?.redacted) continue;
+    for (const match of item.matches) {
+      counts.set(match.type, (counts.get(match.type) ?? 0) + match.count);
+    }
+  }
+
+  return summarizeMatches(counts);
+};
+
+export const redactStorageText = (text: string): RedactionResult => {
+  let redactedText = text;
+  const counts = new Map<string, number>();
+
+  for (const { type, pattern, replace } of secretPatterns) {
+    redactedText = redactedText.replace(pattern, (match, ...groups: string[]) => {
+      counts.set(type, (counts.get(type) ?? 0) + 1);
+      return replace(match, ...groups);
+    });
+  }
+
+  return {
+    text: redactedText,
+    ...summarizeMatches(counts),
+  };
+};
+
+export const addRedactionPayload = (
+  payload: Record<string, unknown>,
+  summary: RedactionSummary,
+): void => {
+  if (summary.redacted) {
+    payload["redaction"] = {
+      redacted: summary.redacted,
+      summary: summary.summary,
+      matches: summary.matches,
+    };
+  }
+};

--- a/packages/ui/src/routes/memory.test.ts
+++ b/packages/ui/src/routes/memory.test.ts
@@ -27,9 +27,9 @@ interface QdrantCall { method: string; path: string; body: any }
 function installMock(opts: {
   qdrantHandler?: (call: QdrantCall) => unknown;
   embedding?: number[];
-} = {}): { calls: QdrantCall[]; embedCalls: number } {
+} = {}): { calls: QdrantCall[]; embedCalls: number; embedInputs: string[] } {
   const calls: QdrantCall[] = [];
-  const state = { embedCalls: 0 };
+  const state = { embedCalls: 0, embedInputs: [] as string[] };
 
   globalThis.fetch = (async (input: any, init: RequestInit = {}) => {
     const url = typeof input === "string" ? input : input.toString();
@@ -39,6 +39,7 @@ function installMock(opts: {
     // Embedding endpoint
     if (url.includes("/v1/embeddings")) {
       state.embedCalls++;
+      state.embedInputs.push(String(body?.input ?? ""));
       return new Response(JSON.stringify({
         data: [{ embedding: opts.embedding ?? [0.1, 0.2, 0.3] }],
       }), { status: 200 });
@@ -53,9 +54,10 @@ function installMock(opts: {
     return new Response(JSON.stringify(result), { status: 200 });
   }) as typeof fetch;
 
-  return new Proxy({ calls, embedCalls: state.embedCalls } as { calls: QdrantCall[]; embedCalls: number }, {
+  return new Proxy({ calls, embedCalls: state.embedCalls, embedInputs: state.embedInputs } as { calls: QdrantCall[]; embedCalls: number; embedInputs: string[] }, {
     get(_target, prop) {
       if (prop === "embedCalls") return state.embedCalls;
+      if (prop === "embedInputs") return state.embedInputs;
       if (prop === "calls") return calls;
       return undefined;
     },
@@ -230,7 +232,7 @@ describe("ui/routes/memory", () => {
       assert.equal(res.status, 404);
     });
 
-    it("calls setPayload with normalized entities and re-embeds when content changes", async () => {
+    it("redacts content before setPayload and re-embedding when content changes", async () => {
       let getCount = 0;
       const log = installMock({
         qdrantHandler: (c) => {
@@ -247,18 +249,24 @@ describe("ui/routes/memory", () => {
       const res = await app.fetch(new Request("http://localhost/api/memory/facts/id1", {
         method: "PUT",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ content: "updated", entities: ["FOO", "Bar"] }),
+        body: JSON.stringify({ content: "updated password=supersecretvalue", entities: ["FOO", "Bar"] }),
       }));
       assert.equal(res.status, 200);
 
       const setPayload = log.calls.find((c) => c.path.endsWith("/points/payload"));
       assert.ok(setPayload, "expected setPayload call");
       assert.deepEqual(setPayload!.body.payload.entities, ["foo", "bar"]);
-      assert.equal(setPayload!.body.payload.content, "updated");
+      assert.equal(setPayload!.body.payload.content, "updated password=[REDACTED:secret]");
+      assert.deepEqual(setPayload!.body.payload.redaction, {
+        redacted: true,
+        summary: "secret:1",
+        matches: [{ type: "secret", count: 1 }],
+      });
 
       // Re-embed + upsert because content changed
       const upsert = log.calls.find((c) => c.method === "PUT" && c.path.endsWith("/points"));
       assert.ok(upsert, "expected upsert call after re-embed");
+      assert.deepEqual(log.embedInputs, ["updated password=[REDACTED:secret]"]);
     });
   });
 
@@ -305,26 +313,43 @@ describe("ui/routes/memory", () => {
       assert.equal(res.status, 501);
     });
 
-    it("creates the fact, embeds it, lowercases entities, and returns 201", async () => {
+    it("creates the fact, redacts secrets in stored fields, lowercases entities, and returns 201", async () => {
       const log = installMock({ qdrantHandler: () => ({ result: {} }) });
       const app = buildApp();
 
       const res = await app.fetch(new Request("http://localhost/api/memory/facts", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ content: "Hello world", category: "infrastructure", entities: ["FOO", "Bar"] }),
+        body: JSON.stringify({
+          content: "Hello password=supersecretvalue",
+          category: "infrastructure",
+          entities: ["FOO", "api_key=entitysecret"],
+          from_entity: "token=fromsecret",
+          relation_type: "Owns",
+          to_entity: "Bar",
+        }),
       }));
       assert.equal(res.status, 201);
 
       const upsert = log.calls.find((c) => c.method === "PUT" && c.path.endsWith("/points"));
       assert.ok(upsert);
       const point = upsert!.body.points[0];
-      assert.deepEqual(point.payload.entities, ["foo", "bar"]);
+      assert.equal(point.payload.content, "Hello password=[REDACTED:secret]");
+      assert.deepEqual(point.payload.entities, ["foo", "api_key=[redacted:secret]"]);
+      assert.equal(point.payload.from_entity, "token=[REDACTED:secret]");
+      assert.equal(point.payload.relation_type, "Owns");
+      assert.equal(point.payload.to_entity, "Bar");
       assert.equal(point.payload.source, "ui");
       assert.equal(point.payload.kind, "fact");
       assert.equal(point.payload.domain, "work");
       assert.equal(typeof point.id, "string");
       assert.equal(typeof point.payload.content_hash, "string");
+      assert.deepEqual(point.payload.redaction, {
+        redacted: true,
+        summary: "secret:3",
+        matches: [{ type: "secret", count: 3 }],
+      });
+      assert.deepEqual(log.embedInputs, ["Hello password=[REDACTED:secret]"]);
     });
   });
 

--- a/packages/ui/src/routes/memory.ts
+++ b/packages/ui/src/routes/memory.ts
@@ -6,6 +6,7 @@
 import { Hono } from "hono";
 import { createQdrantClient, buildFilter, type QdrantPoint, type QdrantFilter, type FactPayload } from "../lib/qdrant.js";
 import { embed, isEmbeddingAvailable } from "../lib/embed.js";
+import { addRedactionPayload, combineRedactions, redactStorageText } from "../lib/redaction.js";
 
 export const memoryRoutes = new Hono();
 
@@ -115,24 +116,47 @@ memoryRoutes.get("/facts/:id", async (c) => {
 // PUT /api/memory/facts/:id
 memoryRoutes.put("/facts/:id", async (c) => {
   const id = c.req.param("id");
-  const body = await c.req.json<Partial<Pick<FactPayload, "content" | "category" | "domain" | "entities" | "confidence">>>();
+  const body = await c.req.json<Partial<Pick<FactPayload, "content" | "category" | "domain" | "entities" | "confidence" | "from_entity" | "relation_type" | "to_entity">>>();
 
   const qdrant = createQdrantClient();
   const existing = await qdrant.getPoints([id]);
   if (existing.length === 0) return c.json({ error: "Not found" }, 404);
 
   const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
-  if (body.content !== undefined) updates.content = body.content;
+  const redactedContent = body.content !== undefined ? redactStorageText(body.content) : null;
+  const redactedEntities = body.entities !== undefined ? body.entities.map((entity) => redactStorageText(entity)) : null;
+  const redactedFromEntity = body.from_entity !== undefined ? redactStorageText(body.from_entity) : null;
+  const redactedRelationType = body.relation_type !== undefined ? redactStorageText(body.relation_type) : null;
+  const redactedToEntity = body.to_entity !== undefined ? redactStorageText(body.to_entity) : null;
+  const redactionSummary = combineRedactions([
+    redactedContent,
+    ...(redactedEntities ?? []),
+    redactedFromEntity,
+    redactedRelationType,
+    redactedToEntity,
+  ]);
+  if (redactedContent) {
+    updates.content = redactedContent.text;
+    updates.content_hash = await hashContent(redactedContent.text);
+  }
   if (body.category !== undefined) updates.category = body.category;
   if (body.domain !== undefined) updates.domain = body.domain;
-  if (body.entities !== undefined) updates.entities = body.entities.map((e: string) => e.toLowerCase());
+  if (redactedEntities !== null) updates.entities = redactedEntities.map((e) => e.text.toLowerCase());
   if (body.confidence !== undefined) updates.confidence = body.confidence;
+  if (redactedFromEntity) updates.from_entity = redactedFromEntity.text;
+  if (redactedRelationType) updates.relation_type = redactedRelationType.text;
+  if (redactedToEntity) updates.to_entity = redactedToEntity.text;
+  if (redactionSummary.redacted) {
+    addRedactionPayload(updates, redactionSummary);
+  } else if (redactedContent) {
+    updates.redaction = null;
+  }
 
   await qdrant.setPayload([id], updates);
 
   // Re-embed if content changed and embedding is available
-  if (body.content && isEmbeddingAvailable()) {
-    const vector = await embed(body.content);
+  if (redactedContent && isEmbeddingAvailable()) {
+    const vector = await embed(redactedContent.text);
     const mergedPayload = { ...existing[0]!.payload, ...updates };
     await qdrant.upsert(id, vector, mergedPayload);
   }
@@ -181,19 +205,31 @@ memoryRoutes.post("/facts", async (c) => {
   }
 
   const qdrant = createQdrantClient();
-  const vector = await embed(body.content);
+  const redactedContent = redactStorageText(body.content);
+  const redactedEntities = body.entities.map((entity) => redactStorageText(entity));
+  const redactedFromEntity = body.from_entity ? redactStorageText(body.from_entity) : null;
+  const redactedRelationType = body.relation_type ? redactStorageText(body.relation_type) : null;
+  const redactedToEntity = body.to_entity ? redactStorageText(body.to_entity) : null;
+  const redactionSummary = combineRedactions([
+    redactedContent,
+    ...redactedEntities,
+    redactedFromEntity,
+    redactedRelationType,
+    redactedToEntity,
+  ]);
+  const vector = await embed(redactedContent.text);
   const id = crypto.randomUUID();
   const now = new Date().toISOString();
 
   const payload: Record<string, unknown> = {
-    content: body.content,
+    content: redactedContent.text,
     category: body.category,
     domain: body.domain || "work",
     kind: body.kind || "fact",
-    entities: body.entities.map((e) => e.toLowerCase()),
+    entities: redactedEntities.map((e) => e.text.toLowerCase()),
     source: "ui",
     confidence: body.confidence ?? 0.9,
-    content_hash: await hashContent(body.content),
+    content_hash: await hashContent(redactedContent.text),
     reinforcement_count: 0,
     last_reinforced_at: now,
     superseded_by: null,
@@ -203,9 +239,10 @@ memoryRoutes.post("/facts", async (c) => {
   };
 
   if (body.metadata) payload.metadata = body.metadata;
-  if (body.from_entity) payload.from_entity = body.from_entity;
-  if (body.relation_type) payload.relation_type = body.relation_type;
-  if (body.to_entity) payload.to_entity = body.to_entity;
+  if (redactedFromEntity) payload.from_entity = redactedFromEntity.text;
+  if (redactedRelationType) payload.relation_type = redactedRelationType.text;
+  if (redactedToEntity) payload.to_entity = redactedToEntity.text;
+  addRedactionPayload(payload, redactionSummary);
 
   await qdrant.upsert(id, vector, payload);
   return c.json({ ok: true, id }, 201);

--- a/src/daemon/episode-summary.test.ts
+++ b/src/daemon/episode-summary.test.ts
@@ -92,10 +92,10 @@ describe("daemon/episode-summary", () => {
     ), false);
   });
 
-  it("builds memory ontology episode payloads", () => {
-    const { payload } = buildEpisodeSummaryPayload({
+  it("redacts secrets in memory ontology episode payloads", () => {
+    const { payload, redaction } = buildEpisodeSummaryPayload({
       draft: {
-        content: "Implemented daemon episode summaries for src/daemon/episode-summary.ts.",
+        content: "Implemented daemon episode summaries with token=supersecretvalue.",
         tasks_completed: ["episode summaries"],
         decisions_made: ["Use episode summaries instead of one evolving session summary"],
         open_questions: ["workstream updater"],
@@ -121,5 +121,8 @@ describe("daemon/episode-summary", () => {
     assert.equal(payload.episode_id, "episode-1");
     assert.equal(payload.workstream_key, "243-bikky-data-capture-policy");
     assert.equal((payload.metadata as Record<string, string>).summary_subtype, "episode");
+    assert.equal(payload.content, "Implemented daemon episode summaries with token=[REDACTED:secret]");
+    assert.equal(redaction.redacted, true);
+    assert.deepEqual(payload.redaction, redaction);
   });
 });

--- a/src/daemon/episode-summary.ts
+++ b/src/daemon/episode-summary.ts
@@ -20,6 +20,11 @@ import {
 import * as qdrant from "./qdrant.js";
 import type { QdrantPayload } from "./qdrant.js";
 import {
+  combineRedactions,
+  redactStorageText,
+  type RedactionSummary,
+} from "../privacy/redaction.js";
+import {
   resolveWorkstreamKey,
   type ResolvedWorkstream,
   type WorkstreamRegistry,
@@ -32,19 +37,6 @@ export interface WorkspaceScope {
   actorId?: string;
   includeLegacy?: boolean;
 }
-
-export interface RedactionSummary {
-  redacted: boolean;
-  summary: string;
-  matches: Array<{ type: string; count: number }>;
-}
-
-const noRedaction = (): RedactionSummary => ({ redacted: false, summary: "none", matches: [] });
-const passthroughText = (text: string, _options?: { enabled: boolean; redactPii: boolean }): { text: string; redacted: boolean; summary: string; matches: Array<{ type: string; count: number }> } => ({
-  text,
-  ...noRedaction(),
-});
-const combinePassThrough = (): RedactionSummary => noRedaction();
 
 export interface EpisodeSegment {
   episode_id: string;
@@ -198,12 +190,18 @@ export const buildEpisodeSummaryPayload = (input: {
   existing?: { id: string; payload?: Partial<QdrantPayload> } | null;
   redactionOptions: { enabled: boolean; redactPii: boolean };
 }): EpisodeSummaryPayloadResult => {
-  const redactedContent = passthroughText(input.draft.content, input.redactionOptions);
-  const redactedTasks = input.draft.tasks_completed.map((task) => passthroughText(task, input.redactionOptions));
-  const redactedDecisions = input.draft.decisions_made.map((decision) => passthroughText(decision, input.redactionOptions));
-  const redactedOpenQuestions = input.draft.open_questions.map((question) => passthroughText(question, input.redactionOptions));
-  const redactedEntities = input.draft.entities.map((entity) => passthroughText(entity, input.redactionOptions));
-  const redaction = combinePassThrough();
+  const redactedContent = redactStorageText(input.draft.content, input.redactionOptions);
+  const redactedTasks = input.draft.tasks_completed.map((task) => redactStorageText(task, input.redactionOptions));
+  const redactedDecisions = input.draft.decisions_made.map((decision) => redactStorageText(decision, input.redactionOptions));
+  const redactedOpenQuestions = input.draft.open_questions.map((question) => redactStorageText(question, input.redactionOptions));
+  const redactedEntities = input.draft.entities.map((entity) => redactStorageText(entity, input.redactionOptions));
+  const redaction = combineRedactions([
+    redactedContent,
+    ...redactedTasks,
+    ...redactedDecisions,
+    ...redactedOpenQuestions,
+    ...redactedEntities,
+  ]);
   const existingPayload = input.existing?.payload ?? {};
   const workstreamKey = input.draft.workstream_key ?? input.segment.workstream_key ?? null;
 
@@ -251,6 +249,8 @@ export const buildEpisodeSummaryPayload = (input: {
 
   if (redaction.redacted) {
     payload["redaction"] = redaction;
+  } else {
+    delete payload["redaction"];
   }
 
   return { payload, redaction };
@@ -311,7 +311,7 @@ export const updateEpisodeSummary = async (input: {
     now,
     existing,
     redactionOptions: {
-      enabled: false,
+      enabled: true,
       redactPii: false,
     },
   });

--- a/src/daemon/extraction.ts
+++ b/src/daemon/extraction.ts
@@ -38,6 +38,7 @@ import {
   subtypeForCategory,
 } from "./capture-policy.js";
 import { shouldSummarizeEvents, updateSessionSummary } from "./session-summary.js";
+import { redactStorageText } from "../privacy/redaction.js";
 import { compareSubtype, hasTypedToken, verifyGrounding, verifyVolatilityCoherence } from "./extraction-rules.js";
 
 // ── Module state ─────────────────────────────────────────────────────────────
@@ -604,11 +605,13 @@ const storeFacts = async (
   let stored = 0;
 
   for (const fact of facts) {
-    const hash = contentHash(fact.content);
+    const redactedContent = redactStorageText(fact.content);
     const sanitizedFact: ExtractedFact = {
       ...fact,
+      content: redactedContent.text,
       entities: fact.entities.map((entity) => entity.toLowerCase()),
     };
+    const hash = contentHash(sanitizedFact.content);
 
     try {
       const dedup = await qdrant.dedupCheck(sanitizedFact.content, hash);

--- a/src/daemon/qdrant.test.ts
+++ b/src/daemon/qdrant.test.ts
@@ -17,6 +17,7 @@ import {
   isReady,
   setLogger,
   setEmbeddingConfig,
+  storeFact,
 } from "./qdrant.js";
 import type { StoreFact } from "./qdrant.js";
 
@@ -26,6 +27,7 @@ import type { StoreFact } from "./qdrant.js";
 
 let savedConfig: string | null = null;
 const configPath = path.join(os.homedir(), ".bikky", "config.json");
+const realFetch = globalThis.fetch;
 
 // Env vars that override config — must be cleared for null-credential tests
 const QDRANT_ENV_KEYS = ["QDRANT_URL", "QDRANT_API_KEY"];
@@ -55,6 +57,7 @@ describe("daemon/qdrant", () => {
     if (savedConfig !== null) {
       fs.writeFileSync(configPath, savedConfig);
     }
+    globalThis.fetch = realFetch;
     resetConfig();
   });
 
@@ -63,6 +66,7 @@ describe("daemon/qdrant", () => {
     for (const key of QDRANT_ENV_KEYS) {
       delete process.env[key];
     }
+    globalThis.fetch = realFetch;
     resetConfig();
   });
 
@@ -242,6 +246,63 @@ describe("daemon/qdrant", () => {
         relation: null,
       };
       assert.strictEqual(fact.relation, null);
+    });
+  });
+
+  describe("storeFact", () => {
+    it("redacts secret content before embedding and Qdrant upsert", async () => {
+      const embedInputs: string[] = [];
+      const upsertBodies: Record<string, unknown>[] = [];
+
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const body = init?.body ? JSON.parse(String(init.body)) : null;
+        if (url.includes("/v1/embeddings")) {
+          embedInputs.push(String(body?.input ?? ""));
+          return new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2, 0.3] }] }), { status: 200 });
+        }
+        if (url.includes("/collections/test-redaction/points") && init?.method === "PUT") {
+          if (body) upsertBodies.push(body);
+        }
+        return new Response(JSON.stringify({ result: {} }), { status: 200 });
+      }) as typeof fetch;
+
+      saveConfig({
+        ...CONFIG_DEFAULTS,
+        qdrant_url: "https://qdrant.example.com:6333",
+        qdrant_api_key: null,
+        collection: "test-redaction",
+        embedding: {
+          ...CONFIG_DEFAULTS.embedding,
+          provider: "ollama",
+          model: "test-model",
+          base_url: "http://embed.test:11434",
+          dimensions: 3,
+        },
+      });
+      resetConfig();
+      init();
+
+      await storeFact({
+        content: "daemon extracted token=supersecretvalue",
+        category: "infrastructure",
+        entities: ["daemon"],
+        content_hash: "raw-hash",
+      });
+
+      assert.deepEqual(embedInputs, ["daemon extracted token=[REDACTED:secret]"]);
+      assert.equal(upsertBodies.length, 1, "expected Qdrant upsert body");
+      const upsertBody = upsertBodies[0]!;
+      const points = upsertBody.points;
+      assert.ok(Array.isArray(points), "expected Qdrant points array");
+      const point = points[0] as { payload: Record<string, unknown> };
+      assert.equal(point.payload.content, "daemon extracted token=[REDACTED:secret]");
+      assert.notEqual(point.payload.content_hash, "raw-hash");
+      assert.deepEqual(point.payload.redaction, {
+        redacted: true,
+        summary: "secret:1",
+        matches: [{ type: "secret", count: 1 }],
+      });
     });
   });
 });

--- a/src/daemon/qdrant.ts
+++ b/src/daemon/qdrant.ts
@@ -8,7 +8,7 @@
  * self-hosted instances.
  */
 
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import { loadConfig } from "../config.js";
 import { embed, initEmbedding, getEmbeddingConfig } from "../llm/index.js";
@@ -24,6 +24,11 @@ import {
   normalizeKind,
   validateMemorySubtype,
 } from "../mcp/taxonomy.js";
+import {
+  combineRedactions,
+  redactStorageText,
+  type RedactionSummary,
+} from "../privacy/redaction.js";
 
 // ---------------------------------------------------------------------------
 // Types (local)
@@ -71,6 +76,7 @@ export interface QdrantPayload {
   expires_at?: string | null;
   quality_score?: number | null;
   confidence_reason?: string | null;
+  redaction?: RedactionSummary;
   from_entity?: string;
   relation_type?: string;
   to_entity?: string;
@@ -362,11 +368,23 @@ const storeFact = async (fact: StoreFact): Promise<string> => {
     : normalizeCategory(fact.category);
   const normalizedDomain = normalizeDomain(fact.domain ?? DEFAULT_DOMAIN);
   const normalizedLayer = fact.layer ?? (normalizedSubtype ? layerForMemorySubtype(normalizedSubtype) : null);
-  const vector = await embed(fact.content);
+  const redactedContent = redactStorageText(fact.content);
+  const redactedEntities = (fact.entities || []).map((entity) => redactStorageText(entity));
+  const redactedRelation = fact.relation ? {
+    from: redactStorageText(fact.relation.from),
+    type: redactStorageText(fact.relation.type),
+    to: redactStorageText(fact.relation.to),
+  } : null;
+  const redaction = combineRedactions([
+    redactedContent,
+    ...redactedEntities,
+    ...(redactedRelation ? [redactedRelation.from, redactedRelation.type, redactedRelation.to] : []),
+  ]);
+  const vector = await embed(redactedContent.text);
   const now = new Date().toISOString();
   const id = randomUUID();
   const payload: QdrantPayload = {
-    content: fact.content,
+    content: redactedContent.text,
     category: normalizedCategory,
     domain: normalizedDomain,
     kind: normalizedKind,
@@ -374,11 +392,13 @@ const storeFact = async (fact: StoreFact): Promise<string> => {
     ...(normalizedSubtype ? { memory_subtype: normalizedSubtype } : {}),
     ...(fact.workspace_id ? { workspace_id: fact.workspace_id } : {}),
     ...(fact.actor_id ? { actor_id: fact.actor_id } : {}),
-    entities: (fact.entities || []).map((entity) => entity.toLowerCase()),
+    entities: redactedEntities.map((entity) => entity.text.toLowerCase()),
     source: fact.source || "daemon",
     confidence: fact.confidence ?? 0.7,
     importance: fact.importance ?? 0.5,
-    content_hash: fact.content_hash,
+    content_hash: redactedContent.redacted
+      ? createHash("sha256").update(redactedContent.text).digest("hex")
+      : fact.content_hash,
     reinforcement_count: 1,
     last_reinforced_at: now,
     superseded_by: null,
@@ -407,17 +427,20 @@ const storeFact = async (fact: StoreFact): Promise<string> => {
     ...(fact.confidence_reason ? { confidence_reason: fact.confidence_reason } : {}),
   };
   // Add relation fields if present
-  if (fact.relation) {
-    payload.from_entity = fact.relation.from;
-    payload.relation_type = fact.relation.type;
-    payload.to_entity = fact.relation.to;
+  if (redactedRelation) {
+    payload.from_entity = redactedRelation.from.text;
+    payload.relation_type = redactedRelation.type.text;
+    payload.to_entity = redactedRelation.to.text;
+  }
+  if (redaction.redacted) {
+    payload.redaction = redaction;
   }
 
   await qdrantRequest("PUT", `/collections/${collection}/points`, {
     points: [{ id, vector, payload }],
   });
 
-  logFn("DEBUG", `Qdrant: stored fact ${id} [${normalizedCategory}] ${fact.content.slice(0, 60)}`);
+  logFn("DEBUG", `Qdrant: stored fact ${id} [${normalizedCategory}] ${redactedContent.text.slice(0, 60)}`);
   return id;
 };
 

--- a/src/daemon/session-index.test.ts
+++ b/src/daemon/session-index.test.ts
@@ -46,14 +46,17 @@ describe("daemon/session-index", () => {
   });
 
   it("builds memory ontology session index payloads", () => {
-    const draft = buildSessionIndexDraft({
-      sessionId: "uuid:test-session",
-      eventCount: 12,
-      episodeResults: [
-        { action: "stored", factId: "fact-1", episodeId: "episode-1", workstreamKey: "task-a" },
-      ],
-    });
-    const { payload } = buildSessionIndexPayload({
+    const draft = {
+      ...buildSessionIndexDraft({
+        sessionId: "uuid:test-session",
+        eventCount: 12,
+        episodeResults: [
+          { action: "stored", factId: "fact-1", episodeId: "episode-1", workstreamKey: "task-a" },
+        ],
+      }),
+      content: "Session captured one episode with password=supersecretvalue.",
+    };
+    const { payload, redaction } = buildSessionIndexPayload({
       draft,
       sessionId: "uuid:test-session",
       scope: { workspaceId: "team-a", actorId: "agent-1", includeLegacy: false },
@@ -65,7 +68,10 @@ describe("daemon/session-index", () => {
     assert.equal(payload.kind, "summary");
     assert.equal(payload.memory_subtype, "session_index");
     assert.equal(payload.domain, "software_engineering");
+    assert.equal(payload.content, "Session captured one episode with password=[REDACTED:secret]");
     assert.deepEqual(payload.source_episode_ids, ["episode-1"]);
     assert.equal((payload.metadata as Record<string, string>).workstream_keys, "task-a");
+    assert.equal(redaction.redacted, true);
+    assert.deepEqual(payload.redaction, redaction);
   });
 });

--- a/src/daemon/session-index.ts
+++ b/src/daemon/session-index.ts
@@ -11,25 +11,17 @@ import { CAPTURE_POLICY_VERSION, DEFAULT_CAPTURE_CONTEXT, PROMPT_VERSIONS } from
 import type { EpisodeSummaryWriteResult } from "./episode-summary.js";
 import * as qdrant from "./qdrant.js";
 import type { QdrantPayload } from "./qdrant.js";
+import {
+  combineRedactions,
+  redactStorageText,
+  type RedactionSummary,
+} from "../privacy/redaction.js";
 
 export interface WorkspaceScope {
   workspaceId?: string;
   actorId?: string;
   includeLegacy?: boolean;
 }
-
-export interface RedactionSummary {
-  redacted: boolean;
-  summary: string;
-  matches: Array<{ type: string; count: number }>;
-}
-
-const noRedaction = (): RedactionSummary => ({ redacted: false, summary: "none", matches: [] });
-const passthroughText = (text: string, _options?: { enabled: boolean; redactPii: boolean }): { text: string; redacted: boolean; summary: string; matches: Array<{ type: string; count: number }> } => ({
-  text,
-  ...noRedaction(),
-});
-const combinePassThrough = (): RedactionSummary => noRedaction();
 
 export interface SessionIndexDraft {
   content: string;
@@ -99,9 +91,9 @@ export const buildSessionIndexPayload = (input: {
   eventCount: number;
   redactionOptions: { enabled: boolean; redactPii: boolean };
 }): SessionIndexPayloadResult => {
-  const redactedContent = passthroughText(input.draft.content, input.redactionOptions);
-  const redactedEntities = input.draft.entities.map((entity) => passthroughText(entity, input.redactionOptions));
-  const redaction = combinePassThrough();
+  const redactedContent = redactStorageText(input.draft.content, input.redactionOptions);
+  const redactedEntities = input.draft.entities.map((entity) => redactStorageText(entity, input.redactionOptions));
+  const redaction = combineRedactions([redactedContent, ...redactedEntities]);
   const existingPayload = input.existing?.payload ?? {};
 
   const payload: Record<string, unknown> = {
@@ -144,6 +136,8 @@ export const buildSessionIndexPayload = (input: {
 
   if (redaction.redacted) {
     payload["redaction"] = redaction;
+  } else {
+    delete payload["redaction"];
   }
 
   return { payload, redaction };
@@ -187,7 +181,7 @@ export const updateSessionIndex = async (input: {
     existing,
     eventCount: input.eventCount,
     redactionOptions: {
-      enabled: false,
+      enabled: true,
       redactPii: false,
     },
   });

--- a/src/daemon/session-summary.test.ts
+++ b/src/daemon/session-summary.test.ts
@@ -116,7 +116,7 @@ describe("daemon/session-summary", () => {
   });
 
   describe("buildSessionSummaryPayload", () => {
-    it("builds raw system summary payloads with optional workspace metadata", () => {
+    it("redacts secrets in system summary payloads with optional workspace metadata", () => {
       const { payload, redaction } = buildSessionSummaryPayload({
         draft: {
           content: "Configured service with password=supersecretvalue during daemon summary work.",
@@ -140,14 +140,16 @@ describe("daemon/session-summary", () => {
       assert.equal(payload.workspace_id, "team-a");
       assert.equal(payload.actor_id, "agent-1");
       assert.equal(payload.session_id, "uuid:test-session");
-      assert.match(String(payload.content), /password=supersecretvalue/);
+      assert.equal(payload.content, "Configured service with password=[REDACTED:secret] during daemon summary work.");
       assert.deepEqual(payload.tasks_completed, ["issue #14"]);
       assert.deepEqual(payload.decisions_made, ["Daemon owns summaries"]);
       assert.deepEqual(payload.entities, ["bikky", "daemon"]);
       assert.equal((payload.metadata as Record<string, string>).summary_source, "daemon");
       assert.equal((payload.metadata as Record<string, string>).summary_subtype, "session_index");
       assert.equal((payload.metadata as Record<string, string>).summary_event_count, "7");
-      assert.equal(redaction.redacted, false);
+      assert.equal(redaction.redacted, true);
+      assert.deepEqual(redaction.matches, [{ type: "secret", count: 1 }]);
+      assert.deepEqual(payload.redaction, redaction);
     });
 
     it("preserves existing created_at and fact counters on update", () => {

--- a/src/daemon/session-summary.ts
+++ b/src/daemon/session-summary.ts
@@ -16,25 +16,17 @@ import { buildSessionIndexFilter, updateSessionIndex } from "./session-index.js"
 import { updateWorkstreamSummaries } from "./workstream-summary.js";
 import * as qdrant from "./qdrant.js";
 import type { QdrantPayload } from "./qdrant.js";
+import {
+  combineRedactions,
+  redactStorageText,
+  type RedactionSummary,
+} from "../privacy/redaction.js";
 
 export interface WorkspaceScope {
   workspaceId?: string;
   actorId?: string;
   includeLegacy?: boolean;
 }
-
-export interface RedactionSummary {
-  redacted: boolean;
-  summary: string;
-  matches: Array<{ type: string; count: number }>;
-}
-
-const noRedaction = (): RedactionSummary => ({ redacted: false, summary: "none", matches: [] });
-const passthroughText = (text: string, _options?: { enabled: boolean; redactPii: boolean }): { text: string; redacted: boolean; summary: string; matches: Array<{ type: string; count: number }> } => ({
-  text,
-  ...noRedaction(),
-});
-const combinePassThrough = (): RedactionSummary => noRedaction();
 
 export interface SummaryEvent {
   type: string;
@@ -162,11 +154,16 @@ export const buildSessionSummaryPayload = (input: {
   eventCount: number;
   redactionOptions: { enabled: boolean; redactPii: boolean };
 }): SessionSummaryPayloadResult => {
-  const redactedContent = passthroughText(input.draft.content, input.redactionOptions);
-  const redactedTasks = input.draft.tasks_completed.map((task) => passthroughText(task, input.redactionOptions));
-  const redactedDecisions = input.draft.decisions_made.map((decision) => passthroughText(decision, input.redactionOptions));
-  const redactedEntities = input.draft.entities.map((entity) => passthroughText(entity, input.redactionOptions));
-  const redaction = combinePassThrough();
+  const redactedContent = redactStorageText(input.draft.content, input.redactionOptions);
+  const redactedTasks = input.draft.tasks_completed.map((task) => redactStorageText(task, input.redactionOptions));
+  const redactedDecisions = input.draft.decisions_made.map((decision) => redactStorageText(decision, input.redactionOptions));
+  const redactedEntities = input.draft.entities.map((entity) => redactStorageText(entity, input.redactionOptions));
+  const redaction = combineRedactions([
+    redactedContent,
+    ...redactedTasks,
+    ...redactedDecisions,
+    ...redactedEntities,
+  ]);
   const existingPayload = input.existing?.payload ?? {};
 
   const payload: Record<string, unknown> = {
@@ -208,13 +205,15 @@ export const buildSessionSummaryPayload = (input: {
 
   if (redaction.redacted) {
     payload["redaction"] = redaction;
+  } else {
+    delete payload["redaction"];
   }
 
   return { payload, redaction };
 };
 
 const redactionOptions = (_config: BikkyConfig): { enabled: boolean; redactPii: boolean } => ({
-  enabled: false,
+  enabled: true,
   redactPii: false,
 });
 

--- a/src/daemon/workstream-summary.test.ts
+++ b/src/daemon/workstream-summary.test.ts
@@ -86,10 +86,10 @@ describe("daemon/workstream-summary", () => {
     ), false);
   });
 
-  it("builds one current-state payload per workstream", () => {
-    const { payload } = buildWorkstreamSummaryPayload({
+  it("redacts secrets in one current-state payload per workstream", () => {
+    const { payload, redaction } = buildWorkstreamSummaryPayload({
       draft: {
-        content: "Memory ontology implementation is in validation.",
+        content: "Memory ontology implementation is in validation with api_key=supersecretvalue.",
         current_decisions: ["Use software_engineering as the default domain"],
         next_steps: ["Run npm test"],
         blockers: [],
@@ -111,5 +111,8 @@ describe("daemon/workstream-summary", () => {
     assert.equal(payload.repo, "bikky-dev/bikky");
     assert.deepEqual(payload.source_episode_ids, ["episode-1", "episode-2"]);
     assert.equal((payload.metadata as Record<string, string>).summary_subtype, "workstream");
+    assert.equal(payload.content, "Memory ontology implementation is in validation with api_key=[REDACTED:secret]");
+    assert.equal(redaction.redacted, true);
+    assert.deepEqual(payload.redaction, redaction);
   });
 });

--- a/src/daemon/workstream-summary.ts
+++ b/src/daemon/workstream-summary.ts
@@ -19,6 +19,11 @@ import {
 import type { EpisodeSummaryWriteResult } from "./episode-summary.js";
 import * as qdrant from "./qdrant.js";
 import type { QdrantPayload } from "./qdrant.js";
+import {
+  combineRedactions,
+  redactStorageText,
+  type RedactionSummary,
+} from "../privacy/redaction.js";
 
 export { buildWorkstreamSummaryMessages } from "../prompts/index.js";
 
@@ -27,19 +32,6 @@ export interface WorkspaceScope {
   actorId?: string;
   includeLegacy?: boolean;
 }
-
-export interface RedactionSummary {
-  redacted: boolean;
-  summary: string;
-  matches: Array<{ type: string; count: number }>;
-}
-
-const noRedaction = (): RedactionSummary => ({ redacted: false, summary: "none", matches: [] });
-const passthroughText = (text: string, _options?: { enabled: boolean; redactPii: boolean }): { text: string; redacted: boolean; summary: string; matches: Array<{ type: string; count: number }> } => ({
-  text,
-  ...noRedaction(),
-});
-const combinePassThrough = (): RedactionSummary => noRedaction();
 
 export interface WorkstreamSummaryDraft {
   content: string;
@@ -170,12 +162,18 @@ export const buildWorkstreamSummaryPayload = (input: {
   repo?: string | null;
   redactionOptions: { enabled: boolean; redactPii: boolean };
 }): WorkstreamSummaryPayloadResult => {
-  const redactedContent = passthroughText(input.draft.content, input.redactionOptions);
-  const redactedDecisions = input.draft.current_decisions.map((decision) => passthroughText(decision, input.redactionOptions));
-  const redactedNextSteps = input.draft.next_steps.map((step) => passthroughText(step, input.redactionOptions));
-  const redactedBlockers = input.draft.blockers.map((blocker) => passthroughText(blocker, input.redactionOptions));
-  const redactedEntities = input.draft.entities.map((entity) => passthroughText(entity, input.redactionOptions));
-  const redaction = combinePassThrough();
+  const redactedContent = redactStorageText(input.draft.content, input.redactionOptions);
+  const redactedDecisions = input.draft.current_decisions.map((decision) => redactStorageText(decision, input.redactionOptions));
+  const redactedNextSteps = input.draft.next_steps.map((step) => redactStorageText(step, input.redactionOptions));
+  const redactedBlockers = input.draft.blockers.map((blocker) => redactStorageText(blocker, input.redactionOptions));
+  const redactedEntities = input.draft.entities.map((entity) => redactStorageText(entity, input.redactionOptions));
+  const redaction = combineRedactions([
+    redactedContent,
+    ...redactedDecisions,
+    ...redactedNextSteps,
+    ...redactedBlockers,
+    ...redactedEntities,
+  ]);
   const existingPayload = input.existing?.payload ?? {};
 
   const payload: Record<string, unknown> = {
@@ -220,6 +218,8 @@ export const buildWorkstreamSummaryPayload = (input: {
 
   if (redaction.redacted) {
     payload["redaction"] = redaction;
+  } else {
+    delete payload["redaction"];
   }
 
   return { payload, redaction };
@@ -295,7 +295,7 @@ export const updateWorkstreamSummaries = async (input: {
       sourceEpisodeIds: episodes.map((episode) => episode.payload?.episode_id ?? episode.id).filter(Boolean) as string[],
       repo: null,
       redactionOptions: {
-        enabled: false,
+        enabled: true,
         redactPii: false,
       },
     });

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -235,9 +235,9 @@ describe("mcp/tools handlers", () => {
     it("inserts a new point when no duplicates are found", async () => {
       on("/points/scroll", () => ({ result: { points: [] } }));
       on("/points/search", () => ({ result: [] }));
-      let upsertBody: Record<string, unknown> | null = null;
+      const upsertBodies: Record<string, unknown>[] = [];
       on(/\/points$/, (call) => {
-        if (call.method === "PUT") upsertBody = call.body;
+        if (call.method === "PUT" && call.body) upsertBodies.push(call.body);
         return { status: "ok" };
       });
 
@@ -251,14 +251,48 @@ describe("mcp/tools handlers", () => {
       const parsed = JSON.parse(textOf(result));
       assert.equal(parsed.action, "inserted");
       assert.ok(parsed.fact_id, "should return a generated fact_id");
-      assert.ok(upsertBody, "expected an upsert PUT to /points");
-      const pt = (upsertBody as { points: Array<{ payload: Record<string, unknown> }> }).points[0];
+      assert.equal(upsertBodies.length, 1, "expected an upsert PUT to /points");
+      const upsertBody = upsertBodies[0]!;
+      const points = upsertBody.points;
+      assert.ok(Array.isArray(points), "expected points array");
+      const pt = points[0] as { payload: Record<string, unknown> };
       assert.equal(pt.payload.content, "platform is on AWS");
       assert.deepEqual(pt.payload.entities, ["platform"]); // lowercased
       assert.equal(pt.payload.reinforcement_count, 1);
       assert.equal(pt.payload.importance, 0.7);
       assert.ok(pt.payload.content_hash, "content_hash should be set");
       assert.equal(pt.payload.superseded_by, null);
+    });
+
+    it("redacts secret values before embedding and storage", async () => {
+      on("/points/scroll", () => ({ result: { points: [] } }));
+      on("/points/search", () => ({ result: [] }));
+      const upsertBodies: Record<string, unknown>[] = [];
+      on(/\/points$/, (call) => {
+        if (call.method === "PUT" && call.body) upsertBodies.push(call.body);
+        return { status: "ok" };
+      });
+
+      const result = await invoke("memory_store", {
+        content: "platform deploy uses password=supersecretvalue",
+        category: "infrastructure",
+        entities: ["platform"],
+      });
+
+      const parsed = JSON.parse(textOf(result));
+      assert.equal(parsed.action, "inserted");
+      const embedCall = callsTo("/v1/embeddings")[0];
+      assert.equal(embedCall?.body?.input, "platform deploy uses password=[REDACTED:secret]");
+      assert.equal(upsertBodies.length, 1, "expected an upsert PUT to /points");
+      const points = upsertBodies[0]!.points;
+      assert.ok(Array.isArray(points), "expected points array");
+      const pt = points[0] as { payload: Record<string, unknown> };
+      assert.equal(pt.payload.content, "platform deploy uses password=[REDACTED:secret]");
+      assert.deepEqual(pt.payload.redaction, {
+        redacted: true,
+        summary: "secret:1",
+        matches: [{ type: "secret", count: 1 }],
+      });
     });
 
     it("flags potential conflicts when similarity is in the related band with shared entities", async () => {
@@ -351,6 +385,41 @@ describe("mcp/tools handlers", () => {
       assert.equal(relPt.payload.to_entity, "platform");
       assert.equal(relPt.payload.relation_type, "owns");
       assert.deepEqual(relPt.payload.entities, ["saber", "platform"]);
+    });
+
+    it("scopes relation redaction metadata to the relation payload", async () => {
+      on("/points/scroll", () => ({ result: { points: [] } }));
+      on("/points/search", () => ({ result: [] }));
+      const upserts: Array<Record<string, unknown>> = [];
+      on(/\/points$/, (call) => {
+        if (call.method === "PUT") upserts.push(call.body as Record<string, unknown>);
+        return { status: "ok" };
+      });
+
+      const result = await invoke("memory_store", {
+        content: "saber owns platform",
+        category: "team",
+        entities: ["saber", "platform"],
+        relation: { from: "api_key=relationsecret", type: "Owns", to: "Platform" },
+      });
+
+      const parsed = JSON.parse(textOf(result));
+      assert.equal(parsed.action, "inserted");
+      assert.deepEqual(parsed.redaction, {
+        redacted: true,
+        summary: "secret:1",
+        matches: [{ type: "secret", count: 1 }],
+      });
+      assert.equal(upserts.length, 2);
+      const factPt = (upserts[0] as { points: Array<{ payload: Record<string, unknown> }> }).points[0];
+      const relPt = (upserts[1] as { points: Array<{ payload: Record<string, unknown> }> }).points[0];
+      assert.equal(factPt.payload.redaction, undefined);
+      assert.equal(relPt.payload.content, "api_key=[REDACTED:secret] Owns Platform");
+      assert.deepEqual(relPt.payload.redaction, {
+        redacted: true,
+        summary: "secret:1",
+        matches: [{ type: "secret", count: 1 }],
+      });
     });
   });
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -64,6 +64,11 @@ import {
 import { saveConfig, loadConfig, EXTRACTION_HEALTH_PATH } from "../config.js";
 import { existsSync, readFileSync } from "node:fs";
 import { inspectWatcherPaths, formatIssue } from "../daemon/watcher-health.js";
+import {
+  addRedactionPayload,
+  combineRedactions,
+  redactStorageText,
+} from "../privacy/redaction.js";
 
 // ---------------------------------------------------------------------------
 // Runtime state
@@ -91,27 +96,6 @@ interface WorkspaceScope {
   includeLegacy: boolean;
 }
 
-interface RedactionResult {
-  text: string;
-  redacted: boolean;
-  summary: string;
-  matches: Array<{ type: string; count: number }>;
-}
-
-type RedactionSummary = Omit<RedactionResult, "text">;
-
-function redactionOptions(): { enabled: boolean; redactPii: boolean } {
-  return { enabled: false, redactPii: false };
-}
-
-function redactStorageText(text: string): RedactionResult {
-  return { text, redacted: false, summary: "none", matches: [] };
-}
-
-function combineRedactions(_items: RedactionResult[]): RedactionSummary {
-  return { redacted: false, summary: "none", matches: [] };
-}
-
 function resolveScope(workspaceId?: string, includeLegacyWorkspace = false): WorkspaceScope {
   return {
     workspaceId: workspaceId?.trim() || undefined,
@@ -130,10 +114,6 @@ function scopedFilter(scope: WorkspaceScope, extra: Parameters<typeof buildFilte
 function addWorkspacePayload(payload: Record<string, unknown>, scope: WorkspaceScope): void {
   if (scope.workspaceId) payload["workspace_id"] = scope.workspaceId;
   if (scope.actorId) payload["actor_id"] = scope.actorId;
-}
-
-function addRedactionPayload(_payload: Record<string, unknown>, _summary: RedactionSummary): void {
-  // Task 243 keeps storage pass-through; redaction policy is out of scope for this branch.
 }
 
 async function getPointForWorkspaceWrite(factId: string, _scope: WorkspaceScope): Promise<{ point?: QdrantPoint; error?: Record<string, unknown> }> {
@@ -559,10 +539,16 @@ export function registerTools(mcp: McpServer): void {
         type: redactStorageText(relation.type),
         to: redactStorageText(relation.to),
       } : null;
-      const redactionSummary = combineRedactions([
+      const factRedactionSummary = combineRedactions([
         redactedContent,
         ...redactedEntities,
+      ]);
+      const relationRedactionSummary = combineRedactions([
         ...(redactedRelation ? [redactedRelation.from, redactedRelation.type, redactedRelation.to] : []),
+      ]);
+      const redactionSummary = combineRedactions([
+        factRedactionSummary,
+        relationRedactionSummary,
       ]);
       const hash = contentHash(normalizedCategory, redactedContent.text);
       const normalizedEntities = sanitizedEntities.map((e) => e.toLowerCase());
@@ -715,7 +701,7 @@ export function registerTools(mcp: McpServer): void {
       if (branch) payload["branch"] = branch;
       if (review_status) payload["review_status"] = review_status;
       addWorkspacePayload(payload, scope);
-      addRedactionPayload(payload, redactionSummary);
+      addRedactionPayload(payload, factRedactionSummary);
       if (metadata && Object.keys(metadata).length > 0) {
         payload["metadata"] = metadata;
       }
@@ -748,7 +734,7 @@ export function registerTools(mcp: McpServer): void {
           to_entity: sanitizedRelation.to.toLowerCase(),
         };
         addWorkspacePayload(relPayload, scope);
-        addRedactionPayload(relPayload, redactionSummary);
+        addRedactionPayload(relPayload, relationRedactionSummary);
         await qdrantUpsert(relationId, relVector, relPayload);
       }
 
@@ -1217,8 +1203,9 @@ export function registerTools(mcp: McpServer): void {
         const eventContent = note
           ? `Fact ${fact_id} marked useful: ${note}`
           : `Fact ${fact_id} marked useful.`;
+        const redactedEvent = redactStorageText(eventContent);
         const eventPayload: Record<string, unknown> = {
-          content: eventContent,
+          content: redactedEvent.text,
           category: "observations",
           domain: "software_engineering",
           kind: "telemetry",
@@ -1235,8 +1222,9 @@ export function registerTools(mcp: McpServer): void {
           updated_at: now,
         };
         addWorkspacePayload(eventPayload, scope);
+        addRedactionPayload(eventPayload, redactedEvent);
         try {
-          const eventVector = await embed(eventContent);
+          const eventVector = await embed(redactedEvent.text);
           await qdrantUpsert(eventId, eventVector, eventPayload);
         } catch (e) {
           log("WARN", `Failed to record feedback_event: ${e instanceof Error ? e.message : String(e)}`);
@@ -1290,8 +1278,9 @@ export function registerTools(mcp: McpServer): void {
         const eventContent = notes
           ? `Fact ${fact_id} outcome=${outcome}: ${notes}`
           : `Fact ${fact_id} outcome=${outcome}.`;
+        const redactedEvent = redactStorageText(eventContent);
         const eventPayload: Record<string, unknown> = {
-          content: eventContent,
+          content: redactedEvent.text,
           category: "observations",
           domain: "software_engineering",
           kind: "telemetry",
@@ -1308,7 +1297,8 @@ export function registerTools(mcp: McpServer): void {
           updated_at: now,
         };
         addWorkspacePayload(eventPayload, scope);
-        const eventVector = await embed(eventContent);
+        addRedactionPayload(eventPayload, redactedEvent);
+        const eventVector = await embed(redactedEvent.text);
         await qdrantUpsert(eventId, eventVector, eventPayload);
 
         return {
@@ -1356,9 +1346,10 @@ export function registerTools(mcp: McpServer): void {
         const scope = resolveScope(workspace_id);
         const normalizedEntities = (entities ?? []).map((e) => e.trim().toLowerCase()).filter(Boolean);
         const summaryId = newId();
-        const vector = await embed(content);
+        const redactedContent = redactStorageText(content);
+        const vector = await embed(redactedContent.text);
         const payload: Record<string, unknown> = {
-          content,
+          content: redactedContent.text,
           category: categoryForMemorySubtype("session_index") ?? "projects",
           domain: "software_engineering",
           kind: "summary",
@@ -1368,7 +1359,7 @@ export function registerTools(mcp: McpServer): void {
           source: "agent",
           confidence: 0.9,
           importance: 0.6,
-          content_hash: contentHash("summary", content),
+          content_hash: contentHash("summary", redactedContent.text),
           reinforcement_count: 1,
           last_reinforced_at: now,
           superseded_by: null,
@@ -1381,6 +1372,7 @@ export function registerTools(mcp: McpServer): void {
         if (task_key) payload["task_key"] = task_key;
         if (repo) payload["repo"] = repo;
         addWorkspacePayload(payload, scope);
+        addRedactionPayload(payload, redactedContent);
         await qdrantUpsert(summaryId, vector, payload);
 
         return {
@@ -1428,7 +1420,8 @@ export function registerTools(mcp: McpServer): void {
         const scope = resolveScope(workspace_id);
         const normalizedEntities = entities.map((e) => e.trim().toLowerCase()).filter(Boolean);
         const distilledId = newId();
-        const vector = await embed(content);
+        const redactedContent = redactStorageText(content);
+        const vector = await embed(redactedContent.text);
 
         if (supersedes) {
           const existing = await getPointForWorkspaceWrite(supersedes, scope);
@@ -1442,7 +1435,7 @@ export function registerTools(mcp: McpServer): void {
         }
 
         const payload: Record<string, unknown> = {
-          content,
+          content: redactedContent.text,
           category: categoryForMemorySubtype("convention") ?? "observations",
           domain: "software_engineering",
           kind: "distilled",
@@ -1452,7 +1445,7 @@ export function registerTools(mcp: McpServer): void {
           source: "agent",
           confidence: 0.9,
           importance: 0.7,
-          content_hash: contentHash("distilled", content),
+          content_hash: contentHash("distilled", redactedContent.text),
           reinforcement_count: 1,
           last_reinforced_at: now,
           superseded_by: null,
@@ -1463,6 +1456,7 @@ export function registerTools(mcp: McpServer): void {
         if (task_key) payload["task_key"] = task_key;
         if (repo) payload["repo"] = repo;
         addWorkspacePayload(payload, scope);
+        addRedactionPayload(payload, redactedContent);
         await qdrantUpsert(distilledId, vector, payload);
 
         return {

--- a/src/privacy/redaction.test.ts
+++ b/src/privacy/redaction.test.ts
@@ -1,0 +1,68 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  addRedactionPayload,
+  combineRedactions,
+  redactStorageText,
+} from "./redaction.js";
+
+describe("privacy/redaction", () => {
+  it("redacts assignment-style secrets", () => {
+    const result = redactStorageText("Configured service with password=supersecretvalue and api_key: sk-testsecretvalue123456789.");
+
+    assert.equal(result.text, "Configured service with password=[REDACTED:secret] and api_key: [REDACTED:secret]");
+    assert.equal(result.redacted, true);
+    assert.equal(result.summary, "secret:2");
+    assert.deepEqual(result.matches, [{ type: "secret", count: 2 }]);
+  });
+
+  it("redacts bearer and common token prefixes", () => {
+    const result = redactStorageText("Use Bearer abcdefghijklmnop and ghp_abcdefghijklmnopqrstuvwxyz1234567890");
+
+    assert.equal(result.text, "Use Bearer [REDACTED:secret] and [REDACTED:secret]");
+    assert.deepEqual(result.matches, [{ type: "secret", count: 2 }]);
+  });
+
+  it("leaves non-secret text unchanged", () => {
+    const result = redactStorageText("Bikky stores memory in Qdrant.");
+
+    assert.equal(result.text, "Bikky stores memory in Qdrant.");
+    assert.equal(result.redacted, false);
+    assert.equal(result.summary, "none");
+    assert.deepEqual(result.matches, []);
+  });
+
+  it("can be explicitly disabled", () => {
+    const result = redactStorageText("password=supersecretvalue", { enabled: false });
+
+    assert.equal(result.text, "password=supersecretvalue");
+    assert.equal(result.redacted, false);
+  });
+
+  it("combines redaction summaries", () => {
+    const first = redactStorageText("password=one");
+    const second = redactStorageText("token=two");
+
+    assert.deepEqual(combineRedactions([first, second]), {
+      redacted: true,
+      summary: "secret:2",
+      matches: [{ type: "secret", count: 2 }],
+    });
+  });
+
+  it("adds payload metadata only when redacted", () => {
+    const payload: Record<string, unknown> = {};
+    addRedactionPayload(payload, redactStorageText("password=one"));
+
+    assert.deepEqual(payload.redaction, {
+      redacted: true,
+      summary: "secret:1",
+      matches: [{ type: "secret", count: 1 }],
+    });
+
+    const cleanPayload: Record<string, unknown> = {};
+    addRedactionPayload(cleanPayload, redactStorageText("no secrets here"));
+    assert.equal(cleanPayload.redaction, undefined);
+  });
+});

--- a/src/privacy/redaction.ts
+++ b/src/privacy/redaction.ts
@@ -1,0 +1,127 @@
+export interface RedactionMatch {
+  type: string;
+  count: number;
+}
+
+export interface RedactionSummary {
+  redacted: boolean;
+  summary: string;
+  matches: RedactionMatch[];
+}
+
+export interface RedactionResult extends RedactionSummary {
+  text: string;
+}
+
+export interface RedactionOptions {
+  enabled?: boolean;
+  redactPii?: boolean;
+}
+
+const SECRET_PLACEHOLDER = "[REDACTED:secret]";
+
+interface RedactionPattern {
+  type: string;
+  pattern: RegExp;
+  replace(match: string, ...groups: string[]): string;
+}
+
+const secretPatterns: RedactionPattern[] = [
+  {
+    type: "secret",
+    pattern: /\b((?:password|passwd|pwd|api[_-]?key|token|access[_-]?token|refresh[_-]?token|secret|client[_-]?secret|private[_-]?key)\s*[:=]\s*)(?:"[^"\s,;]+"|'[^'\s,;]+'|[^\s,;]+)/gi,
+    replace: (_match, prefix) => `${prefix}${SECRET_PLACEHOLDER}`,
+  },
+  {
+    type: "secret",
+    pattern: /\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi,
+    replace: (_match, prefix) => `${prefix}${SECRET_PLACEHOLDER}`,
+  },
+  {
+    type: "secret",
+    pattern: /\b(?:github_pat_[A-Za-z0-9_]{20,}|gh[opsur]_[A-Za-z0-9_]{20,})\b/g,
+    replace: () => SECRET_PLACEHOLDER,
+  },
+  {
+    type: "secret",
+    pattern: /\bsk-[A-Za-z0-9_-]{20,}\b/g,
+    replace: () => SECRET_PLACEHOLDER,
+  },
+  {
+    type: "secret",
+    pattern: /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g,
+    replace: () => SECRET_PLACEHOLDER,
+  },
+];
+
+export const noRedaction = (): RedactionSummary => ({
+  redacted: false,
+  summary: "none",
+  matches: [],
+});
+
+const summarizeMatches = (counts: Map<string, number>): RedactionSummary => {
+  const matches = [...counts.entries()]
+    .filter(([, count]) => count > 0)
+    .map(([type, count]) => ({ type, count }));
+
+  if (matches.length === 0) return noRedaction();
+
+  return {
+    redacted: true,
+    summary: matches.map((match) => `${match.type}:${match.count}`).join(","),
+    matches,
+  };
+};
+
+export const redactStorageText = (
+  text: string,
+  options: RedactionOptions = {},
+): RedactionResult => {
+  if (options.enabled === false) {
+    return { text, ...noRedaction() };
+  }
+
+  let redactedText = text;
+  const counts = new Map<string, number>();
+
+  for (const { type, pattern, replace } of secretPatterns) {
+    redactedText = redactedText.replace(pattern, (match, ...groups: string[]) => {
+      counts.set(type, (counts.get(type) ?? 0) + 1);
+      return replace(match, ...groups);
+    });
+  }
+
+  return {
+    text: redactedText,
+    ...summarizeMatches(counts),
+  };
+};
+
+export const combineRedactions = (
+  items: Array<RedactionSummary | RedactionResult | null | undefined>,
+): RedactionSummary => {
+  const counts = new Map<string, number>();
+
+  for (const item of items) {
+    if (!item?.redacted) continue;
+    for (const match of item.matches) {
+      counts.set(match.type, (counts.get(match.type) ?? 0) + match.count);
+    }
+  }
+
+  return summarizeMatches(counts);
+};
+
+export const addRedactionPayload = (
+  payload: Record<string, unknown>,
+  summary: RedactionSummary,
+): void => {
+  if (summary.redacted) {
+    payload["redaction"] = {
+      redacted: summary.redacted,
+      summary: summary.summary,
+      matches: summary.matches,
+    };
+  }
+};


### PR DESCRIPTION
## Summary
- add deterministic storage-time redaction for obvious secrets before embedding, hashing, and Qdrant storage
- wire redaction through MCP memory writes, daemon fact storage, daemon summaries/indexes, and UI create/update memory routes
- attach compact redaction metadata only when stored text fields are redacted
- update tests for redaction helpers, MCP writes, daemon storage/summaries, and UI routes

## Validation
- npm run build
- npm test
- npm run typecheck
- cd packages/ui && npm run build && npm test

Note: `npm run check` still cannot start ESLint because the repo is on ESLint v9 without an `eslint.config.*`; standalone TypeScript typecheck passes.

Fixes #65