### PR TITLE
feat(daemon): 3-axis self-judgment CoT and quality gates for relation inference

### DIFF
--- a/src/daemon/relations.ts
+++ b/src/daemon/relations.ts
@@ -41,6 +41,9 @@ const MAX_INFER_PER_CYCLE = 3;
 // Minimum shared facts before we consider inferring a relation
 const MIN_SHARED_FACTS = 2;
 
+// Minimum LLM confidence to store a relation (quality gate)
+const MIN_CONFIDENCE = 0.6;
+
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /** Canonical pair key — alphabetical so (a,b) === (b,a) */
@@ -217,7 +220,7 @@ const inferRelation = async (
   entityA: string,
   entityB: string,
   sharedFacts: Array<{ content: string; category: string }>,
-): Promise<{ from: string; type: string; to: string; content: string; evidence?: string; confidence?: number; inVocabulary?: boolean } | null> => {
+): Promise<{ from: string; type: string; to: string; content: string; evidence?: string; confidence?: number; inVocabulary?: boolean; judgment?: { evidence_strength?: number; durability?: string; directionality_clarity?: string } } | null> => {
   const rendered = relationsPrompt({ entityA, entityB, sharedFacts });
   const raw = await chatCompletion(rendered);
 
@@ -231,9 +234,37 @@ const inferRelation = async (
     evidence?: string;
     confidence?: number;
     reason?: string;
+    judgment?: {
+      evidence_strength?: number;
+      durability?: string;
+      directionality_clarity?: string;
+    };
   }>(raw);
 
   if (!parsed || !parsed.type) return null;
+
+  // ── Self-judgment quality gates ──────────────────────────────────────────
+  if (parsed.judgment) {
+    const j = parsed.judgment;
+
+    // Gate 1: durability — reject transient/ephemeral relations
+    if (j.durability === "transient" || j.durability === "ephemeral") {
+      logFn("DEBUG", `Relations: rejected ${entityA}↔${entityB} — durability="${j.durability}"`);
+      return null;
+    }
+
+    // Gate 2: directionality — reject ambiguous direction
+    if (j.directionality_clarity === "ambiguous") {
+      logFn("DEBUG", `Relations: rejected ${entityA}↔${entityB} — ambiguous directionality`);
+      return null;
+    }
+
+    // Gate 3: evidence strength — reject weak evidence (< 0.5)
+    if (typeof j.evidence_strength === "number" && j.evidence_strength < 0.5) {
+      logFn("DEBUG", `Relations: rejected ${entityA}↔${entityB} — evidence_strength=${j.evidence_strength}`);
+      return null;
+    }
+  }
 
   // Validate that from/to are the provided entities (not hallucinated)
   const entities = new Set([entityA.toLowerCase(), entityB.toLowerCase()]);
@@ -262,11 +293,23 @@ const inferRelation = async (
   const resolvedFrom = from === entityA.toLowerCase() ? entityA : entityB;
   const resolvedTo = to === entityA.toLowerCase() ? entityA : entityB;
 
-  // Map LLM type to canonical vocabulary; out-of-vocab types pass through
-  // (and storeRelation flags them in metadata for human review).
+  // Map LLM type to canonical vocabulary
   const mapped = mapToCanonical(parsed.type);
   if (mapped.changed) {
     logFn("DEBUG", `Relations: mapped type "${parsed.type}" → "${mapped.canonical}"`);
+  }
+
+  // Gate 4: reject out-of-vocab relation types — they are almost always noise
+  if (!mapped.inVocabulary) {
+    logFn("DEBUG", `Relations: rejected ${entityA}↔${entityB} — out-of-vocab type "${parsed.type}"`);
+    return null;
+  }
+
+  // Gate 5: confidence floor — skip low-confidence relations
+  const confidence = typeof parsed.confidence === "number" ? parsed.confidence : 0.5;
+  if (confidence < MIN_CONFIDENCE) {
+    logFn("DEBUG", `Relations: rejected ${entityA}↔${entityB} — confidence ${confidence} < ${MIN_CONFIDENCE}`);
+    return null;
   }
 
   return {
@@ -275,8 +318,9 @@ const inferRelation = async (
     to: resolvedTo,
     content: parsed.content || `${resolvedFrom} ${mapped.canonical} ${resolvedTo}`,
     evidence: parsed.evidence,
-    confidence: typeof parsed.confidence === "number" ? parsed.confidence : undefined,
+    confidence,
     inVocabulary: mapped.inVocabulary,
+    judgment: parsed.judgment,
   };
 };
 
@@ -289,7 +333,7 @@ const storeRelation = async (
   relationType: string,
   content: string,
   sharedFactIds: string[],
-  extras: { evidence?: string; confidence?: number; inVocabulary?: boolean } = {},
+  extras: { evidence?: string; confidence?: number; inVocabulary?: boolean; judgment?: { evidence_strength?: number; durability?: string; directionality_clarity?: string } } = {},
 ): Promise<string> => {
   const hash = createHash("sha256")
     .update(`daemon-relation:${pairKey(fromEntity, toEntity)}:${relationType}`)
@@ -303,8 +347,11 @@ const storeRelation = async (
   if (extras.evidence) {
     metadata.evidence_quote = extras.evidence.slice(0, 500);
   }
-  if (extras.inVocabulary === false) {
-    metadata.relation_type_out_of_vocab = "true";
+  if (extras.judgment) {
+    const j = extras.judgment;
+    if (j.evidence_strength != null) metadata.evidence_strength = String(j.evidence_strength);
+    if (j.durability) metadata.durability = j.durability;
+    if (j.directionality_clarity) metadata.directionality_clarity = j.directionality_clarity;
   }
 
   const id = await qdrant.storeFact({
@@ -383,7 +430,7 @@ const tick = async (config: BikkyConfig): Promise<void> => {
           result.type,
           result.content,
           candidate.factIds,
-          { evidence: result.evidence, confidence: result.confidence, inVocabulary: result.inVocabulary },
+          { evidence: result.evidence, confidence: result.confidence, inVocabulary: result.inVocabulary, judgment: result.judgment },
         );
         inferred++;
       } catch (e: unknown) {

--- a/src/prompts/relations.ts
+++ b/src/prompts/relations.ts
@@ -9,7 +9,7 @@ import { canonicalTypesForPrompt } from "../daemon/relations-vocab.js";
 
 export const RELATIONS_PROMPT_DESCRIPTOR: PromptDescriptor = {
   id: "relations",
-  version: "2026-04-27-1",
+  version: "2026-04-27-2",
 };
 
 const SYSTEM = `<role>
@@ -38,18 +38,54 @@ ${canonicalTypesForPrompt()}
 </vocabulary>
 
 <reasoning-steps>
-Walk these steps before emitting JSON:
-  1. Read each shared fact. Identify the verb that links the two entities.
-  2. Decide direction: which entity is the SUBJECT (does the action / owns the dependency)?
-     If the facts are symmetric ("X and Y both ..."), there is NO directed relation → return type:null.
-  3. Map the verb to a canonical type from <vocabulary>. Examples:
-       "calls" / "invokes" / "triggers"      → calls
-       "uses"  / "needs"   / "relies on"     → depends-on
-       "manages" / "is responsible for"      → owns
-       "writes to" / "persists in"           → stores-in
+Walk these steps IN ORDER before emitting JSON — do not skip any.
+
+  1. Read each shared fact. Identify the verb/phrase that links the two entities.
+
+  2. EPHEMERAL-EVENT GATE — does the verb describe a one-time past action
+     (deployed, reverted, migrated, restarted, upgraded, rolled back, fixed, patched)?
+     If YES → return {"type": null, "reason": "ephemeral event, not a durable relation"}.
+     Also: do the two entities merely participate in the SAME event independently?
+     If YES → return {"type": null, "reason": "independent events, not a relation"}.
+
+  3. DIRECTIONALITY — which entity is the SUBJECT (performs the action / owns the dependency)?
+     If the facts are symmetric ("X and Y both …"), there is NO directed relation → return type:null.
+
+  4. TYPE MAPPING — map the verb to a canonical type from <vocabulary>. Examples:
+       "calls" / "invokes" / "triggers"     → calls
+       "uses"  / "needs"   / "relies on"    → depends-on
+       "manages" / "is responsible for"     → owns
+       "writes to" / "persists in"          → stores-in
      If no canonical fits, write your own kebab-case verb (1-3 words).
-  4. Pick the verbatim quote that anchors the relation — it MUST appear inside <facts>.
-  5. Set confidence: 0.9 if the quote names both entities + the verb; 0.7 if implied; 0.5 if weak.
+
+  5. EVIDENCE — pick the verbatim quote that anchors the relation. It MUST appear inside <facts>.
+
+  6. SELF-JUDGMENT — score the candidate relation on three axes (think step-by-step BEFORE setting these):
+
+     AXIS 1 — evidence_strength (0.0–1.0)
+       Question: Does the evidence explicitly name BOTH entities AND the linking verb?
+       - 1.0 — quote contains both entity names + an explicit verb matching the type
+       - 0.7 — one entity or the verb is implied but clearly resolvable in context
+       - 0.4 — the link is inferred; neither entity is named directly in the quote
+       - 0.0 — no evidence at all (should have returned type:null in step 5)
+
+     AXIS 2 — durability (one of: structural | configuration | transient | ephemeral)
+       Question: How long will this relation remain TRUE?
+       - structural   — architecture, ownership, dependency graph (years)
+       - configuration — feature flags, settings, integrations that change with releases (months)
+       - transient     — currently deployed version, active incident response links (days–weeks)
+       - ephemeral     — one-time events: deploy, revert, migration, rollback (should NOT reach this step — step 2 should have caught it)
+       If durability is "transient" or "ephemeral" → return {"type": null, "reason": "relation is not durable enough to store"}.
+
+     AXIS 3 — directionality_clarity (clear | ambiguous)
+       Question: Is the from→to direction unambiguously supported by the evidence?
+       - clear     — the evidence makes the subject→object direction obvious
+       - ambiguous — reasonable people could read the direction either way
+       If "ambiguous" → return {"type": null, "reason": "direction of relation is ambiguous"}.
+
+  7. CONFIDENCE — derive from self-judgment:
+       confidence = evidence_strength × (durability == "structural" ? 1.0 : 0.85)
+       Round to 1 decimal place.
 </reasoning-steps>
 
 <rules>
@@ -57,21 +93,31 @@ Walk these steps before emitting JSON:
 - Co-occurrence alone is NOT a relation. The shared facts must describe an action, dependency, ownership, or composition link.
 - Pick directionality based on what the facts say, not alphabetical order.
 - Symmetric facts ("X and Y both run on Z") do NOT define a directed relation between X and Y.
+- EPHEMERAL EVENTS are NOT relations. If the facts describe a one-time past action (deployed, reverted, migrated, rolled back, upgraded, restarted, fixed), return {"type": null, "reason": "ephemeral event, not a durable relation"}. Relations must describe ONGOING structural links — things that are true right now and will remain true.
+- If the two entities merely participated in the SAME event independently (e.g. "X reverted to rev 33" and "Y reverted to rev 26"), there is NO relation between X and Y — return {"type": null, "reason": "independent events, not a relation"}.
 </rules>
 
 <examples>
 Entities: "tg-bot", "bedrock"
 Facts: "tg-bot calls Bedrock via Portkey for LLM inference"
-→ {"from":"tg-bot","type":"calls","to":"bedrock","evidence":"tg-bot calls Bedrock via Portkey","reasoning":"verb 'calls' links subject tg-bot to object bedrock; canonical match 'calls'.","content":"tg-bot calls bedrock because it invokes Bedrock via Portkey for LLM inference","confidence":0.9}
+→ {"from":"tg-bot","type":"calls","to":"bedrock","evidence":"tg-bot calls Bedrock via Portkey","reasoning":"verb 'calls' links subject tg-bot to object bedrock; canonical match 'calls'.","judgment":{"evidence_strength":0.9,"durability":"structural","directionality_clarity":"clear"},"confidence":0.9,"content":"tg-bot calls bedrock because it invokes Bedrock via Portkey for LLM inference"}
 
 Entities: "lloyds", "cba"
 Facts: "lloyds and cba are both production clusters in eu-west-2 and ap-southeast-2 respectively"
 → {"type":null,"reason":"facts describe peer cluster setup; no directed relation"}
+
+Entities: "cba", "lloyds"
+Facts: "CBA reverted from revision 27 to 26" / "Lloyds reverted from revision 34 to 33"
+→ {"type":null,"reason":"independent ephemeral events; no durable relation between the two entities"}
+
+Entities: "bikky", "qdrant"
+Facts: "bikky stores all memory vectors in Qdrant Cloud" / "bikky daemon reads from and writes to the qdrant collection"
+→ {"from":"bikky","type":"stores-in","to":"qdrant","evidence":"bikky stores all memory vectors in Qdrant Cloud","reasoning":"'stores … in' maps to stores-in; bikky is subject, qdrant is target datastore.","judgment":{"evidence_strength":1.0,"durability":"structural","directionality_clarity":"clear"},"confidence":1.0,"content":"bikky stores-in qdrant because it persists all memory vectors in Qdrant Cloud"}
 </examples>
 
 <format>
 Output ONLY a JSON object — no prose, no fences. Use one of these shapes:
-{"from":"<entity>","type":"<canonical-or-kebab-verb>","to":"<entity>","evidence":"<verbatim quote>","reasoning":"<one short sentence>","confidence":0.0-1.0,"content":"<full sentence>"}
+{"from":"<entity>","type":"<canonical-or-kebab-verb>","to":"<entity>","evidence":"<verbatim quote>","reasoning":"<one short sentence>","judgment":{"evidence_strength":0.0-1.0,"durability":"structural|configuration|transient|ephemeral","directionality_clarity":"clear|ambiguous"},"confidence":0.0-1.0,"content":"<full sentence>"}
 {"type":null,"reason":"<short explanation>"}
 </format>
 


### PR DESCRIPTION
## Summary

Adds a full chain-of-thought self-judgment pattern to the relation inference prompt (mirroring the extraction prompt's approach) and 5 server-side quality gates to eliminate junk relations.

### Prompt changes (`src/prompts/relations.ts`)
- **3-axis self-judgment CoT** — LLM must score each candidate on:
  - `evidence_strength` (0.0–1.0) — does the evidence name both entities + the verb?
  - `durability` (structural / configuration / transient / ephemeral) — how long will this remain true?
  - `directionality_clarity` (clear / ambiguous) — is from→to unambiguous?
- **Ephemeral-event gate** as explicit reasoning step 2
- **New negative examples** (cba/lloyds revert, symmetric cluster setup)
- **New positive example** (bikky/qdrant stores-in) with judgment fields
- Prompt version bumped to `2026-04-27-2`

### Quality gates (`src/daemon/relations.ts`)
| Gate | Rejects when |
|------|-------------|
| Durability | `transient` or `ephemeral` |
| Directionality | `ambiguous` |
| Evidence strength | `< 0.5` |
| Out-of-vocab type | type not in canonical vocabulary |
| Confidence floor | `< 0.6` (`MIN_CONFIDENCE`) |

Self-judgment metadata is persisted on stored relations for observability.

### Tests
All 502 tests pass, no regressions.