### PR TITLE
Improve config validation and bikky status diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ bikky setup            # writes MCP config for Copilot + Claude Code, then start
 Restart your editor — the memory tools (`memory_store`, `memory_recall`, …) appear automatically.
 
 ```bash
-bikky status           # sanity-check that Qdrant + embeddings are reachable
+bikky status           # validate config, Qdrant, embeddings, daemon, and UI health
 ```
 
 That's the whole thing. From here you can swap any piece (hosted Qdrant, OpenAI / Bedrock embeddings, a hosted LLM for richer daemon distillation) — see **Setup** below.
@@ -198,7 +198,7 @@ bikky-ui              # opens http://localhost:1422
 </p>
 <p align="center"><i>Entity graph — interactive visualization of how concepts, people, and services relate</i></p>
 
-The UI reads from your existing `~/.bikky/config.json` — no extra configuration required.
+The UI reads from your existing `~/.bikky/config.json` (or `BIKKY_HOME/config.json`) — no extra configuration required.
 
 ## CLI
 
@@ -212,6 +212,13 @@ bikky status    # check memory system health
 bikky ui        # launch the local web dashboard
 bikky render    # render a prompt to JSON (for eval harnesses & debugging)
 ```
+
+`bikky status` is the first thing to run when setup feels wrong. It validates the
+config file, highlights env vars that override it, checks Qdrant reachability and
+payload-index readiness without mutating the collection, runs a live embedding
+smoke check, validates the configured LLM provider name without sending a chat
+request, and reports daemon/UI health. Use `bikky status --json` for automation,
+`--no-live` to skip the embedding call, and `--no-ui` to skip the local UI probe.
 
 ### `bikky render` — inspect prompts
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-Config lives at `~/.bikky/config.json`. Resolution order: **defaults → config file → env vars** (highest wins).
+Config lives at `~/.bikky/config.json`, or `BIKKY_HOME/config.json` when `BIKKY_HOME` is set. Resolution order: **defaults → config file → env vars** (highest wins).
 
 ## Qdrant (required)
 
@@ -21,7 +21,7 @@ Both `embedding.provider` and `llm.provider` accept one of four built-in values:
 | Value | What it is | Auth needed | `base_url` used? |
 |-------|-----------|-------------|-----------------|
 | `ollama` | Local Ollama server | None | ✅ default `http://localhost:11434` |
-| `openai` | OpenAI-compatible API | `api_key` or `OPENAI_API_KEY` | ✅ default `https://api.openai.com/v1` |
+| `openai` | OpenAI-compatible API | `api_key` or `OPENAI_API_KEY` | ✅ default `https://api.openai.com` |
 | `bedrock` | AWS Bedrock | AWS credentials (env or IAM role) | ❌ uses AWS SDK |
 | `portkey` | [Portkey](https://portkey.ai) gateway (routes to OpenAI / Anthropic / Bedrock / etc.) | `api_key` (Portkey key) | ✅ default `https://api.portkey.ai` |
 
@@ -56,7 +56,7 @@ Both `embedding.provider` and `llm.provider` accept one of four built-in values:
 | `llm.model` | `LLM_MODEL` | `qwen2.5:7b` |
 | `llm.base_url` | `LLM_BASE_URL` | `http://localhost:11434` |
 | `llm.api_key` | `OPENAI_API_KEY` | — |
-| `llm.bedrock_region` | `AWS_BEDROCK_REGION` | `us-east-1` |
+| `llm.extra.region` | `AWS_BEDROCK_REGION` / `AWS_REGION` | `us-east-1` |
 
 **Models by provider:**
 
@@ -64,10 +64,12 @@ Both `embedding.provider` and `llm.provider` accept one of four built-in values:
 |----------|-------------------|
 | `ollama` | `qwen2.5:7b`, `llama3.1:8b`, or any local model |
 | `openai` | `gpt-4.1-mini`, `gpt-4.1` |
-| `bedrock` | `anthropic.claude-3-5-haiku-20241022-v1:0` |
+| `bedrock` | `us.anthropic.claude-sonnet-4-20250514`, `anthropic.claude-3-5-haiku-20241022-v1:0` |
 | `portkey` | `@openai/gpt-4o-mini`, `@anthropic/claude-3-5-haiku-latest`, or any model exposed by your Portkey workspace |
 
-> `llm.bedrock_region` falls back to `AWS_REGION` if `AWS_BEDROCK_REGION` is not set.
+> Bedrock reads `embedding.extra.region` and `llm.extra.region`. `AWS_BEDROCK_REGION`
+> populates both, falling back to `AWS_REGION`; `aws_profile` or `AWS_PROFILE`
+> selects the shared AWS profile when you are not using direct env credentials.
 
 **Portkey extras** (optional, set via `extra.*` or `BIKKY_LLM_EXTRA_<KEY>` / `BIKKY_EMBEDDING_EXTRA_<KEY>` env vars):
 
@@ -124,7 +126,40 @@ payload that now includes a human-readable `setup_error` field:
 }
 ```
 
-`get_setup_status` exposes the same info for diagnostics.
+`get_setup_status` exposes the same info for MCP diagnostics. From the terminal,
+run `bikky status`.
+
+### `bikky status`
+
+`bikky status` is read-only. It does not create collections, add indexes, repair
+config, or send an LLM chat request. It reports:
+
+| Check | What it does |
+|-------|--------------|
+| Config | Parses `~/.bikky/config.json` (or `BIKKY_HOME/config.json`), validates common schema/type mistakes, and lists active env overrides |
+| Qdrant | Checks reachability, collection existence, vector size, and payload-index readiness against Bikky's canonical index list |
+| Embedding | Validates the provider config and runs a small live embedding request by default |
+| LLM | Validates provider and fallback provider names without a live inference call |
+| Daemon/UI | Reports daemon PID state and probes the local UI `/health` endpoint |
+
+Useful options:
+
+```bash
+bikky status --json     # machine-readable report
+bikky status --no-live  # skip the live embedding request
+bikky status --no-ui    # skip the local UI health probe
+```
+
+`bikky status` exits non-zero when required setup is broken, such as invalid
+JSON, unknown provider names, missing Qdrant configuration, unreachable Qdrant,
+or embedding connectivity/dimension failures. Missing Qdrant payload indexes are
+reported as warnings because they affect query performance/readiness but can be
+repaired separately by normal startup readiness logic.
+
+After changing provider, Qdrant, or AWS settings, restart the long-running
+processes that already loaded the old config: run `bikky stop && bikky start`
+for the daemon, and restart your editor so its MCP server process re-reads the
+file and env vars.
 
 ## Copy-paste examples
 
@@ -187,8 +222,8 @@ payload that now includes a human-readable `setup_error` field:
   },
   "llm": {
     "provider": "bedrock",
-    "model": "anthropic.claude-3-5-haiku-20241022-v1:0",
-    "bedrock_region": "us-east-1"
+    "model": "us.anthropic.claude-sonnet-4-20250514",
+    "extra": { "region": "us-east-1" }
   }
 }
 ```

--- a/packages/ui/src/lib/config.test.ts
+++ b/packages/ui/src/lib/config.test.ts
@@ -6,8 +6,12 @@ import { describe, it, before, after, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
+import os from "node:os";
 
-import { loadConfig, _resetConfig, CONFIG_PATH } from "./config.js";
+const TEST_BIKKY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-ui-config-"));
+process.env.BIKKY_HOME = TEST_BIKKY_HOME;
+
+const { loadConfig, _resetConfig, CONFIG_PATH, BIKKY_DIR } = await import("./config.js");
 
 const ENV_KEYS = [
   "QDRANT_URL",
@@ -16,6 +20,7 @@ const ENV_KEYS = [
   "EMBEDDING_PROVIDER",
   "EMBEDDING_MODEL",
   "EMBEDDING_BASE_URL",
+  "EMBEDDING_DIMENSIONS",
   "OPENAI_API_KEY",
 ];
 
@@ -40,12 +45,18 @@ describe("ui/lib/config", () => {
     if (savedConfig !== null) fs.writeFileSync(CONFIG_PATH, savedConfig);
     else if (!configExisted && fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
     _resetConfig();
+    fs.rmSync(TEST_BIKKY_HOME, { recursive: true, force: true });
   });
 
   beforeEach(() => {
     for (const k of ENV_KEYS) delete process.env[k];
     if (fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
     _resetConfig();
+  });
+
+  it("honors BIKKY_HOME for the config directory", () => {
+    assert.equal(BIKKY_DIR, TEST_BIKKY_HOME);
+    assert.equal(CONFIG_PATH, path.join(TEST_BIKKY_HOME, "config.json"));
   });
 
   it("returns defaults when no config file or env vars are set", () => {
@@ -93,6 +104,14 @@ describe("ui/lib/config", () => {
     assert.equal(cfg.qdrant_url, "https://from-env:6333");
     assert.equal(cfg.qdrant_api_key, "env-key");
     assert.equal(cfg.collection, "envcol");
+  });
+
+  it("reads embedding dimensions from env vars", () => {
+    process.env.EMBEDDING_DIMENSIONS = "1536";
+
+    const cfg = loadConfig();
+
+    assert.equal(cfg.embedding.dimensions, 1536);
   });
 
   it("strips trailing slashes from URLs", () => {

--- a/packages/ui/src/lib/config.ts
+++ b/packages/ui/src/lib/config.ts
@@ -1,13 +1,14 @@
 /**
  * Config reader for @bikky/ui.
- * Reads ~/.bikky/config.json directly — no dependency on core bikky package.
+ * Reads BIKKY_HOME/config.json (or ~/.bikky/config.json) directly — no
+ * dependency on the core bikky package.
  */
 
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
-export const BIKKY_DIR = path.join(os.homedir(), ".bikky");
+export const BIKKY_DIR = process.env.BIKKY_HOME ?? path.join(os.homedir(), ".bikky");
 export const CONFIG_PATH = path.join(BIKKY_DIR, "config.json");
 
 export interface BikkyUIConfig {
@@ -72,6 +73,10 @@ export function loadConfig(): BikkyUIConfig {
   if (process.env.EMBEDDING_PROVIDER) config.embedding.provider = process.env.EMBEDDING_PROVIDER;
   if (process.env.EMBEDDING_MODEL) config.embedding.model = process.env.EMBEDDING_MODEL;
   if (process.env.EMBEDDING_BASE_URL) config.embedding.base_url = process.env.EMBEDDING_BASE_URL;
+  if (process.env.EMBEDDING_DIMENSIONS) {
+    const n = parseInt(process.env.EMBEDDING_DIMENSIONS, 10);
+    if (Number.isFinite(n) && n > 0) config.embedding.dimensions = n;
+  }
   if (process.env.OPENAI_API_KEY) config.embedding.api_key = process.env.OPENAI_API_KEY;
 
   // Strip trailing slashes

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,8 +16,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import { startMcpServer } from "./mcp/index.js";
-import { getDaemonStatus, startAll, killDaemon } from "./lifecycle.js";
+import { startAll, killDaemon } from "./lifecycle.js";
 import { runRenderCli } from "./render.js";
+import { collectStatus, formatStatusReport, statusExitCode } from "./status.js";
 
 const command = process.argv[2] ?? "mcp";
 
@@ -79,11 +80,30 @@ async function main(): Promise<void> {
       break;
 
     case "status": {
-      const status = getDaemonStatus();
-      printVersion();
-      console.log(`Daemon: ${status.running ? `🟢 running (PID ${status.pid})` : "🔴 stopped"}`);
-      console.log("MCP:    managed by your editor (stdio)");
-      console.log("\nRun `bikky start` to launch everything.");
+      const args = process.argv.slice(3);
+      const allowed = new Set(["--json", "--no-live", "--no-ui"]);
+      const unknown = args.filter((arg) => !allowed.has(arg));
+      if (unknown.length > 0) {
+        console.error(`Unknown status option: ${unknown.join(", ")}`);
+        console.error("Usage: bikky status [--json] [--no-live] [--no-ui]");
+        process.exit(1);
+      }
+
+      const report = await collectStatus({
+        live: !args.includes("--no-live"),
+        checkUi: !args.includes("--no-ui"),
+      });
+      if (args.includes("--json")) {
+        console.log(JSON.stringify(report, null, 2));
+      } else {
+        printVersion();
+        console.log("");
+        console.log(formatStatusReport(report));
+        if (!report.ok) {
+          console.log("\nRun `bikky start` after fixing setup issues.");
+        }
+      }
+      process.exitCode = statusExitCode(report);
       break;
     }
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -25,6 +25,9 @@ const {
   LOG_DIR,
   STATE_DIR,
   CONFIG_DEFAULTS,
+  getActiveConfigEnvOverrides,
+  inspectConfigFile,
+  validateConfigObject,
 } = await import("./config.js");
 
 // ---------------------------------------------------------------------------
@@ -64,6 +67,8 @@ const ENV_KEYS = [
   "LLM_BASE_URL",
   "AWS_BEDROCK_REGION",
   "AWS_REGION",
+  "BIKKY_LLM_EXTRA_REGION",
+  "BIKKY_EMBEDDING_EXTRA_REGION",
 ];
 
 let savedEnv: Record<string, string | undefined> = {};
@@ -303,6 +308,13 @@ describe("config", () => {
       assert.strictEqual(cfg.embedding.dimensions, 1536);
     });
 
+    it("ignores invalid EMBEDDING_DIMENSIONS values", () => {
+      if (fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
+      process.env.EMBEDDING_DIMENSIONS = "not-a-number";
+      const cfg = loadConfig();
+      assert.strictEqual(cfg.embedding.dimensions, 1024);
+    });
+
     it("OPENAI_API_KEY overrides embedding.api_key", () => {
       if (fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
       process.env.OPENAI_API_KEY = "sk-test-key";
@@ -459,6 +471,57 @@ describe("config", () => {
       // Should not throw — falls back to defaults
       const cfg = loadConfig();
       assert.strictEqual(cfg.collection, "bikky");
+    });
+  });
+
+  // ── Config diagnostics ────────────────────────────────────────────────────
+
+  describe("config diagnostics", () => {
+    it("reports missing config file without errors", () => {
+      if (fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
+
+      const diag = inspectConfigFile();
+
+      assert.equal(diag.exists, false);
+      assert.equal(diag.parse_error, null);
+      assert.deepEqual(diag.issues, []);
+    });
+
+    it("reports malformed JSON without throwing", () => {
+      fs.mkdirSync(BIKKY_DIR, { recursive: true });
+      fs.writeFileSync(CONFIG_PATH, "{ invalid json !!!");
+
+      const diag = inspectConfigFile();
+
+      assert.equal(diag.exists, true);
+      assert.ok(diag.parse_error);
+      assert.equal(diag.issues[0]?.severity, "error");
+      assert.equal(diag.issues[0]?.path, "$");
+    });
+
+    it("validates config object types and URL fields", () => {
+      const issues = validateConfigObject({
+        qdrant_url: "ftp://qdrant.example",
+        collection: "",
+        embedding: { dimensions: -1, base_url: "not a url" },
+        daemon: { consolidation_enabled: "yes" },
+      });
+
+      assert.ok(issues.some((issue) => issue.path === "qdrant_url"));
+      assert.ok(issues.some((issue) => issue.path === "collection"));
+      assert.ok(issues.some((issue) => issue.path === "embedding.dimensions"));
+      assert.ok(issues.some((issue) => issue.path === "embedding.base_url"));
+      assert.ok(issues.some((issue) => issue.path === "daemon.consolidation_enabled"));
+    });
+
+    it("lists active exact and provider-extra env overrides", () => {
+      process.env.QDRANT_URL = "https://qdrant.example:6333";
+      process.env.BIKKY_LLM_EXTRA_REGION = "us-west-2";
+
+      const active = getActiveConfigEnvOverrides();
+
+      assert.ok(active.includes("QDRANT_URL"));
+      assert.ok(active.includes("BIKKY_LLM_EXTRA_REGION"));
     });
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { z } from "zod";
 
 // ---------------------------------------------------------------------------
 // Paths
@@ -96,6 +97,21 @@ export interface BikkyConfig {
   qdrant_client: QdrantClientConfig;
 }
 
+export type ConfigIssueSeverity = "error" | "warning";
+
+export interface ConfigIssue {
+  severity: ConfigIssueSeverity;
+  path: string;
+  message: string;
+}
+
+export interface ConfigFileDiagnostics {
+  path: string;
+  exists: boolean;
+  parse_error: string | null;
+  issues: ConfigIssue[];
+}
+
 // ---------------------------------------------------------------------------
 // Defaults
 // ---------------------------------------------------------------------------
@@ -147,6 +163,105 @@ const DEFAULTS: BikkyConfig = {
   },
 };
 
+export const CONFIG_ENV_KEYS = [
+  "QDRANT_URL",
+  "QDRANT_API_KEY",
+  "BIKKY_COLLECTION",
+  "EMBEDDING_PROVIDER",
+  "EMBEDDING_MODEL",
+  "EMBEDDING_BASE_URL",
+  "EMBEDDING_DIMENSIONS",
+  "OPENAI_API_KEY",
+  "LLM_PROVIDER",
+  "LLM_MODEL",
+  "LLM_BASE_URL",
+  "LLM_FALLBACK_PROVIDER",
+  "AWS_PROFILE",
+  "AWS_BEDROCK_REGION",
+  "AWS_REGION",
+  "QDRANT_TIMEOUT_MS",
+  "QDRANT_RETRIES",
+  "QDRANT_RETRY_BASE_DELAY_MS",
+  "BIKKY_EMBEDDING_TIMEOUT_MS",
+  "BIKKY_EMBEDDING_RETRIES",
+  "BIKKY_EMBEDDING_RETRY_BASE_DELAY_MS",
+  "BIKKY_LLM_TIMEOUT_MS",
+  "BIKKY_LLM_RETRIES",
+  "BIKKY_LLM_RETRY_BASE_DELAY_MS",
+] as const;
+
+const CONFIG_ENV_PREFIXES = [
+  "BIKKY_EMBEDDING_EXTRA_",
+  "BIKKY_LLM_EXTRA_",
+] as const;
+
+const nonNegativeInt = z.number().int().nonnegative();
+const positiveInt = z.number().int().positive();
+const stringRecord = z.record(z.string());
+
+const embeddingConfigFileSchema = z.object({
+  provider: z.string().optional(),
+  model: z.string().optional(),
+  dimensions: positiveInt.optional(),
+  base_url: z.string().optional(),
+  api_key: z.string().nullable().optional(),
+  extra: stringRecord.optional(),
+  timeout_ms: nonNegativeInt.optional(),
+  retries: nonNegativeInt.optional(),
+  retry_base_delay_ms: nonNegativeInt.optional(),
+}).passthrough();
+
+const llmConfigFileSchema = z.object({
+  provider: z.string().optional(),
+  model: z.string().optional(),
+  base_url: z.string().optional(),
+  api_key: z.string().nullable().optional(),
+  fallback_provider: z.string().nullable().optional(),
+  extra: stringRecord.optional(),
+  timeout_ms: nonNegativeInt.optional(),
+  retries: nonNegativeInt.optional(),
+  retry_base_delay_ms: nonNegativeInt.optional(),
+}).passthrough();
+
+const daemonConfigFileSchema = z.object({
+  tick_interval_sec: nonNegativeInt.optional(),
+  extract_every_sec: nonNegativeInt.optional(),
+  extract_min_events: nonNegativeInt.optional(),
+  extraction_prompt: z.string().nullable().optional(),
+  consolidation_enabled: z.boolean().optional(),
+  relation_inference_enabled: z.boolean().optional(),
+  staleness_threshold_days: nonNegativeInt.optional(),
+}).passthrough();
+
+const watcherConfigFileSchema = z.object({
+  copilot: z.object({
+    enabled: z.boolean().optional(),
+    path: z.string().optional(),
+  }).passthrough().optional(),
+  claude: z.object({
+    enabled: z.boolean().optional(),
+    path: z.string().optional(),
+  }).passthrough().optional(),
+}).passthrough();
+
+const qdrantClientConfigFileSchema = z.object({
+  timeout_ms: nonNegativeInt.optional(),
+  retries: nonNegativeInt.optional(),
+  retry_base_delay_ms: nonNegativeInt.optional(),
+}).passthrough();
+
+const configFileSchema = z.object({
+  qdrant_url: z.string().nullable().optional(),
+  qdrant_api_key: z.string().nullable().optional(),
+  collection: z.string().optional(),
+  aws_profile: z.string().nullable().optional(),
+  embedding: embeddingConfigFileSchema.optional(),
+  llm: llmConfigFileSchema.optional(),
+  daemon: daemonConfigFileSchema.optional(),
+  watchers: watcherConfigFileSchema.optional(),
+  qdrant_client: qdrantClientConfigFileSchema.optional(),
+}).passthrough();
+
 // ---------------------------------------------------------------------------
 // Deep merge utility
 // ---------------------------------------------------------------------------
@@ -163,6 +278,121 @@ function deepMerge<T extends Record<string, unknown>>(base: T, override: Record<
     }
   }
   return result;
+}
+
+function issuePath(pathParts: Array<string | number>): string {
+  return pathParts.length === 0 ? "$" : pathParts.map(String).join(".");
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function childObject(raw: Record<string, unknown>, key: string): Record<string, unknown> | null {
+  const value = raw[key];
+  return isObject(value) ? value : null;
+}
+
+function validateUrlLike(value: unknown, pathName: string, issues: ConfigIssue[]): void {
+  if (typeof value !== "string" || value.trim() === "") return;
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      issues.push({
+        severity: "error",
+        path: pathName,
+        message: "must use http:// or https://",
+      });
+    }
+  } catch {
+    issues.push({
+      severity: "error",
+      path: pathName,
+      message: "must be a valid URL",
+    });
+  }
+}
+
+export function validateConfigObject(raw: unknown): ConfigIssue[] {
+  const parsed = configFileSchema.safeParse(raw);
+  const issues: ConfigIssue[] = [];
+
+  if (!parsed.success) {
+    for (const issue of parsed.error.issues) {
+      issues.push({
+        severity: "error",
+        path: issuePath(issue.path),
+        message: issue.message,
+      });
+    }
+    if (!isObject(raw)) return issues;
+  }
+
+  if (!isObject(raw)) {
+    issues.push({
+      severity: "error",
+      path: "$",
+      message: "config file must contain a JSON object",
+    });
+    return issues;
+  }
+
+  if (typeof raw.collection === "string" && raw.collection.trim() === "") {
+    issues.push({
+      severity: "error",
+      path: "collection",
+      message: "must not be empty",
+    });
+  }
+
+  validateUrlLike(raw.qdrant_url, "qdrant_url", issues);
+
+  const embedding = childObject(raw, "embedding");
+  if (embedding) validateUrlLike(embedding.base_url, "embedding.base_url", issues);
+
+  const llm = childObject(raw, "llm");
+  if (llm) validateUrlLike(llm.base_url, "llm.base_url", issues);
+
+  return issues;
+}
+
+export function inspectConfigFile(configPath = CONFIG_PATH): ConfigFileDiagnostics {
+  if (!fs.existsSync(configPath)) {
+    return { path: configPath, exists: false, parse_error: null, issues: [] };
+  }
+
+  try {
+    const raw = JSON.parse(fs.readFileSync(configPath, "utf-8")) as unknown;
+    return {
+      path: configPath,
+      exists: true,
+      parse_error: null,
+      issues: validateConfigObject(raw),
+    };
+  } catch (e) {
+    return {
+      path: configPath,
+      exists: true,
+      parse_error: e instanceof Error ? e.message : String(e),
+      issues: [{
+        severity: "error",
+        path: "$",
+        message: e instanceof Error ? e.message : String(e),
+      }],
+    };
+  }
+}
+
+export function getActiveConfigEnvOverrides(env: NodeJS.ProcessEnv = process.env): string[] {
+  const active = new Set<string>();
+  for (const key of CONFIG_ENV_KEYS) {
+    if (env[key]) active.add(key);
+  }
+  for (const [key, value] of Object.entries(env)) {
+    if (!value) continue;
+    if (CONFIG_ENV_PREFIXES.some((prefix) => key.startsWith(prefix))) active.add(key);
+  }
+  return [...active].sort();
 }
 
 // ---------------------------------------------------------------------------
@@ -201,7 +431,10 @@ export function loadConfig(): BikkyConfig {
   if (process.env.EMBEDDING_PROVIDER) config.embedding.provider = process.env.EMBEDDING_PROVIDER;
   if (process.env.EMBEDDING_MODEL) config.embedding.model = process.env.EMBEDDING_MODEL;
   if (process.env.EMBEDDING_BASE_URL) config.embedding.base_url = process.env.EMBEDDING_BASE_URL;
-  if (process.env.EMBEDDING_DIMENSIONS) config.embedding.dimensions = parseInt(process.env.EMBEDDING_DIMENSIONS, 10);
+  if (process.env.EMBEDDING_DIMENSIONS) {
+    const n = parseInt(process.env.EMBEDDING_DIMENSIONS, 10);
+    if (Number.isFinite(n) && n > 0) config.embedding.dimensions = n;
+  }
   if (process.env.OPENAI_API_KEY) config.embedding.api_key = process.env.OPENAI_API_KEY;
   // Generic provider-extras: BIKKY_EMBEDDING_EXTRA_<KEY>=value
   config.embedding.extra = config.embedding.extra ?? {};

--- a/src/lib/qdrant-client.test.ts
+++ b/src/lib/qdrant-client.test.ts
@@ -15,6 +15,8 @@ import {
   QdrantNotFoundError,
   QdrantRateLimitError,
   QdrantTransientError,
+  getCollectionVectorSize,
+  inspectPayloadIndexes,
 } from "./qdrant-client.js";
 
 type ScriptedResponse = {
@@ -260,6 +262,62 @@ describe("QdrantClient", () => {
       await client.request("GET", "/collections");
       const headers = mock.calls[0].init?.headers as Record<string, string>;
       assert.equal(headers["api-key"], undefined);
+    });
+  });
+
+  describe("collection diagnostics", () => {
+    it("extracts payload index readiness from collection info", () => {
+      const readiness = inspectPayloadIndexes({
+        payload_schema: {
+          category: { data_type: "keyword" },
+          created_at: { data_type: "datetime" },
+          confidence: { data_type: "float" },
+        },
+      }, [
+        { field_name: "category", field_schema: "keyword" },
+        { field_name: "created_at", field_schema: "datetime" },
+        { field_name: "confidence", field_schema: "integer" },
+        { field_name: "entities", field_schema: "keyword" },
+      ]);
+
+      assert.deepEqual(readiness.present, {
+        category: "keyword",
+        created_at: "datetime",
+        confidence: "float",
+      });
+      assert.deepEqual(readiness.missing, [
+        { field_name: "entities", field_schema: "keyword" },
+      ]);
+      assert.deepEqual(readiness.mismatched, [{
+        field_name: "confidence",
+        expected_schema: "integer",
+        actual_schema: "float",
+      }]);
+    });
+
+    it("reads vector size from unnamed and named vector configs", () => {
+      assert.equal(getCollectionVectorSize({
+        config: { params: { vectors: { size: 1024, distance: "Cosine" } } },
+      }), 1024);
+
+      assert.equal(getCollectionVectorSize({
+        config: { params: { vectors: { content: { size: 1536, distance: "Cosine" } } } },
+      }), 1536);
+
+      assert.equal(getCollectionVectorSize({ config: { params: {} } }), null);
+    });
+
+    it("fetches collection info through the client", async () => {
+      mock = installFetchMock([{
+        status: 200,
+        body: JSON.stringify({ result: { points_count: 10, payload_schema: { category: { data_type: "keyword" } } } }),
+      }]);
+      const client = new QdrantClient(baseOpts);
+
+      const info = await client.getCollectionInfo();
+
+      assert.equal(info.points_count, 10);
+      assert.equal(mock.calls[0].url, "https://example.qdrant.io/collections/bikky-test");
     });
   });
 });

--- a/src/lib/qdrant-client.ts
+++ b/src/lib/qdrant-client.ts
@@ -47,6 +47,40 @@ export interface QdrantIndexSpec {
   field_schema: string;
 }
 
+export interface QdrantPayloadSchemaEntry {
+  data_type?: string;
+  schema?: string;
+  points?: number;
+  params?: unknown;
+  [key: string]: unknown;
+}
+
+export interface QdrantCollectionInfo {
+  status?: string;
+  points_count?: number;
+  vectors_count?: number;
+  indexed_vectors_count?: number;
+  payload_schema?: Record<string, QdrantPayloadSchemaEntry | string>;
+  config?: {
+    params?: {
+      vectors?: unknown;
+    };
+  };
+  [key: string]: unknown;
+}
+
+export interface QdrantIndexMismatch {
+  field_name: string;
+  expected_schema: string;
+  actual_schema: string | null;
+}
+
+export interface QdrantPayloadIndexReadiness {
+  present: Record<string, string>;
+  missing: QdrantIndexSpec[];
+  mismatched: QdrantIndexMismatch[];
+}
+
 // ---------------------------------------------------------------------------
 // Error hierarchy
 // ---------------------------------------------------------------------------
@@ -152,6 +186,60 @@ const classifyStatus = (
   if (status === 400 || status === 422) return new QdrantBadRequestError(message, status, responseBody);
   return new QdrantError(message, status, responseBody);
 };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function payloadSchemaType(entry: QdrantPayloadSchemaEntry | string | undefined): string | null {
+  if (typeof entry === "string") return entry.toLowerCase();
+  const dataType = entry?.data_type ?? entry?.schema;
+  return typeof dataType === "string" ? dataType.toLowerCase() : null;
+}
+
+export function inspectPayloadIndexes(
+  collectionInfo: QdrantCollectionInfo,
+  expected: ReadonlyArray<QdrantIndexSpec>,
+): QdrantPayloadIndexReadiness {
+  const payloadSchema = collectionInfo.payload_schema ?? {};
+  const present: Record<string, string> = {};
+  const missing: QdrantIndexSpec[] = [];
+  const mismatched: QdrantIndexMismatch[] = [];
+
+  for (const [field, entry] of Object.entries(payloadSchema)) {
+    const schema = payloadSchemaType(entry);
+    if (schema) present[field] = schema;
+  }
+
+  for (const spec of expected) {
+    const actual = present[spec.field_name] ?? null;
+    const expectedSchema = spec.field_schema.toLowerCase();
+    if (!actual) {
+      missing.push(spec);
+    } else if (actual !== expectedSchema) {
+      mismatched.push({
+        field_name: spec.field_name,
+        expected_schema: expectedSchema,
+        actual_schema: actual,
+      });
+    }
+  }
+
+  return { present, missing, mismatched };
+}
+
+export function getCollectionVectorSize(collectionInfo: QdrantCollectionInfo): number | null {
+  const vectors = collectionInfo.config?.params?.vectors;
+  if (!isRecord(vectors)) return null;
+
+  if (typeof vectors.size === "number") return vectors.size;
+
+  for (const value of Object.values(vectors)) {
+    if (isRecord(value) && typeof value.size === "number") return value.size;
+  }
+
+  return null;
+}
 
 export class QdrantClient {
   private readonly url: string;
@@ -273,6 +361,17 @@ export class QdrantClient {
         text.slice(0, 500),
       );
     }
+  }
+
+  async getCollectionInfo(): Promise<QdrantCollectionInfo> {
+    const res = await this.request<{ result: QdrantCollectionInfo }>("GET", `/collections/${this.collection}`);
+    return res.result;
+  }
+
+  async inspectPayloadIndexReadiness(
+    expected: ReadonlyArray<QdrantIndexSpec>,
+  ): Promise<QdrantPayloadIndexReadiness> {
+    return inspectPayloadIndexes(await this.getCollectionInfo(), expected);
   }
 
   /**

--- a/src/status.test.ts
+++ b/src/status.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for read-only `bikky status` diagnostics.
+ */
+
+import { describe, it, before, beforeEach, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+const TEST_BIKKY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-home-status-"));
+process.env.BIKKY_HOME = TEST_BIKKY_HOME;
+
+const { CONFIG_PATH, resetConfig } = await import("./config.js");
+const { QDRANT_INDEXES } = await import("./mcp/taxonomy.js");
+const { collectStatus, formatStatusReport, sanitizeStatusUrl, statusExitCode } = await import("./status.js");
+
+const realFetch = globalThis.fetch;
+
+function writeConfig(config: Record<string, unknown>): void {
+  fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
+}
+
+function installStatusFetch(opts: {
+  vectorSize?: number;
+  missingIndex?: string;
+  collectionVectorSize?: number;
+} = {}): void {
+  const vectorSize = opts.vectorSize ?? 1024;
+  const payload_schema = Object.fromEntries(
+    QDRANT_INDEXES
+      .filter((idx) => idx.field_name !== opts.missingIndex)
+      .map((idx) => [idx.field_name, { data_type: idx.field_schema }]),
+  );
+
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.endsWith("/collections")) {
+      return new Response(JSON.stringify({ result: { collections: [{ name: "bikky" }] } }), { status: 200 });
+    }
+    if (url.endsWith("/collections/bikky")) {
+      return new Response(JSON.stringify({
+        result: {
+          points_count: 12,
+          vectors_count: 12,
+          payload_schema,
+          config: {
+            params: {
+              vectors: { size: opts.collectionVectorSize ?? vectorSize, distance: "Cosine" },
+            },
+          },
+        },
+      }), { status: 200 });
+    }
+    if (url.endsWith("/v1/embeddings")) {
+      return new Response(JSON.stringify({
+        data: [{ embedding: Array.from({ length: vectorSize }, () => 0.1) }],
+      }), { status: 200 });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as typeof fetch;
+}
+
+describe("status diagnostics", () => {
+  before(() => {
+    process.env.BIKKY_HOME = TEST_BIKKY_HOME;
+  });
+
+  after(() => {
+    globalThis.fetch = realFetch;
+    fs.rmSync(TEST_BIKKY_HOME, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    resetConfig();
+    globalThis.fetch = realFetch;
+    fs.rmSync(TEST_BIKKY_HOME, { recursive: true, force: true });
+    fs.mkdirSync(TEST_BIKKY_HOME, { recursive: true });
+    delete process.env.QDRANT_URL;
+    delete process.env.QDRANT_API_KEY;
+    delete process.env.BIKKY_COLLECTION;
+    delete process.env.EMBEDDING_PROVIDER;
+    delete process.env.EMBEDDING_MODEL;
+    delete process.env.EMBEDDING_BASE_URL;
+    delete process.env.EMBEDDING_DIMENSIONS;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.LLM_PROVIDER;
+    delete process.env.LLM_MODEL;
+    delete process.env.LLM_BASE_URL;
+  });
+
+  it("surfaces corrupt config instead of looking like defaults", async () => {
+    fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(CONFIG_PATH, "{not-json");
+
+    const report = await collectStatus({ live: false, checkUi: false });
+
+    assert.equal(report.ok, false);
+    assert.equal(report.config.status, "error");
+    assert.ok(report.config.parse_error);
+    assert.equal(statusExitCode(report), 1);
+  });
+
+  it("reports missing payload indexes without failing overall health", async () => {
+    writeConfig({
+      qdrant_url: "https://qdrant.test",
+      collection: "bikky",
+      embedding: {
+        provider: "ollama",
+        model: "qwen3-embedding:0.6b",
+        dimensions: 1024,
+        base_url: "http://localhost:11434",
+      },
+      llm: {
+        provider: "ollama",
+        model: "qwen2.5:7b",
+        base_url: "http://localhost:11434",
+      },
+    });
+    installStatusFetch({ missingIndex: "entities" });
+
+    const report = await collectStatus({ live: true, checkUi: false });
+
+    assert.equal(report.ok, true);
+    assert.equal(report.qdrant.status, "warn");
+    assert.deepEqual(report.qdrant.missing_indexes.map((idx) => idx.field_name), ["entities"]);
+    assert.equal(report.embedding.status, "ok");
+    assert.equal(report.embedding.live_checked, true);
+    assert.match(formatStatusReport(report), /missing indexes: entities/);
+  });
+
+  it("fails when collection vector size differs from configured embedding dimensions", async () => {
+    writeConfig({
+      qdrant_url: "https://qdrant.test",
+      collection: "bikky",
+      embedding: {
+        provider: "ollama",
+        model: "qwen3-embedding:0.6b",
+        dimensions: 1024,
+        base_url: "http://localhost:11434",
+      },
+      llm: {
+        provider: "ollama",
+        model: "qwen2.5:7b",
+        base_url: "http://localhost:11434",
+      },
+    });
+    installStatusFetch({ collectionVectorSize: 1536 });
+
+    const report = await collectStatus({ live: true, checkUi: false });
+
+    assert.equal(report.ok, false);
+    assert.equal(report.qdrant.status, "error");
+    assert.match(report.qdrant.error ?? "", /does not match embedding dimensions/);
+  });
+
+  it("catches unknown providers before runtime memory operations", async () => {
+    writeConfig({
+      qdrant_url: "https://qdrant.test",
+      collection: "bikky",
+      embedding: { provider: "missing-embedder", model: "x", dimensions: 3 },
+      llm: { provider: "missing-llm", model: "x" },
+    });
+    installStatusFetch({ vectorSize: 3 });
+
+    const report = await collectStatus({ live: false, checkUi: false });
+
+    assert.equal(report.ok, false);
+    assert.equal(report.embedding.status, "error");
+    assert.match(report.embedding.error ?? "", /Unknown embedding provider/);
+    assert.equal(report.llm.status, "error");
+    assert.match(report.llm.error ?? "", /Unknown inference provider/);
+  });
+
+  it("sanitizes credentials from URLs in reports", async () => {
+    assert.equal(
+      sanitizeStatusUrl("https://user:secret@example.com:6333/path?api_key=abc&ok=1"),
+      "https://example.com:6333/path?api_key=REDACTED&ok=1",
+    );
+
+    writeConfig({
+      qdrant_url: "https://qdrant.test",
+      collection: "bikky",
+      embedding: {
+        provider: "ollama",
+        model: "qwen3-embedding:0.6b",
+        dimensions: 1024,
+        base_url: "https://user:secret@embed.example/v1?token=abc",
+      },
+      llm: {
+        provider: "ollama",
+        model: "qwen2.5:7b",
+        base_url: "https://user:secret@llm.example/v1?password=abc",
+      },
+    });
+    installStatusFetch();
+
+    const report = await collectStatus({ live: false, checkUi: false });
+
+    assert.equal(report.embedding.base_url, "https://embed.example/v1?token=REDACTED");
+    assert.equal(report.llm.base_url, "https://llm.example/v1?password=REDACTED");
+  });
+});

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,0 +1,463 @@
+/**
+ * Read-only health diagnostics for `bikky status`.
+ */
+
+import {
+  getActiveConfigEnvOverrides,
+  inspectConfigFile,
+  loadConfig,
+  type BikkyConfig,
+  type ConfigIssue,
+} from "./config.js";
+import { getDaemonStatus } from "./lifecycle.js";
+import {
+  embed,
+  getEmbeddingConfig,
+  getEmbeddingProvider,
+  getInferenceProvider,
+  initEmbedding,
+  initLLM,
+  listEmbeddingProviders,
+  listInferenceProviders,
+} from "./llm/index.js";
+import {
+  getCollectionVectorSize,
+  inspectPayloadIndexes,
+  QdrantClient,
+  QdrantNotFoundError,
+  type QdrantIndexMismatch,
+  type QdrantIndexSpec,
+} from "./lib/qdrant-client.js";
+import { QDRANT_INDEXES } from "./mcp/taxonomy.js";
+
+export type DiagnosticState = "ok" | "warn" | "error" | "skipped";
+
+export interface DiagnosticIssue {
+  severity: "error" | "warning";
+  message: string;
+  path?: string;
+}
+
+export interface ConfigStatus {
+  status: DiagnosticState;
+  path: string;
+  exists: boolean;
+  parse_error: string | null;
+  env_overrides: string[];
+  issues: DiagnosticIssue[];
+}
+
+export interface QdrantStatus {
+  status: DiagnosticState;
+  configured: boolean;
+  reachable: boolean;
+  url: string | null;
+  collection: string;
+  collection_exists: boolean;
+  points_count: number | null;
+  vectors_count: number | null;
+  vector_size: number | null;
+  expected_vector_size: number | null;
+  expected_indexes: number;
+  present_indexes: number;
+  missing_indexes: QdrantIndexSpec[];
+  mismatched_indexes: QdrantIndexMismatch[];
+  error: string | null;
+}
+
+export interface ProviderStatus {
+  status: DiagnosticState;
+  provider: string;
+  model: string;
+  base_url: string;
+  dimensions?: number;
+  live_checked: boolean;
+  error: string | null;
+}
+
+export interface DaemonStatusReport {
+  status: DiagnosticState;
+  running: boolean;
+  pid: number | null;
+}
+
+export interface UiStatusReport {
+  status: DiagnosticState;
+  checked: boolean;
+  url: string;
+  ok: boolean | null;
+  error: string | null;
+}
+
+export interface BikkyStatusReport {
+  ok: boolean;
+  config: ConfigStatus;
+  qdrant: QdrantStatus;
+  embedding: ProviderStatus;
+  llm: ProviderStatus;
+  daemon: DaemonStatusReport;
+  ui: UiStatusReport;
+  mcp: { status: DiagnosticState; message: string };
+}
+
+export interface CollectStatusOptions {
+  live?: boolean;
+  checkUi?: boolean;
+  uiUrl?: string;
+  uiTimeoutMs?: number;
+  qdrantTimeoutMs?: number;
+}
+
+const API_KEY_REQUIRED_PROVIDERS = new Set(["openai", "portkey"]);
+const SENSITIVE_QUERY_PARAM = /(api[-_]?key|access[-_]?token|token|secret|password|credential|auth)/i;
+
+function diagnosticIssue(issue: ConfigIssue): DiagnosticIssue {
+  return {
+    severity: issue.severity === "error" ? "error" : "warning",
+    path: issue.path,
+    message: issue.message,
+  };
+}
+
+function statusFromIssues(issues: DiagnosticIssue[]): DiagnosticState {
+  if (issues.some((issue) => issue.severity === "error")) return "error";
+  if (issues.length > 0) return "warn";
+  return "ok";
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function apiKeyIssue(provider: string, apiKey: string | null): string | null {
+  if (!API_KEY_REQUIRED_PROVIDERS.has(provider)) return null;
+  return apiKey ? null : `${provider} provider requires an API key`;
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export function sanitizeStatusUrl(url: string | null): string | null {
+  if (!url) return null;
+  try {
+    const parsed = new URL(url);
+    parsed.username = "";
+    parsed.password = "";
+    for (const key of [...parsed.searchParams.keys()]) {
+      if (SENSITIVE_QUERY_PARAM.test(key)) parsed.searchParams.set(key, "REDACTED");
+    }
+    return parsed.toString().replace(/\/$/, parsed.pathname === "/" ? "" : "/");
+  } catch {
+    return url
+      .replace(/\/\/[^/@\s]+@/, "//[REDACTED]@")
+      .replace(/([?&][^=&#]*(?:api[-_]?key|access[-_]?token|token|secret|password|credential|auth)[^=&#]*=)[^&#]*/gi, "$1REDACTED");
+  }
+}
+
+function collectConfigStatus(): ConfigStatus {
+  const file = inspectConfigFile();
+  const issues = file.issues.map(diagnosticIssue);
+  return {
+    status: statusFromIssues(issues),
+    path: file.path,
+    exists: file.exists,
+    parse_error: file.parse_error,
+    env_overrides: getActiveConfigEnvOverrides(),
+    issues,
+  };
+}
+
+async function collectQdrantStatus(cfg: BikkyConfig, embeddingDimensions: number | null, opts: CollectStatusOptions): Promise<QdrantStatus> {
+  const qdrantUrl = typeof cfg.qdrant_url === "string" ? cfg.qdrant_url : null;
+  const collection = typeof cfg.collection === "string" && cfg.collection ? cfg.collection : "bikky";
+  const base: QdrantStatus = {
+    status: "error",
+    configured: Boolean(qdrantUrl),
+    reachable: false,
+    url: sanitizeStatusUrl(qdrantUrl),
+    collection,
+    collection_exists: false,
+    points_count: null,
+    vectors_count: null,
+    vector_size: null,
+    expected_vector_size: embeddingDimensions,
+    expected_indexes: QDRANT_INDEXES.length,
+    present_indexes: 0,
+    missing_indexes: [],
+    mismatched_indexes: [],
+    error: null,
+  };
+
+  if (!qdrantUrl) {
+    return { ...base, error: "Qdrant URL is not configured" };
+  }
+
+  const client = new QdrantClient({
+    url: qdrantUrl,
+    apiKey: typeof cfg.qdrant_api_key === "string" ? cfg.qdrant_api_key : null,
+    collection,
+    timeoutMs: opts.qdrantTimeoutMs ?? Math.min(numberOrNull(cfg.qdrant_client.timeout_ms) ?? 5_000, 5_000),
+    retries: 0,
+  });
+
+  try {
+    await client.request("GET", "/collections");
+    base.reachable = true;
+  } catch (err) {
+    return { ...base, error: errMessage(err) };
+  }
+
+  try {
+    const info = await client.getCollectionInfo();
+    const readiness = inspectPayloadIndexes(info, QDRANT_INDEXES);
+    const vectorSize = getCollectionVectorSize(info);
+    const vectorMismatch =
+      vectorSize !== null && embeddingDimensions !== null && vectorSize !== embeddingDimensions;
+    base.collection_exists = true;
+    base.points_count = typeof info.points_count === "number" ? info.points_count : null;
+    base.vectors_count = typeof info.vectors_count === "number" ? info.vectors_count : null;
+    base.vector_size = vectorSize;
+    base.present_indexes = Object.keys(readiness.present).length;
+    base.missing_indexes = readiness.missing;
+    base.mismatched_indexes = readiness.mismatched;
+    base.status = vectorMismatch || readiness.mismatched.length > 0
+      ? "error"
+      : readiness.missing.length > 0
+        ? "warn"
+        : "ok";
+    base.error = vectorMismatch
+      ? `Qdrant vector size ${vectorSize} does not match embedding dimensions ${embeddingDimensions}`
+      : readiness.mismatched.length > 0
+        ? "Qdrant payload indexes have schema mismatches"
+        : null;
+    return base;
+  } catch (err) {
+    if (err instanceof QdrantNotFoundError) {
+      return { ...base, reachable: true, collection_exists: false, error: `Collection '${collection}' does not exist` };
+    }
+    return { ...base, reachable: true, error: errMessage(err) };
+  }
+}
+
+async function collectEmbeddingStatus(cfg: BikkyConfig, live: boolean): Promise<ProviderStatus> {
+  const dimensions = numberOrNull(cfg.embedding.dimensions) ?? undefined;
+  const base: ProviderStatus = {
+    status: "error",
+    provider: cfg.embedding.provider,
+    model: cfg.embedding.model,
+    base_url: sanitizeStatusUrl(cfg.embedding.base_url) ?? "",
+    dimensions,
+    live_checked: false,
+    error: null,
+  };
+
+  try {
+    getEmbeddingProvider(cfg.embedding.provider);
+    const keyIssue = apiKeyIssue(cfg.embedding.provider, cfg.embedding.api_key);
+    if (keyIssue) return { ...base, error: keyIssue };
+
+    const resolved = initEmbedding({
+      provider: cfg.embedding.provider,
+      model: cfg.embedding.model,
+      dimensions,
+      baseUrl: cfg.embedding.base_url,
+      apiKey: cfg.embedding.api_key,
+      extra: cfg.embedding.extra ?? {},
+      timeoutMs: cfg.embedding.timeout_ms,
+      retries: cfg.embedding.retries,
+      retryBaseDelayMs: cfg.embedding.retry_base_delay_ms,
+    });
+    base.provider = resolved.provider;
+    base.model = resolved.model;
+    base.base_url = sanitizeStatusUrl(resolved.baseUrl) ?? "";
+    base.dimensions = resolved.dimensions;
+
+    if (live) {
+      await embed("bikky status embedding check");
+      base.live_checked = true;
+    }
+
+    return { ...base, status: "ok" };
+  } catch (err) {
+    const known = listEmbeddingProviders().map((p) => p.name).sort().join(", ");
+    return { ...base, error: `${errMessage(err)} (available embedding providers: ${known})` };
+  }
+}
+
+function collectLlmStatus(cfg: BikkyConfig): ProviderStatus {
+  const base: ProviderStatus = {
+    status: "error",
+    provider: cfg.llm.provider,
+    model: cfg.llm.model,
+    base_url: sanitizeStatusUrl(cfg.llm.base_url) ?? "",
+    live_checked: false,
+    error: null,
+  };
+
+  try {
+    getInferenceProvider(cfg.llm.provider);
+    if (cfg.llm.fallback_provider) getInferenceProvider(cfg.llm.fallback_provider);
+    const keyIssue = apiKeyIssue(cfg.llm.provider, cfg.llm.api_key);
+    if (keyIssue) return { ...base, error: keyIssue };
+
+    const resolved = initLLM({
+      config: {
+        provider: cfg.llm.provider,
+        model: cfg.llm.model,
+        baseUrl: cfg.llm.base_url,
+        apiKey: cfg.llm.api_key,
+        fallback: cfg.llm.fallback_provider ?? null,
+        extra: cfg.llm.extra ?? {},
+        timeoutMs: cfg.llm.timeout_ms,
+        retries: cfg.llm.retries,
+        retryBaseDelayMs: cfg.llm.retry_base_delay_ms,
+      },
+    });
+    return {
+      ...base,
+      status: "ok",
+      provider: resolved.provider,
+      model: resolved.model,
+      base_url: sanitizeStatusUrl(resolved.baseUrl) ?? "",
+    };
+  } catch (err) {
+    const known = listInferenceProviders().map((p) => p.name).sort().join(", ");
+    return { ...base, error: `${errMessage(err)} (available LLM providers: ${known})` };
+  }
+}
+
+function collectDaemonStatus(): DaemonStatusReport {
+  const daemon = getDaemonStatus();
+  return {
+    status: daemon.running ? "ok" : "warn",
+    running: daemon.running,
+    pid: daemon.pid,
+  };
+}
+
+async function collectUiStatus(opts: CollectStatusOptions): Promise<UiStatusReport> {
+  const url = opts.uiUrl ?? "http://localhost:1422/health";
+  const reportedUrl = sanitizeStatusUrl(url) ?? url;
+  if (opts.checkUi === false) {
+    return { status: "skipped", checked: false, url: reportedUrl, ok: null, error: null };
+  }
+
+  try {
+    const signal = AbortSignal.timeout(opts.uiTimeoutMs ?? 750);
+    const resp = await fetch(url, { signal });
+    if (!resp.ok) {
+      return { status: "warn", checked: true, url: reportedUrl, ok: false, error: `HTTP ${resp.status}` };
+    }
+    const body = await resp.json().catch(() => null) as { ok?: unknown } | null;
+    const ok = body?.ok === true;
+    return { status: ok ? "ok" : "warn", checked: true, url: reportedUrl, ok, error: ok ? null : "health response did not include ok=true" };
+  } catch (err) {
+    return { status: "skipped", checked: true, url: reportedUrl, ok: null, error: errMessage(err) };
+  }
+}
+
+export async function collectStatus(opts: CollectStatusOptions = {}): Promise<BikkyStatusReport> {
+  const live = opts.live !== false;
+  const config = collectConfigStatus();
+  const cfg = loadConfig();
+  const embedding = await collectEmbeddingStatus(cfg, live);
+  const qdrant = await collectQdrantStatus(
+    cfg,
+    embedding.dimensions ?? getEmbeddingConfigSafe(),
+    opts,
+  );
+  const llm = collectLlmStatus(cfg);
+  const daemon = collectDaemonStatus();
+  const ui = await collectUiStatus(opts);
+  const required = [config.status, qdrant.status, embedding.status, llm.status];
+
+  return {
+    ok: required.every((status) => status !== "error"),
+    config,
+    qdrant,
+    embedding,
+    llm,
+    daemon,
+    ui,
+    mcp: { status: "ok", message: "managed by your editor (stdio)" },
+  };
+}
+
+function getEmbeddingConfigSafe(): number | null {
+  try {
+    return getEmbeddingConfig().dimensions;
+  } catch {
+    return null;
+  }
+}
+
+function icon(status: DiagnosticState): string {
+  switch (status) {
+    case "ok": return "🟢";
+    case "warn": return "🟡";
+    case "error": return "🔴";
+    case "skipped": return "⚪";
+  }
+}
+
+function qdrantSummary(qdrant: QdrantStatus): string {
+  if (!qdrant.configured) return "not configured";
+  if (!qdrant.reachable) return `unreachable (${qdrant.error ?? "unknown error"})`;
+  if (!qdrant.collection_exists) return qdrant.error ?? "collection missing";
+  const matchingIndexes = qdrant.expected_indexes - qdrant.missing_indexes.length - qdrant.mismatched_indexes.length;
+  const indexSummary = `${matchingIndexes}/${qdrant.expected_indexes} expected indexes`;
+  const details = [
+    `collection '${qdrant.collection}'`,
+    indexSummary,
+    qdrant.vector_size !== null ? `vector size ${qdrant.vector_size}` : null,
+  ].filter(Boolean).join(", ");
+  return qdrant.error ? `${details} — ${qdrant.error}` : details;
+}
+
+export function formatStatusReport(report: BikkyStatusReport): string {
+  const lines: string[] = [];
+  const configLabel = report.config.exists ? report.config.path : `${report.config.path} (not created yet)`;
+
+  lines.push(`Config:   ${icon(report.config.status)} ${report.config.status} — ${configLabel}`);
+  if (report.config.env_overrides.length > 0) {
+    lines.push(`          env overrides: ${report.config.env_overrides.join(", ")}`);
+  }
+  for (const issue of report.config.issues) {
+    lines.push(`          ${issue.severity}: ${issue.path ? `${issue.path}: ` : ""}${issue.message}`);
+  }
+
+  lines.push(`Qdrant:   ${icon(report.qdrant.status)} ${report.qdrant.status} — ${qdrantSummary(report.qdrant)}`);
+  if (report.qdrant.missing_indexes.length > 0) {
+    lines.push(`          missing indexes: ${report.qdrant.missing_indexes.map((idx) => idx.field_name).join(", ")}`);
+  }
+  if (report.qdrant.mismatched_indexes.length > 0) {
+    const mismatches = report.qdrant.mismatched_indexes
+      .map((idx) => `${idx.field_name} expected ${idx.expected_schema}, got ${idx.actual_schema ?? "missing"}`)
+      .join("; ");
+    lines.push(`          index mismatches: ${mismatches}`);
+  }
+
+  const embLive = report.embedding.live_checked ? "live check passed" : "configured";
+  lines.push(
+    `Embedding:${icon(report.embedding.status).padStart(4, " ")} ${report.embedding.status} — ` +
+    `${report.embedding.provider}/${report.embedding.model} (${report.embedding.dimensions ?? "?"}d), ${embLive}` +
+    `${report.embedding.error ? ` — ${report.embedding.error}` : ""}`,
+  );
+
+  lines.push(
+    `LLM:      ${icon(report.llm.status)} ${report.llm.status} — ` +
+    `${report.llm.provider}/${report.llm.model}, provider config checked (no live chat)` +
+    `${report.llm.error ? ` — ${report.llm.error}` : ""}`,
+  );
+
+  lines.push(`Daemon:   ${icon(report.daemon.status)} ${report.daemon.running ? `running (PID ${report.daemon.pid})` : "stopped"}`);
+  lines.push(`UI:       ${icon(report.ui.status)} ${report.ui.checked ? report.ui.url : "not checked"}${report.ui.error ? ` — ${report.ui.error}` : ""}`);
+  lines.push(`MCP:      ${icon(report.mcp.status)} ${report.mcp.message}`);
+
+  return lines.join("\n");
+}
+
+export function statusExitCode(report: BikkyStatusReport): number {
+  return report.ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Closes #67.

- adds read-only config diagnostics for JSON parse/schema issues, provider validation, and active env overrides
- adds Qdrant collection/vector-size/payload-index readiness checks without mutating the collection
- replaces shallow `bikky status` output with human and JSON reports plus `--no-live` / `--no-ui` options
- live-checks embeddings by default, validates LLM provider/fallback names without live chat, and sanitizes reported URLs
- aligns UI config with `BIKKY_HOME`, adds `EMBEDDING_DIMENSIONS`, and updates README/config docs

## Validation

- `npm run build`
- `npm test` (502 passed)
- `npm run typecheck`
- `cd packages/ui && npm run build`
- `cd packages/ui && npm test` (61 passed)
- `node dist/cli.js status --no-live --no-ui`
- `node dist/cli.js status --json --no-live --no-ui`