### PR TITLE
Bound daemon maintenance cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ export QDRANT_URL="http://localhost:6333"
 
 `memory_store` · `memory_recall` · `memory_entity` · `memory_relations` · `memory_forget` · `memory_verify` · `memory_heartbeat` · `memory_review` · `configure_credentials` · `verify_connection`
 
-**Daemon** — background process that passively watches session logs, extracts structured facts, writes lightweight session indexes, captures coherent episode summaries, updates current-state workstream summaries, infers entity relationships, and runs the consolidation pipeline. Lifecycle memory is daemon-owned so agents do not need to remember summary/distillation tool calls.
+**Daemon** — background process that passively watches session logs, extracts structured facts, writes lightweight session indexes, captures coherent episode summaries, updates current-state workstream summaries, infers entity relationships from recently changed facts, and runs the consolidation pipeline. Lifecycle memory is daemon-owned so agents do not need to remember summary/distillation tool calls.
 
 ---
 
@@ -168,7 +168,7 @@ Raw fact accumulation creates noise. bikky keeps the knowledge store clean autom
 - **Confidence decay** — old facts lose weight and surface for review
 - **Contradiction detection** — conflicting facts are resolved, not silently stacked
 - **Distillation** — recurring patterns across sessions consolidate into higher-level insights
-- **Entity graph** — relationships between concepts are inferred for richer recall
+- **Entity graph** — relationships between concepts are inferred incrementally for richer recall
 
 ---
 
@@ -217,7 +217,7 @@ bikky render    # render a prompt to JSON (for eval harnesses & debugging)
 config file, highlights env vars that override it, checks Qdrant reachability and
 payload-index readiness without mutating the collection, runs a live embedding
 smoke check, validates the configured LLM provider name without sending a chat
-request, and reports daemon/UI health. Use `bikky status --json` for automation,
+request, and reports daemon maintenance plus UI health. Use `bikky status --json` for automation,
 `--no-live` to skip the embedding call, and `--no-ui` to skip the local UI probe.
 
 ### `bikky render` — inspect prompts

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,7 +140,7 @@ config, or send an LLM chat request. It reports:
 | Qdrant | Checks reachability, collection existence, vector size, and payload-index readiness against Bikky's canonical index list |
 | Embedding | Validates the provider config and runs a small live embedding request by default |
 | LLM | Validates provider and fallback provider names without a live inference call |
-| Daemon/UI | Reports daemon PID state and probes the local UI `/health` endpoint |
+| Daemon/UI | Reports daemon PID state, maintenance-worker summaries, and probes the local UI `/health` endpoint |
 
 Useful options:
 
@@ -230,7 +230,7 @@ file and env vars.
 
 ## Daemon settings
 
-The daemon owns memory lifecycle work: it extracts structured facts, writes lightweight session indexes, captures coherent episode summaries, and distills longer-lived patterns when consolidation is enabled.
+The daemon owns memory lifecycle work: it extracts structured facts, writes lightweight session indexes, captures coherent episode summaries, and distills longer-lived patterns when consolidation is enabled. Cost-sensitive maintenance workers use wall-clock intervals plus a persistent cursor in `~/.bikky/state/maintenance-state.json`, so relation inference and entity typing process recently changed facts instead of rescanning all memory on every cycle.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
@@ -238,8 +238,26 @@ The daemon owns memory lifecycle work: it extracts structured facts, writes ligh
 | `daemon.extract_every_sec` | `300` | Seconds between extraction runs |
 | `daemon.extract_min_events` | `10` | Minimum session events before triggering extraction |
 | `daemon.consolidation_enabled` | `true` | Auto-distill daemon-generated session summaries into patterns |
-| `daemon.relation_inference_enabled` | `true` | Infer entity relationships via LLM |
+| `daemon.relation_inference_enabled` | `true` | Infer entity relationships via LLM from recently changed facts |
+| `daemon.relation_inference_interval_sec` | `7200` | Minimum seconds between relation-inference maintenance runs |
+| `daemon.relation_inference_max_pairs_per_run` | `3` | Maximum entity pairs sent to the LLM in one relation-inference run |
+| `daemon.entity_typing_enabled` | `true` | Classify entities for UI/graph filtering |
+| `daemon.entity_typing_interval_sec` | `900` | Minimum seconds between entity-typing maintenance runs |
+| `daemon.entity_typing_max_entities_per_run` | `5` | Maximum entities classified in one entity-typing run |
 | `daemon.staleness_threshold_days` | `30` | Days before a fact is flagged as stale |
+
+Environment overrides are available for the high-cost maintenance controls:
+
+| Env var | Config field |
+|---------|--------------|
+| `BIKKY_DAEMON_RELATION_INFERENCE_ENABLED` | `daemon.relation_inference_enabled` |
+| `BIKKY_DAEMON_RELATION_INFERENCE_INTERVAL_SEC` | `daemon.relation_inference_interval_sec` |
+| `BIKKY_DAEMON_RELATION_INFERENCE_MAX_PAIRS_PER_RUN` | `daemon.relation_inference_max_pairs_per_run` |
+| `BIKKY_DAEMON_ENTITY_TYPING_ENABLED` | `daemon.entity_typing_enabled` |
+| `BIKKY_DAEMON_ENTITY_TYPING_INTERVAL_SEC` | `daemon.entity_typing_interval_sec` |
+| `BIKKY_DAEMON_ENTITY_TYPING_MAX_ENTITIES_PER_RUN` | `daemon.entity_typing_max_entities_per_run` |
+
+`bikky status` shows the latest maintenance summaries: candidates seen, LLM calls made, accepted records, deterministic entity classifications, skip reasons, and errors. For per-call token cost, inspect `~/.bikky/logs/llm.jsonl`; each daemon LLM call includes `prompt`, `subsystem`, estimated tokens, and provider-actual token fields when the provider returns usage metadata.
 
 ## Logs
 
@@ -249,6 +267,7 @@ Bikky writes logs to `~/.bikky/logs/` (the same directory as the config file).
 |------|-----------|
 | `mcp.log` | The MCP server (`bikky mcp`) |
 | `daemon.log` | The background daemon (`bikky daemon` / `bikky start`) |
+| `llm.jsonl` | LLM telemetry from daemon and MCP chat-completion calls |
 
 Logs are **structured JSON lines** produced by [pino](https://github.com/pinojs/pino). Each line has at minimum `{level, time, name, msg}`; provider failures, telemetry events, and Qdrant operations attach extra fields (e.g. `provider`, `kind`, `status`). Files rotate in-process at 2MB, keeping 3 generations (`mcp.log` + `mcp.log.1` + `mcp.log.2`).
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -69,6 +69,12 @@ const ENV_KEYS = [
   "AWS_REGION",
   "BIKKY_LLM_EXTRA_REGION",
   "BIKKY_EMBEDDING_EXTRA_REGION",
+  "BIKKY_DAEMON_RELATION_INFERENCE_ENABLED",
+  "BIKKY_DAEMON_RELATION_INFERENCE_INTERVAL_SEC",
+  "BIKKY_DAEMON_RELATION_INFERENCE_MAX_PAIRS_PER_RUN",
+  "BIKKY_DAEMON_ENTITY_TYPING_ENABLED",
+  "BIKKY_DAEMON_ENTITY_TYPING_INTERVAL_SEC",
+  "BIKKY_DAEMON_ENTITY_TYPING_MAX_ENTITIES_PER_RUN",
 ];
 
 let savedEnv: Record<string, string | undefined> = {};
@@ -210,6 +216,11 @@ describe("config", () => {
       assert.strictEqual(cfg.daemon.extract_min_events, 10);
       assert.strictEqual(cfg.daemon.consolidation_enabled, true);
       assert.strictEqual(cfg.daemon.relation_inference_enabled, true);
+      assert.strictEqual(cfg.daemon.relation_inference_interval_sec, 7200);
+      assert.strictEqual(cfg.daemon.relation_inference_max_pairs_per_run, 3);
+      assert.strictEqual(cfg.daemon.entity_typing_enabled, true);
+      assert.strictEqual(cfg.daemon.entity_typing_interval_sec, 900);
+      assert.strictEqual(cfg.daemon.entity_typing_max_entities_per_run, 5);
       assert.strictEqual(cfg.daemon.staleness_threshold_days, 30);
     });
 
@@ -372,6 +383,25 @@ describe("config", () => {
       assert.strictEqual(cfg.llm.extra?.virtual_key, "vk-1");
       delete process.env.BIKKY_LLM_EXTRA_VIRTUAL_KEY;
     });
+
+    it("BIKKY_DAEMON_* env vars override maintenance controls", () => {
+      if (fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
+      process.env.BIKKY_DAEMON_RELATION_INFERENCE_ENABLED = "false";
+      process.env.BIKKY_DAEMON_RELATION_INFERENCE_INTERVAL_SEC = "3600";
+      process.env.BIKKY_DAEMON_RELATION_INFERENCE_MAX_PAIRS_PER_RUN = "2";
+      process.env.BIKKY_DAEMON_ENTITY_TYPING_ENABLED = "0";
+      process.env.BIKKY_DAEMON_ENTITY_TYPING_INTERVAL_SEC = "1200";
+      process.env.BIKKY_DAEMON_ENTITY_TYPING_MAX_ENTITIES_PER_RUN = "4";
+
+      const cfg = loadConfig();
+
+      assert.strictEqual(cfg.daemon.relation_inference_enabled, false);
+      assert.strictEqual(cfg.daemon.relation_inference_interval_sec, 3600);
+      assert.strictEqual(cfg.daemon.relation_inference_max_pairs_per_run, 2);
+      assert.strictEqual(cfg.daemon.entity_typing_enabled, false);
+      assert.strictEqual(cfg.daemon.entity_typing_interval_sec, 1200);
+      assert.strictEqual(cfg.daemon.entity_typing_max_entities_per_run, 4);
+    });
   });
 
   // ── URL trailing slash stripping ──────────────────────────────────────────
@@ -504,7 +534,11 @@ describe("config", () => {
         qdrant_url: "ftp://qdrant.example",
         collection: "",
         embedding: { dimensions: -1, base_url: "not a url" },
-        daemon: { consolidation_enabled: "yes" },
+        daemon: {
+          consolidation_enabled: "yes",
+          relation_inference_interval_sec: -1,
+          entity_typing_enabled: "yes",
+        },
       });
 
       assert.ok(issues.some((issue) => issue.path === "qdrant_url"));
@@ -512,6 +546,8 @@ describe("config", () => {
       assert.ok(issues.some((issue) => issue.path === "embedding.dimensions"));
       assert.ok(issues.some((issue) => issue.path === "embedding.base_url"));
       assert.ok(issues.some((issue) => issue.path === "daemon.consolidation_enabled"));
+      assert.ok(issues.some((issue) => issue.path === "daemon.relation_inference_interval_sec"));
+      assert.ok(issues.some((issue) => issue.path === "daemon.entity_typing_enabled"));
     });
 
     it("lists active exact and provider-extra env overrides", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,6 +71,11 @@ export interface DaemonConfig {
   extraction_prompt: string | null;
   consolidation_enabled: boolean;
   relation_inference_enabled: boolean;
+  relation_inference_interval_sec: number;
+  relation_inference_max_pairs_per_run: number;
+  entity_typing_enabled: boolean;
+  entity_typing_interval_sec: number;
+  entity_typing_max_entities_per_run: number;
   staleness_threshold_days: number;
 }
 
@@ -150,6 +155,11 @@ const DEFAULTS: BikkyConfig = {
     extraction_prompt: null,
     consolidation_enabled: true,
     relation_inference_enabled: true,
+    relation_inference_interval_sec: 7200,
+    relation_inference_max_pairs_per_run: 3,
+    entity_typing_enabled: true,
+    entity_typing_interval_sec: 900,
+    entity_typing_max_entities_per_run: 5,
     staleness_threshold_days: 30,
   },
   watchers: {
@@ -188,6 +198,12 @@ export const CONFIG_ENV_KEYS = [
   "BIKKY_LLM_TIMEOUT_MS",
   "BIKKY_LLM_RETRIES",
   "BIKKY_LLM_RETRY_BASE_DELAY_MS",
+  "BIKKY_DAEMON_RELATION_INFERENCE_ENABLED",
+  "BIKKY_DAEMON_RELATION_INFERENCE_INTERVAL_SEC",
+  "BIKKY_DAEMON_RELATION_INFERENCE_MAX_PAIRS_PER_RUN",
+  "BIKKY_DAEMON_ENTITY_TYPING_ENABLED",
+  "BIKKY_DAEMON_ENTITY_TYPING_INTERVAL_SEC",
+  "BIKKY_DAEMON_ENTITY_TYPING_MAX_ENTITIES_PER_RUN",
 ] as const;
 
 const CONFIG_ENV_PREFIXES = [
@@ -230,6 +246,11 @@ const daemonConfigFileSchema = z.object({
   extraction_prompt: z.string().nullable().optional(),
   consolidation_enabled: z.boolean().optional(),
   relation_inference_enabled: z.boolean().optional(),
+  relation_inference_interval_sec: nonNegativeInt.optional(),
+  relation_inference_max_pairs_per_run: nonNegativeInt.optional(),
+  entity_typing_enabled: z.boolean().optional(),
+  entity_typing_interval_sec: nonNegativeInt.optional(),
+  entity_typing_max_entities_per_run: nonNegativeInt.optional(),
   staleness_threshold_days: nonNegativeInt.optional(),
 }).passthrough();
 
@@ -499,6 +520,26 @@ export function loadConfig(): BikkyConfig {
   if (llmRetries !== null) config.llm.retries = llmRetries;
   const llmDelay = positiveInt(process.env.BIKKY_LLM_RETRY_BASE_DELAY_MS);
   if (llmDelay !== null) config.llm.retry_base_delay_ms = llmDelay;
+
+  const booleanEnv = (raw: string | undefined): boolean | null => {
+    if (!raw) return null;
+    const normalized = raw.trim().toLowerCase();
+    if (["1", "true", "yes", "on"].includes(normalized)) return true;
+    if (["0", "false", "no", "off"].includes(normalized)) return false;
+    return null;
+  };
+  const relationEnabled = booleanEnv(process.env.BIKKY_DAEMON_RELATION_INFERENCE_ENABLED);
+  if (relationEnabled !== null) config.daemon.relation_inference_enabled = relationEnabled;
+  const relationInterval = positiveInt(process.env.BIKKY_DAEMON_RELATION_INFERENCE_INTERVAL_SEC);
+  if (relationInterval !== null) config.daemon.relation_inference_interval_sec = relationInterval;
+  const relationMax = positiveInt(process.env.BIKKY_DAEMON_RELATION_INFERENCE_MAX_PAIRS_PER_RUN);
+  if (relationMax !== null) config.daemon.relation_inference_max_pairs_per_run = relationMax;
+  const entityTypingEnabled = booleanEnv(process.env.BIKKY_DAEMON_ENTITY_TYPING_ENABLED);
+  if (entityTypingEnabled !== null) config.daemon.entity_typing_enabled = entityTypingEnabled;
+  const entityTypingInterval = positiveInt(process.env.BIKKY_DAEMON_ENTITY_TYPING_INTERVAL_SEC);
+  if (entityTypingInterval !== null) config.daemon.entity_typing_interval_sec = entityTypingInterval;
+  const entityTypingMax = positiveInt(process.env.BIKKY_DAEMON_ENTITY_TYPING_MAX_ENTITIES_PER_RUN);
+  if (entityTypingMax !== null) config.daemon.entity_typing_max_entities_per_run = entityTypingMax;
 
   // Propagate aws_profile into env so both Bedrock clients (LLM + embedding)
   // pick it up via the SDK's default credential chain.

--- a/src/daemon/consolidation.ts
+++ b/src/daemon/consolidation.ts
@@ -142,7 +142,10 @@ const autoDistill = async (
       })),
     });
 
-    const raw = await chatCompletion(rendered);
+    const raw = await chatCompletion({
+      ...rendered,
+      telemetry: { subsystem: "distillation", trigger: "auto_distill" },
+    });
 
     if (!raw) {
       logFn("WARN", "Auto-distill LLM returned empty");
@@ -221,6 +224,7 @@ const autoDistill = async (
 const detectContradiction = async (
   fact: { content: string; category: string; entities: string[]; importance?: number },
   _config: BikkyConfig,
+  telemetry?: { sessionId?: string; workstreamKey?: string },
 ): Promise<ContradictionResult> => {
   if (!qdrant.isReady()) return { contradiction: false };
   if ((fact.importance || 0) < 0.3) return { contradiction: false };
@@ -250,7 +254,15 @@ const detectContradiction = async (
       })),
     });
 
-    const raw = await chatCompletion(rendered);
+    const raw = await chatCompletion({
+      ...rendered,
+      telemetry: {
+        subsystem: "contradiction",
+        ...(telemetry?.sessionId ? { session_id: telemetry.sessionId } : {}),
+        ...(telemetry?.workstreamKey ? { workstream_key: telemetry.workstreamKey } : {}),
+        trigger: "fact_contradiction_check",
+      },
+    });
     if (!raw) return { contradiction: false };
 
     const result = safeParseJson<{
@@ -500,7 +512,10 @@ const generateMemoryBrief = async (_config: BikkyConfig): Promise<boolean> => {
 
     const generatedAt = new Date().toISOString().slice(0, 10);
     const rendered = briefPrompt({ generatedAt, sections });
-    const brief = await chatCompletion(rendered);
+    const brief = await chatCompletion({
+      ...rendered,
+      telemetry: { subsystem: "brief", trigger: "memory_brief" },
+    });
 
     if (!brief) return false;
 

--- a/src/daemon/entity-typing.test.ts
+++ b/src/daemon/entity-typing.test.ts
@@ -1,0 +1,55 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { __test } from "./entity-typing.js";
+import type { QdrantScrollResult } from "./qdrant.js";
+
+const fact = (overrides: Partial<QdrantScrollResult>): QdrantScrollResult => ({
+  id: "fact-1",
+  content: "The code lives in src/index.ts.",
+  category: "codebase",
+  entities: [],
+  confidence: 0.9,
+  last_reinforced_at: "2026-04-27T09:00:00.000Z",
+  created_at: "2026-04-27T09:00:00.000Z",
+  updated_at: "2026-04-27T09:00:00.000Z",
+  metadata: {},
+  ...overrides,
+});
+
+describe("daemon/entity-typing helpers", () => {
+  it("classifies obvious entity shapes without an LLM", () => {
+    assert.equal(__test.deterministicEntityType("src/daemon/entity-typing.ts")?.type, "file");
+    assert.equal(__test.deterministicEntityType("bikky-dev/bikky")?.type, "repo");
+    assert.equal(__test.deterministicEntityType("https://qdrant.example")?.type, "service");
+    assert.equal(__test.deterministicEntityType("QDRANT_URL")?.type, "artifact");
+    assert.equal(__test.deterministicEntityType("kubectl")?.type, "tool");
+    assert.equal(__test.deterministicEntityType("staging")?.type, "environment");
+  });
+
+  it("builds entity candidates with attribution from changed facts", () => {
+    const candidates = __test.buildEntityCandidates([
+      fact({
+        id: "fact-1",
+        entities: ["src/daemon/entity-typing.ts", "bikky-dev/bikky", "system"],
+        metadata: { extracted_from_session: "uuid:abc" },
+        workstream_key: "daemon-cost",
+      }),
+      fact({
+        id: "fact-2",
+        entities: ["src/daemon/entity-typing.ts"],
+        updated_at: "2026-04-27T09:05:00.000Z",
+        metadata: { extracted_from_session: "uuid:abc" },
+        workstream_key: "daemon-cost",
+      }),
+    ]);
+
+    const fileCandidate = candidates.find((candidate) => candidate.name === "src/daemon/entity-typing.ts");
+    assert.ok(fileCandidate);
+    assert.deepEqual(fileCandidate.factIds, ["fact-1", "fact-2"]);
+    assert.deepEqual(fileCandidate.sessionIds, ["uuid:abc"]);
+    assert.deepEqual(fileCandidate.workstreamKeys, ["daemon-cost"]);
+    assert.equal(fileCandidate.latestUpdatedAt, "2026-04-27T09:05:00.000Z");
+    assert.ok(!candidates.some((candidate) => candidate.name === "system"));
+  });
+});

--- a/src/daemon/entity-typing.ts
+++ b/src/daemon/entity-typing.ts
@@ -1,26 +1,30 @@
 /**
- * Entity-typing daemon module — Phase 5a of #46.
+ * Entity-typing daemon module.
  *
- * Periodically classifies entities mentioned by facts into a small ontology
- * (service / repo / file / person / organization / infrastructure / tool /
- * concept / environment / artifact / unknown) so the UI can render typed
- * chips and recall can filter by type.
- *
- * Classification results are stored as standalone Qdrant points with
- * kind="entity_type" and a stable ID derived from the entity name. Each tick
- * picks a small batch of untyped entities, runs the classifier, and upserts.
+ * Classifies entities from recently changed facts into a small ontology for
+ * UI chips and graph filtering. Work is scheduled by wall-clock config and a
+ * persistent cursor so cost grows with new memory, not total memory size.
  */
 
 import crypto from "node:crypto";
 import { chatCompletion } from "../llm/index.js";
+import type { BikkyConfig } from "../config.js";
 import { entityTypingPrompt, ENTITY_TYPING_PROMPT_DESCRIPTOR, safeParseJson } from "../prompts/index.js";
 import * as qdrant from "./qdrant.js";
-import type { LogFn } from "./qdrant.js";
+import type { LogFn, QdrantScrollResult } from "./qdrant.js";
+import {
+  isAttemptBackedOff,
+  pruneRecentAttempts,
+  readMaintenanceState,
+  recordMaintenanceRun,
+  shouldRunMaintenance,
+} from "./maintenance-state.js";
+import { isGenericEntity } from "./relations-vocab.js";
 
-const ENTITY_TYPING_INTERVAL_TICKS = 20;
 const FACTS_SCAN_LIMIT = 200;
-const MAX_ENTITIES_PER_TICK = 5;
 const FACTS_PER_ENTITY = 5;
+const DEFAULT_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000;
+const ENTITY_ATTEMPT_BACKOFF_MS = 24 * 60 * 60 * 1000;
 
 const VALID_ENTITY_TYPES = new Set([
   "service",
@@ -37,16 +41,12 @@ const VALID_ENTITY_TYPES = new Set([
 ]);
 
 let logFn: LogFn = () => {};
-let tickCount = 0;
 
 export const setLogger = (fn: LogFn): void => {
   logFn = fn;
 };
 
 const entityIdFor = (name: string): string => {
-  // Stable, deterministic ID per entity name (lowercase) so repeated
-  // classifications of the same entity overwrite the same point.
-  // UUID-formatted so Qdrant accepts it.
   const hash = crypto.createHash("sha256").update(`entity_type:${name.toLowerCase()}`).digest("hex");
   return [
     hash.slice(0, 8),
@@ -58,23 +58,130 @@ const entityIdFor = (name: string): string => {
 };
 
 interface EntityFactSample {
+  id: string;
   content: string;
   category: string;
+  updated_at: string;
+  session_id?: string | null;
+  workstream_key?: string | null;
+  metadata: Record<string, string | number | boolean | null>;
 }
 
+interface EntityCandidate {
+  name: string;
+  facts: EntityFactSample[];
+  factIds: string[];
+  sessionIds: string[];
+  workstreamKeys: string[];
+  latestUpdatedAt: string;
+}
+
+interface Classification {
+  type: string;
+  reasoning?: string;
+  confidence?: number;
+}
+
+const sessionIdFromFact = (fact: EntityFactSample): string | null => {
+  if (fact.session_id) return fact.session_id;
+  const extracted = fact.metadata.extracted_from_session;
+  if (typeof extracted === "string" && extracted.trim()) return extracted;
+  const summarized = fact.metadata.summarized_from_session;
+  return typeof summarized === "string" && summarized.trim() ? summarized : null;
+};
+
+const uniqueStrings = (values: Array<string | null | undefined>): string[] =>
+  [...new Set(values.map((value) => value?.trim()).filter((value): value is string => Boolean(value)))];
+
+const buildEntityCandidates = (facts: QdrantScrollResult[]): EntityCandidate[] => {
+  const candidates = new Map<string, EntityFactSample[]>();
+  for (const fact of facts) {
+    for (const entity of fact.entities || []) {
+      const name = entity.trim().toLowerCase();
+      if (!name || name.length < 2 || isGenericEntity(name)) continue;
+      const samples = candidates.get(name) ?? [];
+      if (samples.length < FACTS_PER_ENTITY) {
+        samples.push({
+          id: fact.id,
+          content: fact.content,
+          category: fact.category,
+          updated_at: fact.updated_at || fact.created_at,
+          session_id: fact.session_id,
+          workstream_key: fact.workstream_key,
+          metadata: fact.metadata,
+        });
+      }
+      candidates.set(name, samples);
+    }
+  }
+
+  return [...candidates.entries()]
+    .map(([name, samples]) => ({
+      name,
+      facts: samples,
+      factIds: uniqueStrings(samples.map((sample) => sample.id)),
+      sessionIds: uniqueStrings(samples.map(sessionIdFromFact)),
+      workstreamKeys: uniqueStrings(samples.map((sample) => sample.workstream_key)),
+      latestUpdatedAt: samples
+        .map((sample) => sample.updated_at)
+        .filter(Boolean)
+        .sort()
+        .at(-1) ?? "",
+    }))
+    .sort((a, b) => a.latestUpdatedAt.localeCompare(b.latestUpdatedAt) || a.name.localeCompare(b.name));
+};
+
+const deterministicEntityType = (entity: string): Classification | null => {
+  const value = entity.trim();
+  const lower = value.toLowerCase();
+
+  if (/^https?:\/\//i.test(value) || /^[a-z0-9.-]+\.[a-z]{2,}(?::\d+)?(?:\/.*)?$/i.test(value)) {
+    return { type: "service", reasoning: "deterministic shape: URL or domain", confidence: 0.95 };
+  }
+  if (/^(?:\.{1,2}\/|\/)?(?:[\w.-]+\/)+[\w.-]+\.(?:ts|tsx|js|jsx|mjs|cjs|json|md|yml|yaml|toml|py|go|rs|java|sql|sh|css|html)$/i.test(value)) {
+    return { type: "file", reasoning: "deterministic shape: file path", confidence: 0.95 };
+  }
+  if (/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/i.test(value)) {
+    return { type: "repo", reasoning: "deterministic shape: owner/repo slug", confidence: 0.9 };
+  }
+  if (/^[A-Z][A-Z0-9_]{2,}$/.test(value)) {
+    return { type: "artifact", reasoning: "deterministic shape: environment variable or constant", confidence: 0.85 };
+  }
+  if (/^(main|master|develop|development|feat\/[\w.-]+|fix\/[\w.-]+|chore\/[\w.-]+|release\/[\w.-]+)$/i.test(value)) {
+    return { type: "artifact", reasoning: "deterministic shape: branch or release ref", confidence: 0.8 };
+  }
+  if (/^(prod|production|staging|stage|dev|test|local|sandbox)$/i.test(value)) {
+    return { type: "environment", reasoning: "deterministic shape: environment name", confidence: 0.85 };
+  }
+  if (/^(npm|npx|node|bun|pnpm|yarn|git|gh|docker|kubectl|helm|make|python|pip|go|cargo|curl)$/i.test(lower)) {
+    return { type: "tool", reasoning: "deterministic shape: CLI tool name", confidence: 0.9 };
+  }
+  return null;
+};
+
 const classifyEntity = async (
-  entity: string,
-  samples: EntityFactSample[],
-): Promise<{ type: string; reasoning?: string; confidence?: number } | null> => {
-  if (samples.length === 0) return null;
-  const rendered = entityTypingPrompt({ entity, facts: samples });
-  const raw = await chatCompletion(rendered);
+  candidate: EntityCandidate,
+): Promise<Classification | null> => {
+  if (candidate.facts.length === 0) return null;
+  const rendered = entityTypingPrompt({
+    entity: candidate.name,
+    facts: candidate.facts.map((fact) => ({ content: fact.content, category: fact.category })),
+  });
+  const raw = await chatCompletion({
+    ...rendered,
+    telemetry: {
+      subsystem: "entity-typing",
+      ...(candidate.sessionIds.length > 0 ? { session_id: candidate.sessionIds.join(",") } : {}),
+      ...(candidate.workstreamKeys.length > 0 ? { workstream_key: candidate.workstreamKeys.join(",") } : {}),
+      trigger: "classify_entity",
+    },
+  });
   if (!raw) return null;
   const parsed = safeParseJson<{ type?: string; reasoning?: string; confidence?: number }>(raw);
   if (!parsed?.type) return null;
   const type = parsed.type.toLowerCase();
   if (!VALID_ENTITY_TYPES.has(type)) {
-    logFn("DEBUG", `EntityTyping: LLM returned invalid type '${type}' for '${entity}' — skipping`);
+    logFn("DEBUG", `EntityTyping: LLM returned invalid type '${type}' for '${candidate.name}' — skipping`);
     return null;
   }
   return {
@@ -84,52 +191,24 @@ const classifyEntity = async (
   };
 };
 
-const findUntypedEntities = async (): Promise<Map<string, EntityFactSample[]>> => {
-  // Scroll recent facts to gather candidate entities + their context.
-  const recent = await qdrant.scrollFacts({}, FACTS_SCAN_LIMIT);
-  const candidates = new Map<string, EntityFactSample[]>();
-  for (const f of recent) {
-    for (const e of f.entities || []) {
-      if (!e || e.length < 2) continue;
-      if (!candidates.has(e)) candidates.set(e, []);
-      const arr = candidates.get(e)!;
-      if (arr.length < FACTS_PER_ENTITY) {
-        arr.push({ content: f.content, category: f.category });
-      }
-    }
-  }
-
-  // Filter out entities that already have a type point in Qdrant.
-  const untyped = new Map<string, EntityFactSample[]>();
-  for (const [name, facts] of candidates) {
-    const id = entityIdFor(name);
-    try {
-      const result = await qdrant.qdrantRequest(
-        "POST",
-        `/collections/${qdrant.collection}/points`,
-        { ids: [id], with_payload: true },
-      ) as { result?: Array<{ id: string }> };
-      if (!result.result || result.result.length === 0) {
-        untyped.set(name, facts);
-      }
-    } catch {
-      // If lookup fails treat as untyped — the upsert is idempotent.
-      untyped.set(name, facts);
-    }
-    if (untyped.size >= MAX_ENTITIES_PER_TICK) break;
-  }
-  return untyped;
+const existingEntityTypeIds = async (ids: string[]): Promise<Set<string>> => {
+  if (ids.length === 0) return new Set();
+  const result = await qdrant.qdrantRequest(
+    "POST",
+    `/collections/${qdrant.collection}/points`,
+    { ids, with_payload: false },
+  ) as { result?: Array<{ id: string }> };
+  return new Set((result.result ?? []).map((point) => point.id));
 };
 
 const upsertEntityTypePoint = async (
-  entity: string,
-  classification: { type: string; reasoning?: string; confidence?: number },
+  candidate: EntityCandidate,
+  classification: Classification,
+  source: "deterministic" | "llm",
 ): Promise<void> => {
-  const id = entityIdFor(entity);
+  const id = entityIdFor(candidate.name);
   const now = new Date().toISOString();
-  // The vector is the embedding of the entity NAME — lets us nearest-neighbour
-  // entities of the same type later if we want to.
-  const vector = await qdrant.embed(entity);
+  const vector = await qdrant.embed(candidate.name);
   await qdrant.qdrantRequest("PUT", `/collections/${qdrant.collection}/points`, {
     points: [
       {
@@ -137,50 +216,143 @@ const upsertEntityTypePoint = async (
         vector,
         payload: {
           kind: "entity_type",
-          entity_name: entity,
+          entity_name: candidate.name,
           entity_type: classification.type,
           entity_type_reasoning: classification.reasoning ?? null,
           entity_type_confidence: classification.confidence ?? 0.7,
           classified_at: now,
           updated_at: now,
           created_at: now,
+          source_fact_ids: candidate.factIds,
+          ...(candidate.workstreamKeys.length > 0 ? { workstream_key: candidate.workstreamKeys[0] } : {}),
+          metadata: {
+            classification_source: source,
+            classified_by_prompt: `${ENTITY_TYPING_PROMPT_DESCRIPTOR.id}@${ENTITY_TYPING_PROMPT_DESCRIPTOR.version}`,
+            triggering_fact_ids: candidate.factIds.join(","),
+            ...(candidate.sessionIds.length > 0 ? { triggering_sessions: candidate.sessionIds.join(",") } : {}),
+            ...(candidate.workstreamKeys.length > 0 ? { triggering_workstreams: candidate.workstreamKeys.join(",") } : {}),
+          },
         },
       },
     ],
   });
 };
 
-export const tick = async (): Promise<void> => {
-  tickCount++;
-  if (tickCount % ENTITY_TYPING_INTERVAL_TICKS !== 0) return;
+const maxUpdatedAt = (facts: QdrantScrollResult[], fallback: string): string =>
+  facts.map((fact) => fact.updated_at || fact.created_at).filter(Boolean).sort().at(-1) ?? fallback;
 
-  let typed = 0;
+export const tick = async (config: BikkyConfig): Promise<void> => {
+  if (!config.daemon.entity_typing_enabled) return;
+  if (!qdrant.isReady()) return;
+
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const state = readMaintenanceState(logFn);
+  const job = state.jobs.entity_typing;
+  const intervalSec = config.daemon.entity_typing_interval_sec ?? 900;
+  if (!shouldRunMaintenance(now, job.last_run_at, intervalSec)) return;
+
+  const attempts = pruneRecentAttempts(job.recent_attempts, now, ENTITY_ATTEMPT_BACKOFF_MS);
+  const maxEntities = config.daemon.entity_typing_max_entities_per_run ?? 5;
+  const since = job.cursor_updated_at ?? new Date(now.getTime() - DEFAULT_LOOKBACK_MS).toISOString();
+
   try {
-    const untyped = await findUntypedEntities();
-    for (const [name, facts] of untyped) {
+    const changedFacts = await qdrant.scrollFacts({
+      sinceUpdated: since,
+      excludeKinds: ["relation"],
+      orderBy: { key: "updated_at", direction: "asc" },
+    }, FACTS_SCAN_LIMIT);
+
+    if (changedFacts.length === 0) {
+      recordMaintenanceRun("entity_typing", {
+        job: "entity_typing",
+        ran_at: nowIso,
+        status: "skipped",
+        candidates_seen: 0,
+        llm_calls: 0,
+        accepted: 0,
+        deterministic: 0,
+        skipped_reason: "no_changed_facts",
+      }, { cursorUpdatedAt: nowIso, recentAttempts: attempts }, logFn);
+      return;
+    }
+
+    const candidates = buildEntityCandidates(changedFacts);
+    const existing = await existingEntityTypeIds(candidates.map((candidate) => entityIdFor(candidate.name)));
+    const untyped = candidates
+      .filter((candidate) => !existing.has(entityIdFor(candidate.name)))
+      .filter((candidate) => !isAttemptBackedOff(attempts, candidate.name, now, ENTITY_ATTEMPT_BACKOFF_MS));
+
+    let accepted = 0;
+    let deterministic = 0;
+    let llmCalls = 0;
+    let failures = 0;
+
+    for (const candidate of untyped.slice(0, maxEntities)) {
       try {
-        const classification = await classifyEntity(name, facts);
-        if (!classification) continue;
-        await upsertEntityTypePoint(name, classification);
-        typed++;
+        const deterministicClassification = deterministicEntityType(candidate.name);
+        if (deterministicClassification) {
+          await upsertEntityTypePoint(candidate, deterministicClassification, "deterministic");
+          accepted++;
+          deterministic++;
+          continue;
+        }
+
+        llmCalls++;
+        attempts[candidate.name] = nowIso;
+        const classification = await classifyEntity(candidate);
+        if (!classification) {
+          failures++;
+          continue;
+        }
+        await upsertEntityTypePoint(candidate, classification, "llm");
+        accepted++;
         logFn(
           "DEBUG",
-          `EntityTyping: classified '${name}' as ${classification.type} (confidence ${classification.confidence})`,
+          `EntityTyping: classified '${candidate.name}' as ${classification.type} (confidence ${classification.confidence})`,
         );
       } catch (e) {
-        logFn("WARN", `EntityTyping: classify failed for '${name}': ${(e as Error).message}`);
+        failures++;
+        logFn("WARN", `EntityTyping: classify failed for '${candidate.name}': ${(e as Error).message}`);
       }
     }
-    if (typed > 0) {
-      logFn("INFO", `EntityTyping: typed ${typed} entities (prompt v${ENTITY_TYPING_PROMPT_DESCRIPTOR.version})`);
+
+    const capped = untyped.length > maxEntities;
+    const cursorUpdatedAt = capped || failures > 0 ? job.cursor_updated_at : maxUpdatedAt(changedFacts, nowIso);
+    recordMaintenanceRun("entity_typing", {
+      job: "entity_typing",
+      ran_at: nowIso,
+      status: "success",
+      candidates_seen: candidates.length,
+      llm_calls: llmCalls,
+      accepted,
+      deterministic,
+      skipped_reason: capped ? "max_entities_per_run_reached" : undefined,
+    }, { cursorUpdatedAt, recentAttempts: attempts }, logFn);
+
+    if (accepted > 0) {
+      logFn("INFO", `EntityTyping: typed ${accepted} entities (${deterministic} deterministic, ${llmCalls} LLM)`);
     }
   } catch (e) {
+    recordMaintenanceRun("entity_typing", {
+      job: "entity_typing",
+      ran_at: nowIso,
+      status: "error",
+      candidates_seen: 0,
+      llm_calls: 0,
+      accepted: 0,
+      deterministic: 0,
+      error: (e as Error).message,
+    }, { cursorUpdatedAt: job.cursor_updated_at, recentAttempts: attempts }, logFn);
     logFn("WARN", `EntityTyping: tick failed: ${(e as Error).message}`);
   }
 };
 
 // Exported for testing only
 export const __test = {
+  buildEntityCandidates,
+  deterministicEntityType,
   entityIdFor,
+  maxUpdatedAt,
   VALID_ENTITY_TYPES,
 };

--- a/src/daemon/episode-summary.ts
+++ b/src/daemon/episode-summary.ts
@@ -256,8 +256,21 @@ export const buildEpisodeSummaryPayload = (input: {
   return { payload, redaction };
 };
 
-const summarizeEpisodeTranscript = async (transcript: string): Promise<EpisodeSummaryDraft> => {
-  const result = await chatCompletion(episodeSummaryPrompt({ transcript }));
+const summarizeEpisodeTranscript = async (input: {
+  transcript: string;
+  sessionId: string;
+  workstreamKey?: string | null;
+}): Promise<EpisodeSummaryDraft> => {
+  const rendered = episodeSummaryPrompt({ transcript: input.transcript });
+  const result = await chatCompletion({
+    ...rendered,
+    telemetry: {
+      subsystem: "summary",
+      session_id: input.sessionId,
+      ...(input.workstreamKey ? { workstream_key: input.workstreamKey } : {}),
+      trigger: "episode_summary",
+    },
+  });
   if (!result) throw new Error("Episode summary LLM returned null");
   return parseEpisodeSummaryDraft(result);
 };
@@ -287,7 +300,11 @@ export const updateEpisodeSummary = async (input: {
   }
 
   const existing = await findExistingEpisodeSummary(input.segment.episode_id, input.scope);
-  const draft = await summarizeEpisodeTranscript(input.segment.transcript);
+  const draft = await summarizeEpisodeTranscript({
+    transcript: input.segment.transcript,
+    sessionId: input.sessionId,
+    workstreamKey: input.segment.workstream_key ?? null,
+  });
 
   // Resolve workstream key: deterministic extraction wins, then alias lookup,
   // then accept LLM-proposed key as new canonical, otherwise null.

--- a/src/daemon/extraction.ts
+++ b/src/daemon/extraction.ts
@@ -528,7 +528,7 @@ export const isHighQualityExtractedFact = (fact: ExtractedFact): boolean => {
 /**
  * Call the LLM to extract facts from a conversation transcript.
  */
-const extractFacts = async (transcript: string, config?: BikkyConfig): Promise<ExtractedFact[]> => {
+const extractFacts = async (transcript: string, sessionId: string, config?: BikkyConfig): Promise<ExtractedFact[]> => {
   if (!transcript.trim()) return [];
 
   const rendered = extractionPrompt({
@@ -536,7 +536,10 @@ const extractFacts = async (transcript: string, config?: BikkyConfig): Promise<E
     systemOverride: config?.daemon.extraction_prompt ?? null,
   });
 
-  const result = await chatCompletion(rendered);
+  const result = await chatCompletion({
+    ...rendered,
+    telemetry: { subsystem: "extraction", session_id: sessionId, trigger: "daemon_extraction" },
+  });
 
   if (!result) {
     logFn("WARN", "Extraction LLM call returned null");
@@ -627,7 +630,10 @@ const storeFacts = async (
       // Run contradiction detection for non-trivial facts
       if (config && (fact.confidence ?? 0.5) >= 0.5) {
         try {
-          const contradiction = await detectContradiction(sanitizedFact, config);
+          const contradiction = await detectContradiction(sanitizedFact, config, {
+            sessionId,
+            workstreamKey: sanitizedFact.workstream_key ?? undefined,
+          });
           if (contradiction.contradiction && contradiction.existingId) {
             logFn("INFO", `Extraction: contradiction detected for "${fact.content.slice(0, 60)}..." vs ${contradiction.existingId}: ${contradiction.reason}`);
             // Log contradiction instead of writing to inbox
@@ -919,7 +925,7 @@ const extractForUuid = async (
     logFn("DEBUG", `Extraction: UUID ${uuid.slice(0, 8)} — chunk ${i + 1}/${chunks.length}, ${chunks[i]!.length} events, ${transcript.length} chars`);
 
     if (events.length >= minEvents) {
-      const facts = await extractFacts(transcript, config);
+      const facts = await extractFacts(transcript, stateKey, config);
 
       if (facts.length > 0) {
         const stored = await storeFacts(facts, stateKey, config);

--- a/src/daemon/loop.ts
+++ b/src/daemon/loop.ts
@@ -97,7 +97,7 @@ export async function startDaemon(): Promise<void> {
     }
 
     try {
-      await entityTypingTick();
+      await entityTypingTick(cfg);
     } catch (e) {
       log("ERROR", `Entity typing tick failed: ${(e as Error).message}`);
     }

--- a/src/daemon/maintenance-state.test.ts
+++ b/src/daemon/maintenance-state.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+const TEST_BIKKY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-maint-state-"));
+process.env.BIKKY_HOME = TEST_BIKKY_HOME;
+
+const {
+  MAINTENANCE_STATE_PATH,
+  defaultMaintenanceState,
+  isAttemptBackedOff,
+  pruneRecentAttempts,
+  readMaintenanceState,
+  recordMaintenanceRun,
+  shouldRunMaintenance,
+} = await import("./maintenance-state.js");
+
+describe("daemon/maintenance-state", () => {
+  beforeEach(() => {
+    fs.rmSync(TEST_BIKKY_HOME, { recursive: true, force: true });
+    fs.mkdirSync(TEST_BIKKY_HOME, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(TEST_BIKKY_HOME, { recursive: true, force: true });
+  });
+
+  it("starts with default job states", () => {
+    assert.deepEqual(readMaintenanceState(), defaultMaintenanceState());
+  });
+
+  it("uses wall-clock intervals to decide whether a job should run", () => {
+    const now = new Date("2026-04-27T10:00:00.000Z");
+
+    assert.equal(shouldRunMaintenance(now, null, 900), true);
+    assert.equal(shouldRunMaintenance(now, "2026-04-27T09:50:00.000Z", 900), false);
+    assert.equal(shouldRunMaintenance(now, "2026-04-27T09:40:00.000Z", 900), true);
+    assert.equal(shouldRunMaintenance(now, "not-a-date", 900), true);
+    assert.equal(shouldRunMaintenance(now, "2026-04-27T09:59:59.000Z", 0), true);
+  });
+
+  it("records run summaries and cursors", () => {
+    recordMaintenanceRun("entity_typing", {
+      job: "entity_typing",
+      ran_at: "2026-04-27T10:00:00.000Z",
+      status: "success",
+      candidates_seen: 2,
+      llm_calls: 1,
+      accepted: 2,
+      deterministic: 1,
+    }, { cursorUpdatedAt: "2026-04-27T09:59:00.000Z" });
+
+    const state = readMaintenanceState();
+    assert.ok(fs.existsSync(MAINTENANCE_STATE_PATH));
+    assert.equal(state.jobs.entity_typing.last_run_at, "2026-04-27T10:00:00.000Z");
+    assert.equal(state.jobs.entity_typing.cursor_updated_at, "2026-04-27T09:59:00.000Z");
+    assert.equal(state.jobs.entity_typing.last_summary?.accepted, 2);
+  });
+
+  it("prunes and checks recent attempt backoff windows", () => {
+    const now = new Date("2026-04-27T10:00:00.000Z");
+    const attempts = {
+      fresh: "2026-04-27T09:59:00.000Z",
+      old: "2026-04-20T09:59:00.000Z",
+      bad: "not-a-date",
+    };
+
+    assert.equal(isAttemptBackedOff(attempts, "fresh", now, 5 * 60 * 1000), true);
+    assert.equal(isAttemptBackedOff(attempts, "old", now, 5 * 60 * 1000), false);
+    assert.deepEqual(pruneRecentAttempts(attempts, now, 24 * 60 * 60 * 1000), { fresh: attempts.fresh });
+  });
+});

--- a/src/daemon/maintenance-state.ts
+++ b/src/daemon/maintenance-state.ts
@@ -1,0 +1,155 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { STATE_DIR } from "../config.js";
+import type { LogFn } from "./qdrant.js";
+
+export const MAINTENANCE_STATE_PATH = join(STATE_DIR, "maintenance-state.json");
+
+export type MaintenanceJobName = "relation_inference" | "entity_typing";
+
+export interface MaintenanceRunSummary {
+  job: MaintenanceJobName;
+  ran_at: string;
+  status: "success" | "skipped" | "error";
+  candidates_seen: number;
+  llm_calls: number;
+  accepted: number;
+  deterministic?: number;
+  skipped_reason?: string;
+  error?: string;
+}
+
+export interface MaintenanceJobState {
+  last_run_at: string | null;
+  cursor_updated_at: string | null;
+  last_summary: MaintenanceRunSummary | null;
+  recent_attempts: Record<string, string>;
+}
+
+export interface MaintenanceState {
+  version: 1;
+  jobs: Record<MaintenanceJobName, MaintenanceJobState>;
+}
+
+const defaultJobState = (): MaintenanceJobState => ({
+  last_run_at: null,
+  cursor_updated_at: null,
+  last_summary: null,
+  recent_attempts: {},
+});
+
+export const defaultMaintenanceState = (): MaintenanceState => ({
+  version: 1,
+  jobs: {
+    relation_inference: defaultJobState(),
+    entity_typing: defaultJobState(),
+  },
+});
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const coerceJobState = (value: unknown): MaintenanceJobState => {
+  if (!isRecord(value)) return defaultJobState();
+  return {
+    last_run_at: typeof value.last_run_at === "string" ? value.last_run_at : null,
+    cursor_updated_at: typeof value.cursor_updated_at === "string" ? value.cursor_updated_at : null,
+    last_summary: isRecord(value.last_summary) ? value.last_summary as unknown as MaintenanceRunSummary : null,
+    recent_attempts: isRecord(value.recent_attempts)
+      ? Object.fromEntries(
+        Object.entries(value.recent_attempts)
+          .filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+      )
+      : {},
+  };
+};
+
+export const readMaintenanceState = (log: LogFn = () => {}): MaintenanceState => {
+  if (!existsSync(MAINTENANCE_STATE_PATH)) return defaultMaintenanceState();
+  try {
+    const parsed = JSON.parse(readFileSync(MAINTENANCE_STATE_PATH, "utf-8")) as unknown;
+    if (!isRecord(parsed)) return defaultMaintenanceState();
+    const jobs = isRecord(parsed.jobs) ? parsed.jobs : {};
+    return {
+      version: 1,
+      jobs: {
+        relation_inference: coerceJobState(jobs.relation_inference),
+        entity_typing: coerceJobState(jobs.entity_typing),
+      },
+    };
+  } catch (e) {
+    log("WARN", `Maintenance state: failed to read state, starting fresh: ${(e as Error).message}`);
+    return defaultMaintenanceState();
+  }
+};
+
+export const writeMaintenanceState = (state: MaintenanceState, log: LogFn = () => {}): void => {
+  try {
+    mkdirSync(STATE_DIR, { recursive: true });
+    writeFileSync(MAINTENANCE_STATE_PATH, JSON.stringify(state, null, 2) + "\n", "utf-8");
+  } catch (e) {
+    log("WARN", `Maintenance state: failed to write state: ${(e as Error).message}`);
+  }
+};
+
+export const shouldRunMaintenance = (
+  now: Date,
+  lastRunAt: string | null,
+  intervalSec: number,
+): boolean => {
+  if (intervalSec <= 0) return true;
+  if (!lastRunAt) return true;
+  const last = Date.parse(lastRunAt);
+  if (!Number.isFinite(last)) return true;
+  return now.getTime() - last >= intervalSec * 1000;
+};
+
+export const updateMaintenanceJob = (
+  jobName: MaintenanceJobName,
+  update: (job: MaintenanceJobState) => MaintenanceJobState,
+  log: LogFn = () => {},
+): MaintenanceState => {
+  const state = readMaintenanceState(log);
+  state.jobs[jobName] = update(state.jobs[jobName]);
+  writeMaintenanceState(state, log);
+  return state;
+};
+
+export const recordMaintenanceRun = (
+  jobName: MaintenanceJobName,
+  summary: MaintenanceRunSummary,
+  options: {
+    cursorUpdatedAt?: string | null;
+    recentAttempts?: Record<string, string>;
+  } = {},
+  log: LogFn = () => {},
+): MaintenanceState => updateMaintenanceJob(jobName, (job) => ({
+  last_run_at: summary.ran_at,
+  cursor_updated_at: options.cursorUpdatedAt === undefined ? job.cursor_updated_at : options.cursorUpdatedAt,
+  last_summary: summary,
+  recent_attempts: options.recentAttempts ?? job.recent_attempts,
+}), log);
+
+export const pruneRecentAttempts = (
+  attempts: Record<string, string>,
+  now: Date,
+  maxAgeMs: number,
+): Record<string, string> => Object.fromEntries(
+  Object.entries(attempts).filter(([, attemptedAt]) => {
+    const ts = Date.parse(attemptedAt);
+    return Number.isFinite(ts) && now.getTime() - ts <= maxAgeMs;
+  }),
+);
+
+export const isAttemptBackedOff = (
+  attempts: Record<string, string>,
+  key: string,
+  now: Date,
+  backoffMs: number,
+): boolean => {
+  const attemptedAt = attempts[key];
+  if (!attemptedAt) return false;
+  const ts = Date.parse(attemptedAt);
+  return Number.isFinite(ts) && now.getTime() - ts < backoffMs;
+};

--- a/src/daemon/qdrant.ts
+++ b/src/daemon/qdrant.ts
@@ -57,6 +57,7 @@ export interface QdrantPayload {
   created_at: string;
   updated_at: string;
   metadata: Record<string, string | number | boolean | null>;
+  session_id?: string | null;
   episode_id?: string | null;
   workstream_key?: string | null;
   task_key?: string | null;
@@ -97,6 +98,7 @@ export interface StoreFact {
   workspace_id?: string;
   actor_id?: string;
   metadata?: Record<string, string | number | boolean | null>;
+  session_id?: string | null;
   episode_id?: string | null;
   workstream_key?: string | null;
   task_key?: string | null;
@@ -138,6 +140,14 @@ export interface QdrantScrollResult {
   confidence: number;
   last_reinforced_at: string;
   created_at: string;
+  updated_at: string;
+  metadata: Record<string, string | number | boolean | null>;
+  session_id?: string | null;
+  workstream_key?: string | null;
+  task_key?: string | null;
+  repo?: string | null;
+  branch?: string | null;
+  source_fact_ids?: string[];
 }
 
 export interface QdrantSearchFilters {
@@ -152,7 +162,14 @@ export interface QdrantSearchFilters {
 export interface QdrantScrollFilters {
   categories?: string[];
   olderThan?: string;
+  sinceUpdated?: string;
   domain?: string;
+  entity?: string;
+  kinds?: string[];
+  excludeKinds?: string[];
+  source?: string;
+  workspaceId?: string;
+  orderBy?: { key: "created_at" | "updated_at" | "last_reinforced_at"; direction: "asc" | "desc" };
 }
 
 export type DedupAction = "insert" | "skip" | "supersede";
@@ -336,12 +353,38 @@ const scrollFacts = async (
     });
   }
 
+  if (filters.sinceUpdated) {
+    must.push({
+      key: "updated_at",
+      range: { gte: filters.sinceUpdated },
+    });
+  }
+
   if (filters.domain) {
     must.push({ key: "domain", match: { value: filters.domain } });
+  }
+  if (filters.entity) {
+    must.push({ key: "entities", match: { value: filters.entity } });
+  }
+  if (filters.kinds && filters.kinds.length > 0) {
+    must.push({
+      key: "kind",
+      match: { any: filters.kinds },
+    });
+  }
+  for (const kind of filters.excludeKinds ?? []) {
+    must_not.push({ key: "kind", match: { value: kind } });
+  }
+  if (filters.source) {
+    must.push({ key: "source", match: { value: filters.source } });
+  }
+  if (filters.workspaceId) {
+    must.push({ key: "workspace_id", match: { value: filters.workspaceId } });
   }
   const result = await qdrantRequest("POST", `/collections/${collection}/points/scroll`, {
     filter: { must, must_not },
     limit,
+    ...(filters.orderBy ? { order_by: { key: filters.orderBy.key, direction: filters.orderBy.direction } } : {}),
     with_payload: true,
   }) as { result?: { points?: Array<{ id: string; payload?: Partial<QdrantPayload> }> } };
 
@@ -353,6 +396,14 @@ const scrollFacts = async (
     confidence: pt.payload?.confidence ?? 0,
     last_reinforced_at: pt.payload?.last_reinforced_at ?? "",
     created_at: pt.payload?.created_at ?? "",
+    updated_at: pt.payload?.updated_at ?? pt.payload?.created_at ?? "",
+    metadata: pt.payload?.metadata ?? {},
+    session_id: pt.payload?.session_id ?? null,
+    workstream_key: pt.payload?.workstream_key ?? null,
+    task_key: pt.payload?.task_key ?? null,
+    repo: pt.payload?.repo ?? null,
+    branch: pt.payload?.branch ?? null,
+    source_fact_ids: pt.payload?.source_fact_ids ?? [],
   }));
 };
 
@@ -406,6 +457,7 @@ const storeFact = async (fact: StoreFact): Promise<string> => {
     created_at: now,
     updated_at: now,
     metadata: fact.metadata || {},
+    ...(fact.session_id ? { session_id: fact.session_id } : {}),
     ...(fact.episode_id ? { episode_id: fact.episode_id } : {}),
     ...(fact.workstream_key ? { workstream_key: fact.workstream_key } : {}),
     ...(fact.task_key ? { task_key: fact.task_key } : {}),

--- a/src/daemon/relations.test.ts
+++ b/src/daemon/relations.test.ts
@@ -1,0 +1,41 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildChangedCoOccurrenceCandidates, pairKey } from "./relations.js";
+import type { QdrantScrollResult } from "./qdrant.js";
+
+const fact = (overrides: Partial<QdrantScrollResult>): QdrantScrollResult => ({
+  id: "fact-1",
+  content: "Bikky uses Qdrant for memory storage.",
+  category: "codebase",
+  entities: [],
+  confidence: 0.9,
+  last_reinforced_at: "2026-04-27T09:00:00.000Z",
+  created_at: "2026-04-27T09:00:00.000Z",
+  updated_at: "2026-04-27T09:00:00.000Z",
+  metadata: {},
+  ...overrides,
+});
+
+describe("daemon/relations helpers", () => {
+  it("uses stable unordered pair keys", () => {
+    assert.equal(pairKey("Bikky", "Qdrant"), pairKey("qdrant", "bikky"));
+  });
+
+  it("builds changed-fact relation candidates instead of global co-occurrences", () => {
+    const candidates = buildChangedCoOccurrenceCandidates([
+      fact({ id: "fact-1", entities: ["bikky", "qdrant", "system"] }),
+      fact({
+        id: "fact-2",
+        entities: ["qdrant", "bikky"],
+        updated_at: "2026-04-27T09:10:00.000Z",
+      }),
+    ]);
+
+    assert.equal(candidates.length, 1);
+    assert.equal(candidates[0]?.entityA, "bikky");
+    assert.equal(candidates[0]?.entityB, "qdrant");
+    assert.deepEqual(candidates[0]?.triggeringFactIds, ["fact-1", "fact-2"]);
+    assert.equal(candidates[0]?.latestUpdatedAt, "2026-04-27T09:10:00.000Z");
+  });
+});

--- a/src/daemon/relations.ts
+++ b/src/daemon/relations.ts
@@ -1,15 +1,9 @@
 /**
- * Relationship Inference
+ * Relationship inference.
  *
- * Periodic task that infers typed relationships between entities by analysing
- * their shared facts.  Runs inside the consolidation tick cadence.
- *
- * Flow:
- *   1. Scroll all non-superseded facts → build entity co-occurrence map
- *   2. Filter out pairs that already have a `kind: "relation"` fact
- *   3. For the top N pairs by shared-fact count, fetch the actual shared facts
- *   4. Send to a cheap LLM for a 2-4 word relationship label
- *   5. Store via storeFact with kind: "relation", source: "daemon"
+ * Infers typed relationships between entities from recently changed facts. The
+ * daemon keeps a persistent cursor so each cycle considers new evidence first
+ * instead of rebuilding a whole-collection co-occurrence map.
  */
 
 import { createHash } from "node:crypto";
@@ -21,123 +15,107 @@ import {
   safeParseJson,
 } from "../prompts/index.js";
 import type { BikkyConfig } from "../config.js";
-import type { LogFn, QdrantPayload } from "./qdrant.js";
+import type { LogFn, QdrantPayload, QdrantScrollResult } from "./qdrant.js";
+import { DEFAULT_CAPTURE_CONTEXT } from "./capture-policy.js";
 import { isGenericEntity, mapToCanonical } from "./relations-vocab.js";
-
-// ─── State ───────────────────────────────────────────────────────────────────
+import {
+  isAttemptBackedOff,
+  pruneRecentAttempts,
+  readMaintenanceState,
+  recordMaintenanceRun,
+  shouldRunMaintenance,
+} from "./maintenance-state.js";
 
 let logFn: LogFn = () => {};
-let internalTickCount = 0;
 
 const setLogger = (fn: LogFn): void => { logFn = fn; };
 
-// Run every 300 internal ticks.  consolidation.tick calls us every 5 daemon
-// ticks (≈25 s each), so effective period ≈ 300 × 25 s ≈ 2 hours.
-const TICK_INTERVAL = 300;
+const CHANGED_FACTS_LIMIT = 200;
+const SUPPORTING_FACTS_LIMIT = 10;
+const DEFAULT_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000;
+const RELATION_ATTEMPT_BACKOFF_MS = 7 * 24 * 60 * 60 * 1000;
 
-// Max relations to infer per cycle (keeps LLM cost bounded)
-const MAX_INFER_PER_CYCLE = 3;
-
-// Minimum shared facts before we consider inferring a relation
 const MIN_SHARED_FACTS = 2;
-
-// Minimum LLM confidence to store a relation (quality gate)
 const MIN_CONFIDENCE = 0.6;
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-/** Canonical pair key — alphabetical so (a,b) === (b,a) */
+/** Canonical pair key — alphabetical so (a,b) === (b,a). */
 const pairKey = (a: string, b: string): string => {
-  const sorted = [a, b].sort();
+  const sorted = [a, b].map((entity) => entity.toLowerCase()).sort();
   return `${sorted[0]}::${sorted[1]}`;
 };
 
-interface CoOccurrence {
+interface ChangedCoOccurrence {
   entityA: string;
   entityB: string;
-  count: number;
-  factIds: string[];
+  triggeringFactIds: string[];
+  latestUpdatedAt: string;
 }
 
-/**
- * Scroll ALL non-superseded facts in batches and build a co-occurrence map.
- * Returns pairs sorted by count descending.
- */
-const buildCoOccurrenceMap = async (): Promise<CoOccurrence[]> => {
-  const pairMap = new Map<string, { entityA: string; entityB: string; count: number; factIds: string[] }>();
+interface RelationFact {
+  id: string;
+  content: string;
+  category: string;
+  updated_at: string;
+  session_id?: string | null;
+  workstream_key?: string | null;
+  metadata: Record<string, string | number | boolean | null>;
+}
 
-  let offset: string | null = null;
-  const BATCH = 100;
-  let totalScrolled = 0;
+interface RelationCandidate {
+  entityA: string;
+  entityB: string;
+  triggeringFactIds: string[];
+  supportingFactIds: string[];
+  facts: Array<{ id: string; content: string; category: string }>;
+  sessionIds: string[];
+  workstreamKeys: string[];
+  latestUpdatedAt: string;
+}
 
-  // Scroll through all non-superseded, non-relation facts
-  for (;;) {
-    const body: Record<string, unknown> = {
-      filter: {
-        must: [
-          { is_null: { key: "superseded_by" } },
-        ],
-        must_not: [
-          { key: "kind", match: { value: "relation" } },
-        ],
-      },
-      limit: BATCH,
-      with_payload: { include: ["entities"] },
-    };
-    if (offset) body.offset = offset;
+const uniqueStrings = (values: Array<string | null | undefined>): string[] =>
+  [...new Set(values.map((value) => value?.trim()).filter((value): value is string => Boolean(value)))];
 
-    const result = await qdrant.qdrantRequest(
-      "POST",
-      `/collections/${qdrant.collection}/points/scroll`,
-      body,
-    ) as {
-      result?: {
-        points?: Array<{ id: string; payload?: Partial<QdrantPayload> }>;
-        next_page_offset?: string | null;
-      };
-    };
+const sessionIdFromFact = (fact: RelationFact | QdrantScrollResult): string | null => {
+  if (fact.session_id) return fact.session_id;
+  const extracted = fact.metadata.extracted_from_session;
+  if (typeof extracted === "string" && extracted.trim()) return extracted;
+  const summarized = fact.metadata.summarized_from_session;
+  return typeof summarized === "string" && summarized.trim() ? summarized : null;
+};
 
-    const points = result.result?.points || [];
-    if (points.length === 0) break;
+const buildChangedCoOccurrenceCandidates = (facts: QdrantScrollResult[]): ChangedCoOccurrence[] => {
+  const pairMap = new Map<string, ChangedCoOccurrence>();
 
-    for (const pt of points) {
-      const entities = (pt.payload?.entities || []).filter((e) => !isGenericEntity(e));
-      if (entities.length < 2) continue;
+  for (const fact of facts) {
+    const entities = [...new Set((fact.entities || [])
+      .map((entity) => entity.trim().toLowerCase())
+      .filter((entity) => entity.length >= 2 && !isGenericEntity(entity)))];
+    if (entities.length < 2) continue;
 
-      // Generate all pairs from this fact's entities
-      for (let i = 0; i < entities.length; i++) {
-        for (let j = i + 1; j < entities.length; j++) {
-          const eA = entities[i]!;
-          const eB = entities[j]!;
-          const key = pairKey(eA, eB);
-          const existing = pairMap.get(key);
-          if (existing) {
-            existing.count++;
-            if (existing.factIds.length < 10) existing.factIds.push(pt.id);
-          } else {
-            const sorted = [eA, eB].sort();
-            pairMap.set(key, {
-              entityA: sorted[0]!,
-              entityB: sorted[1]!,
-              count: 1,
-              factIds: [pt.id],
-            });
-          }
+    for (let i = 0; i < entities.length; i++) {
+      for (let j = i + 1; j < entities.length; j++) {
+        const entityA = entities[i]!;
+        const entityB = entities[j]!;
+        const key = pairKey(entityA, entityB);
+        const sorted = [entityA, entityB].sort();
+        const existing = pairMap.get(key);
+        if (existing) {
+          existing.triggeringFactIds = uniqueStrings([...existing.triggeringFactIds, fact.id]);
+          existing.latestUpdatedAt = [existing.latestUpdatedAt, fact.updated_at || fact.created_at].filter(Boolean).sort().at(-1) ?? "";
+        } else {
+          pairMap.set(key, {
+            entityA: sorted[0]!,
+            entityB: sorted[1]!,
+            triggeringFactIds: [fact.id],
+            latestUpdatedAt: fact.updated_at || fact.created_at,
+          });
         }
       }
     }
-
-    totalScrolled += points.length;
-    offset = result.result?.next_page_offset ?? null;
-    if (!offset) break;
   }
 
-  logFn("DEBUG", `Relations: scrolled ${totalScrolled} facts, found ${pairMap.size} co-occurrence pairs`);
-
-  // Sort by count descending
-  return Array.from(pairMap.values())
-    .filter(p => p.count >= MIN_SHARED_FACTS)
-    .sort((a, b) => b.count - a.count);
+  return [...pairMap.values()]
+    .sort((a, b) => a.latestUpdatedAt.localeCompare(b.latestUpdatedAt) || pairKey(a.entityA, a.entityB).localeCompare(pairKey(b.entityA, b.entityB)));
 };
 
 /**
@@ -179,9 +157,7 @@ const getExistingRelations = async (): Promise<Set<string>> => {
     for (const pt of points) {
       const from = pt.payload?.from_entity;
       const to = pt.payload?.to_entity;
-      if (from && to) {
-        existing.add(pairKey(from, to));
-      }
+      if (from && to) existing.add(pairKey(from, to));
     }
 
     offset = result.result?.next_page_offset ?? null;
@@ -192,37 +168,77 @@ const getExistingRelations = async (): Promise<Set<string>> => {
   return existing;
 };
 
-/**
- * Fetch the full content of specific fact IDs for the LLM prompt.
- */
-const fetchFactContents = async (
-  factIds: string[],
-): Promise<Array<{ id: string; content: string; category: string }>> => {
+const fetchSupportingFacts = async (
+  entityA: string,
+  entityB: string,
+): Promise<RelationFact[]> => {
   const result = await qdrant.qdrantRequest(
     "POST",
-    `/collections/${qdrant.collection}/points`,
-    { ids: factIds, with_payload: { include: ["content", "category"] } },
-  ) as { result?: Array<{ id: string; payload?: { content?: string; category?: string } }> };
+    `/collections/${qdrant.collection}/points/scroll`,
+    {
+      filter: {
+        must: [
+          { is_null: { key: "superseded_by" } },
+          { key: "entities", match: { value: entityA } },
+          { key: "entities", match: { value: entityB } },
+        ],
+        must_not: [
+          { key: "kind", match: { value: "relation" } },
+          { key: "kind", match: { value: "entity_type" } },
+        ],
+      },
+      order_by: { key: "updated_at", direction: "desc" },
+      limit: SUPPORTING_FACTS_LIMIT,
+      with_payload: true,
+    },
+  ) as { result?: { points?: Array<{ id: string; payload?: Partial<QdrantPayload> }> } };
 
-  return (result.result || []).map(pt => ({
-    id: pt.id,
-    content: pt.payload?.content ?? "",
-    category: pt.payload?.category ?? "",
+  return (result.result?.points ?? []).map((point) => ({
+    id: point.id,
+    content: point.payload?.content ?? "",
+    category: point.payload?.category ?? "",
+    updated_at: point.payload?.updated_at ?? point.payload?.created_at ?? "",
+    session_id: point.payload?.session_id ?? null,
+    workstream_key: point.payload?.workstream_key ?? null,
+    metadata: point.payload?.metadata ?? {},
   }));
 };
 
-/**
- * Use LLM to infer a relationship label from shared facts.
- * Returns null if the LLM can't determine a meaningful relationship.
- * The LLM decides directionality — `from` is the subject, `to` is the object.
- */
+const buildRelationCandidate = async (
+  changed: ChangedCoOccurrence,
+): Promise<RelationCandidate | null> => {
+  const supportingFacts = await fetchSupportingFacts(changed.entityA, changed.entityB);
+  if (supportingFacts.length < MIN_SHARED_FACTS) return null;
+
+  return {
+    entityA: changed.entityA,
+    entityB: changed.entityB,
+    triggeringFactIds: changed.triggeringFactIds,
+    supportingFactIds: supportingFacts.map((fact) => fact.id),
+    facts: supportingFacts.map((fact) => ({ id: fact.id, content: fact.content, category: fact.category })),
+    sessionIds: uniqueStrings(supportingFacts.map(sessionIdFromFact)),
+    workstreamKeys: uniqueStrings(supportingFacts.map((fact) => fact.workstream_key)),
+    latestUpdatedAt: [changed.latestUpdatedAt, ...supportingFacts.map((fact) => fact.updated_at)].filter(Boolean).sort().at(-1) ?? "",
+  };
+};
+
 const inferRelation = async (
-  entityA: string,
-  entityB: string,
-  sharedFacts: Array<{ content: string; category: string }>,
+  candidate: RelationCandidate,
 ): Promise<{ from: string; type: string; to: string; content: string; evidence?: string; confidence?: number; inVocabulary?: boolean; judgment?: { evidence_strength?: number; durability?: string; directionality_clarity?: string } } | null> => {
-  const rendered = relationsPrompt({ entityA, entityB, sharedFacts });
-  const raw = await chatCompletion(rendered);
+  const rendered = relationsPrompt({
+    entityA: candidate.entityA,
+    entityB: candidate.entityB,
+    sharedFacts: candidate.facts.map((fact) => ({ content: fact.content, category: fact.category })),
+  });
+  const raw = await chatCompletion({
+    ...rendered,
+    telemetry: {
+      subsystem: "relation-inference",
+      ...(candidate.sessionIds.length > 0 ? { session_id: candidate.sessionIds.join(",") } : {}),
+      ...(candidate.workstreamKeys.length > 0 ? { workstream_key: candidate.workstreamKeys.join(",") } : {}),
+      trigger: "infer_relation",
+    },
+  });
 
   if (!raw) return null;
 
@@ -243,72 +259,58 @@ const inferRelation = async (
 
   if (!parsed || !parsed.type) return null;
 
-  // ── Self-judgment quality gates ──────────────────────────────────────────
   if (parsed.judgment) {
     const j = parsed.judgment;
-
-    // Gate 1: durability — reject transient/ephemeral relations
     if (j.durability === "transient" || j.durability === "ephemeral") {
-      logFn("DEBUG", `Relations: rejected ${entityA}↔${entityB} — durability="${j.durability}"`);
+      logFn("DEBUG", `Relations: rejected ${candidate.entityA}↔${candidate.entityB} — durability="${j.durability}"`);
       return null;
     }
-
-    // Gate 2: directionality — reject ambiguous direction
     if (j.directionality_clarity === "ambiguous") {
-      logFn("DEBUG", `Relations: rejected ${entityA}↔${entityB} — ambiguous directionality`);
+      logFn("DEBUG", `Relations: rejected ${candidate.entityA}↔${candidate.entityB} — ambiguous directionality`);
       return null;
     }
-
-    // Gate 3: evidence strength — reject weak evidence (< 0.5)
     if (typeof j.evidence_strength === "number" && j.evidence_strength < 0.5) {
-      logFn("DEBUG", `Relations: rejected ${entityA}↔${entityB} — evidence_strength=${j.evidence_strength}`);
+      logFn("DEBUG", `Relations: rejected ${candidate.entityA}↔${candidate.entityB} — evidence_strength=${j.evidence_strength}`);
       return null;
     }
   }
 
-  // Validate that from/to are the provided entities (not hallucinated)
-  const entities = new Set([entityA.toLowerCase(), entityB.toLowerCase()]);
+  const entities = new Set([candidate.entityA.toLowerCase(), candidate.entityB.toLowerCase()]);
   const from = parsed.from?.toLowerCase() ?? "";
   const to = parsed.to?.toLowerCase() ?? "";
 
   if (!entities.has(from) || !entities.has(to) || from === to) {
-    logFn("WARN", `Relations: LLM returned invalid from/to for ${entityA}↔${entityB}: from="${parsed.from}", to="${parsed.to}"`);
+    logFn("WARN", `Relations: LLM returned invalid from/to for ${candidate.entityA}↔${candidate.entityB}: from="${parsed.from}", to="${parsed.to}"`);
     return null;
   }
 
-  // Verify evidence quote actually appears in shared facts (anti-hallucination guard).
   if (parsed.evidence) {
-    const haystack = sharedFacts.map((f) => f.content).join(" ").toLowerCase();
+    const haystack = candidate.facts.map((f) => f.content).join(" ").toLowerCase();
     const needle = parsed.evidence.toLowerCase().slice(0, 30);
     if (needle.length > 0 && !haystack.includes(needle)) {
       logFn(
         "WARN",
-        `Relations: evidence quote not found in source facts for ${entityA}↔${entityB}: "${parsed.evidence.slice(0, 80)}"`,
+        `Relations: evidence quote not found in source facts for ${candidate.entityA}↔${candidate.entityB}: "${parsed.evidence.slice(0, 80)}"`,
       );
       return null;
     }
   }
 
-  // Use the LLM's chosen direction (normalised to original casing)
-  const resolvedFrom = from === entityA.toLowerCase() ? entityA : entityB;
-  const resolvedTo = to === entityA.toLowerCase() ? entityA : entityB;
+  const resolvedFrom = from === candidate.entityA.toLowerCase() ? candidate.entityA : candidate.entityB;
+  const resolvedTo = to === candidate.entityA.toLowerCase() ? candidate.entityA : candidate.entityB;
 
-  // Map LLM type to canonical vocabulary
   const mapped = mapToCanonical(parsed.type);
   if (mapped.changed) {
     logFn("DEBUG", `Relations: mapped type "${parsed.type}" → "${mapped.canonical}"`);
   }
-
-  // Gate 4: reject out-of-vocab relation types — they are almost always noise
   if (!mapped.inVocabulary) {
-    logFn("DEBUG", `Relations: rejected ${entityA}↔${entityB} — out-of-vocab type "${parsed.type}"`);
+    logFn("DEBUG", `Relations: rejected ${candidate.entityA}↔${candidate.entityB} — out-of-vocab type "${parsed.type}"`);
     return null;
   }
 
-  // Gate 5: confidence floor — skip low-confidence relations
   const confidence = typeof parsed.confidence === "number" ? parsed.confidence : 0.5;
   if (confidence < MIN_CONFIDENCE) {
-    logFn("DEBUG", `Relations: rejected ${entityA}↔${entityB} — confidence ${confidence} < ${MIN_CONFIDENCE}`);
+    logFn("DEBUG", `Relations: rejected ${candidate.entityA}↔${candidate.entityB} — confidence ${confidence} < ${MIN_CONFIDENCE}`);
     return null;
   }
 
@@ -324,15 +326,12 @@ const inferRelation = async (
   };
 };
 
-/**
- * Store an inferred relation as a memory fact.
- */
 const storeRelation = async (
   fromEntity: string,
   toEntity: string,
   relationType: string,
   content: string,
-  sharedFactIds: string[],
+  candidate: RelationCandidate,
   extras: { evidence?: string; confidence?: number; inVocabulary?: boolean; judgment?: { evidence_strength?: number; durability?: string; directionality_clarity?: string } } = {},
 ): Promise<string> => {
   const hash = createHash("sha256")
@@ -340,13 +339,15 @@ const storeRelation = async (
     .digest("hex");
 
   const metadata: Record<string, string> = {
-    inferred_from: sharedFactIds.slice(0, 5).join(","),
-    shared_fact_count: String(sharedFactIds.length),
+    inferred_from: candidate.supportingFactIds.slice(0, 5).join(","),
+    shared_fact_count: String(candidate.supportingFactIds.length),
     inferred_by_prompt: `${RELATIONS_PROMPT_DESCRIPTOR.id}@${RELATIONS_PROMPT_DESCRIPTOR.version}`,
+    triggering_fact_ids: candidate.triggeringFactIds.join(","),
+    supporting_fact_ids: candidate.supportingFactIds.join(","),
   };
-  if (extras.evidence) {
-    metadata.evidence_quote = extras.evidence.slice(0, 500);
-  }
+  if (candidate.sessionIds.length > 0) metadata.triggering_sessions = candidate.sessionIds.join(",");
+  if (candidate.workstreamKeys.length > 0) metadata.triggering_workstreams = candidate.workstreamKeys.join(",");
+  if (extras.evidence) metadata.evidence_quote = extras.evidence.slice(0, 500);
   if (extras.judgment) {
     const j = extras.judgment;
     if (j.evidence_strength != null) metadata.evidence_strength = String(j.evidence_strength);
@@ -356,8 +357,8 @@ const storeRelation = async (
 
   const id = await qdrant.storeFact({
     content,
-    category: "team",    // relations are about entity structure
-    domain: "work",
+    category: "people",
+    domain: DEFAULT_CAPTURE_CONTEXT.domain,
     kind: "relation",
     entities: [fromEntity, toEntity],
     source: "daemon",
@@ -365,6 +366,8 @@ const storeRelation = async (
     importance: 0.6,
     content_hash: hash,
     metadata,
+    source_fact_ids: candidate.supportingFactIds,
+    ...(candidate.workstreamKeys.length > 0 ? { workstream_key: candidate.workstreamKeys[0] } : {}),
     relation: {
       from: fromEntity,
       type: relationType,
@@ -376,45 +379,80 @@ const storeRelation = async (
   return id;
 };
 
-// ─── Main Tick ───────────────────────────────────────────────────────────────
-
 const tick = async (config: BikkyConfig): Promise<void> => {
   if (!qdrant.isReady()) return;
   if (config.daemon.relation_inference_enabled === false) return;
 
-  internalTickCount++;
-  if (internalTickCount % TICK_INTERVAL !== 0) return;
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const state = readMaintenanceState(logFn);
+  const job = state.jobs.relation_inference;
+  const intervalSec = config.daemon.relation_inference_interval_sec ?? 7200;
+  if (!shouldRunMaintenance(now, job.last_run_at, intervalSec)) return;
 
-  logFn("DEBUG", "Relations: starting inference cycle");
+  const attempts = pruneRecentAttempts(job.recent_attempts, now, RELATION_ATTEMPT_BACKOFF_MS);
+  const maxPairs = config.daemon.relation_inference_max_pairs_per_run ?? 3;
+  const since = job.cursor_updated_at ?? new Date(now.getTime() - DEFAULT_LOOKBACK_MS).toISOString();
 
   try {
-    // 1. Build co-occurrence map
-    const pairs = await buildCoOccurrenceMap();
-    if (pairs.length === 0) {
-      logFn("DEBUG", "Relations: no co-occurrence pairs above threshold");
+    const changedFacts = await qdrant.scrollFacts({
+      sinceUpdated: since,
+      excludeKinds: ["relation"],
+      orderBy: { key: "updated_at", direction: "asc" },
+    }, CHANGED_FACTS_LIMIT);
+
+    if (changedFacts.length === 0) {
+      recordMaintenanceRun("relation_inference", {
+        job: "relation_inference",
+        ran_at: nowIso,
+        status: "skipped",
+        candidates_seen: 0,
+        llm_calls: 0,
+        accepted: 0,
+        skipped_reason: "no_changed_facts",
+      }, { cursorUpdatedAt: nowIso, recentAttempts: attempts }, logFn);
       return;
     }
 
-    // 2. Get existing relations to avoid duplicates
+    const changedPairs = buildChangedCoOccurrenceCandidates(changedFacts);
+    if (changedPairs.length === 0) {
+      recordMaintenanceRun("relation_inference", {
+        job: "relation_inference",
+        ran_at: nowIso,
+        status: "skipped",
+        candidates_seen: 0,
+        llm_calls: 0,
+        accepted: 0,
+        skipped_reason: "no_entity_pairs",
+      }, { cursorUpdatedAt: changedFacts.map((fact) => fact.updated_at || fact.created_at).filter(Boolean).sort().at(-1) ?? nowIso, recentAttempts: attempts }, logFn);
+      return;
+    }
+
     const existing = await getExistingRelations();
+    const touchedPairs = changedPairs
+      .filter((pair) => !existing.has(pairKey(pair.entityA, pair.entityB)))
+      .filter((pair) => !isAttemptBackedOff(attempts, pairKey(pair.entityA, pair.entityB), now, RELATION_ATTEMPT_BACKOFF_MS));
 
-    // 3. Find candidate pairs (not yet inferred)
-    const candidates = pairs.filter(p => !existing.has(pairKey(p.entityA, p.entityB)));
-    logFn("DEBUG", `Relations: ${candidates.length} candidate pairs (${pairs.length} total above threshold)`);
+    const supportLookupLimit = Math.max(maxPairs * 5, maxPairs);
+    const relationCandidates: RelationCandidate[] = [];
+    for (const changed of touchedPairs.slice(0, supportLookupLimit)) {
+      const candidate = await buildRelationCandidate(changed);
+      if (candidate) relationCandidates.push(candidate);
+      if (relationCandidates.length >= maxPairs) break;
+    }
 
-    if (candidates.length === 0) return;
-
-    // 4. Infer relations for top N candidates
     let inferred = 0;
-    for (const candidate of candidates.slice(0, MAX_INFER_PER_CYCLE)) {
-      try {
-        const facts = await fetchFactContents(candidate.factIds);
-        if (facts.length < MIN_SHARED_FACTS) continue;
+    let llmCalls = 0;
+    let failures = 0;
 
-        const result = await inferRelation(candidate.entityA, candidate.entityB, facts);
+    for (const candidate of relationCandidates.slice(0, maxPairs)) {
+      const key = pairKey(candidate.entityA, candidate.entityB);
+      try {
+        llmCalls++;
+        attempts[key] = nowIso;
+        const result = await inferRelation(candidate);
         if (!result) continue;
 
-        // Dedup check before storing
         const hash = createHash("sha256")
           .update(`daemon-relation:${pairKey(result.from, result.to)}:${result.type}`)
           .digest("hex");
@@ -429,32 +467,52 @@ const tick = async (config: BikkyConfig): Promise<void> => {
           result.to,
           result.type,
           result.content,
-          candidate.factIds,
+          candidate,
           { evidence: result.evidence, confidence: result.confidence, inVocabulary: result.inVocabulary, judgment: result.judgment },
         );
         inferred++;
       } catch (e: unknown) {
+        failures++;
         logFn("WARN", `Relations: failed to infer ${candidate.entityA}↔${candidate.entityB}: ${(e as Error).message}`);
       }
     }
 
-    logFn("INFO", `Relations: inference cycle complete — ${inferred} new relations from ${candidates.length} candidates`);
+    const deferred = failures > 0 || touchedPairs.length > supportLookupLimit || relationCandidates.length > maxPairs;
+    const cursorUpdatedAt = deferred ? job.cursor_updated_at : changedFacts.map((fact) => fact.updated_at || fact.created_at).filter(Boolean).sort().at(-1) ?? nowIso;
+    recordMaintenanceRun("relation_inference", {
+      job: "relation_inference",
+      ran_at: nowIso,
+      status: "success",
+      candidates_seen: touchedPairs.length,
+      llm_calls: llmCalls,
+      accepted: inferred,
+      skipped_reason: deferred ? "work_deferred" : undefined,
+    }, { cursorUpdatedAt, recentAttempts: attempts }, logFn);
+
+    logFn("INFO", `Relations: inference cycle complete — ${inferred} new relations from ${touchedPairs.length} changed pair(s)`);
   } catch (e: unknown) {
+    recordMaintenanceRun("relation_inference", {
+      job: "relation_inference",
+      ran_at: nowIso,
+      status: "error",
+      candidates_seen: 0,
+      llm_calls: 0,
+      accepted: 0,
+      error: (e as Error).message,
+    }, { cursorUpdatedAt: job.cursor_updated_at, recentAttempts: attempts }, logFn);
     logFn("ERROR", `Relations: inference cycle failed: ${(e as Error).message}`);
   }
 };
 
 /** Reset state (for testing). */
-const _reset = (): void => {
-  internalTickCount = 0;
-};
+const _reset = (): void => {};
 
 export {
   tick,
   setLogger,
   _reset,
-  // Exported for testing
-  buildCoOccurrenceMap,
+  buildChangedCoOccurrenceCandidates,
+  fetchSupportingFacts,
   getExistingRelations,
   inferRelation,
   storeRelation,

--- a/src/daemon/session-summary.ts
+++ b/src/daemon/session-summary.ts
@@ -222,10 +222,12 @@ const summarizeTranscript = async (input: {
   existingSummary?: string | null;
 }): Promise<SessionSummaryDraft> => {
   const result = await chatCompletion({
+    promptName: `session-index@${PROMPT_VERSIONS.sessionIndex}`,
     messages: buildSessionSummaryMessages(input),
     temperature: 0.2,
     max_tokens: 1500,
     response_format: { type: "json_object" },
+    telemetry: { subsystem: "summary", trigger: "session_index" },
   });
   if (!result) throw new Error("Session summary LLM returned null");
   return parseSessionSummaryDraft(result);

--- a/src/daemon/workstream-summary.ts
+++ b/src/daemon/workstream-summary.ts
@@ -255,7 +255,11 @@ const summarizeWorkstream = async (input: {
   existingSummary?: string | null;
   episodeSummaries: string[];
 }): Promise<WorkstreamSummaryDraft> => {
-  const result = await chatCompletion(workstreamSummaryPrompt(input));
+  const rendered = workstreamSummaryPrompt(input);
+  const result = await chatCompletion({
+    ...rendered,
+    telemetry: { subsystem: "summary", workstream_key: input.workstreamKey, trigger: "workstream_summary" },
+  });
   if (!result) throw new Error("Workstream summary LLM returned null");
   return parseWorkstreamSummaryDraft(result);
 };

--- a/src/llm/inference/index.test.ts
+++ b/src/llm/inference/index.test.ts
@@ -5,6 +5,9 @@
 
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
 
 import {
   initLLM,
@@ -12,6 +15,7 @@ import {
   getInferenceConfig,
   registerInferenceProvider,
   _resetInference,
+  _recordInferenceUsage,
 } from "./index.js";
 import {
   listInferenceProviders,
@@ -78,27 +82,38 @@ describe("getInferenceConfig", () => {
 describe("chatCompletion — dispatch + fallback", () => {
   let snapshot: InferenceProvider[];
   let calls: string[];
+  let telemetryDir: string;
+  let telemetryFile: string;
 
   beforeEach(() => {
     snapshot = listInferenceProviders();
     _resetInferenceRegistry();
     _resetInference();
     calls = [];
+    telemetryDir = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-inference-telemetry-"));
+    telemetryFile = path.join(telemetryDir, "llm.jsonl");
+    process.env.BIKKY_LLM_LOG = telemetryFile;
   });
 
   afterEach(() => {
     _resetInferenceRegistry();
     _resetInference();
     for (const p of snapshot) registerInferenceProvider(p);
+    delete process.env.BIKKY_LLM_LOG;
+    fs.rmSync(telemetryDir, { recursive: true, force: true });
   });
 
-  function fakeProvider(name: string, result: string | null): InferenceProvider {
+  function fakeProvider(name: string, result: string | null, usage?: Parameters<typeof _recordInferenceUsage>[0]): InferenceProvider {
     return {
       name,
       label: name,
       browserCompatible: false,
       defaults: { model: `${name}-model` },
-      async chat() { calls.push(name); return result; },
+      async chat() {
+        calls.push(name);
+        if (usage) _recordInferenceUsage(usage);
+        return result;
+      },
     };
   }
 
@@ -108,6 +123,35 @@ describe("chatCompletion — dispatch + fallback", () => {
     const out = await chatCompletion({ messages: [{ role: "user", content: "hi" }] });
     assert.strictEqual(out, "primary-said-hi");
     assert.deepStrictEqual(calls, ["primary"]);
+  });
+
+  it("writes telemetry with prompt context and actual usage when provided", async () => {
+    registerInferenceProvider(fakeProvider("primary", "primary-said-hi", {
+      input_tokens: 11,
+      output_tokens: 7,
+      total_tokens: 18,
+      request_id: "req-1",
+    }));
+    initLLM({ config: { provider: "primary" } });
+
+    const out = await chatCompletion({
+      promptName: "test-prompt@1",
+      messages: [{ role: "user", content: "hi" }],
+      telemetry: { subsystem: "unit-test", session_id: "session-1", workstream_key: "workstream-1", trigger: "test" },
+    });
+
+    assert.strictEqual(out, "primary-said-hi");
+    const lines = fs.readFileSync(telemetryFile, "utf-8").trim().split("\n");
+    assert.equal(lines.length, 1);
+    const record = JSON.parse(lines[0]!) as Record<string, unknown>;
+    assert.equal(record.prompt, "test-prompt@1");
+    assert.equal(record.subsystem, "unit-test");
+    assert.equal(record.session_id, "session-1");
+    assert.equal(record.workstream_key, "workstream-1");
+    assert.equal(record.tokens_in_actual, 11);
+    assert.equal(record.tokens_out_actual, 7);
+    assert.equal(record.tokens_total_actual, 18);
+    assert.equal(record.request_id, "req-1");
   });
 
   it("falls back to the configured fallback when primary returns null", async () => {

--- a/src/llm/inference/index.ts
+++ b/src/llm/inference/index.ts
@@ -20,12 +20,14 @@ import {
 } from "./registry.js";
 import type {
   ChatCompletionOpts,
+  ChatCompletionUsage,
   InferenceProvider,
   InitLLMInput,
   LogFn,
   ResolvedInferenceConfig,
 } from "./types.js";
 import { LlmHttpError } from "../errors.js";
+import { estimateTokens, writeTelemetry } from "../telemetry.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_RETRIES = 2;
@@ -34,6 +36,7 @@ const DEFAULT_RETRY_BASE_MS = 250;
 let resolved: ResolvedInferenceConfig | null = null;
 let log: LogFn = () => {};
 let lastError: LlmHttpError | null = null;
+let lastUsage: ChatCompletionUsage | null = null;
 
 export function initLLM(opts: { config: InitLLMInput; logger?: LogFn }): ResolvedInferenceConfig {
   const provider = getInferenceProvider(opts.config.provider);
@@ -76,11 +79,15 @@ export function _recordInferenceError(err: LlmHttpError | null): void {
   lastError = err;
 }
 
+export function _recordInferenceUsage(usage: ChatCompletionUsage | null): void {
+  lastUsage = usage;
+}
+
 export async function chatCompletion(opts: ChatCompletionOpts): Promise<string | null> {
   const cfg = getInferenceConfig();
   lastError = null;
   const primary = getInferenceProvider(cfg.provider);
-  const result = await primary.chat(opts, cfg, log);
+  const result = await callProviderWithTelemetry(primary, opts, cfg);
   if (result !== null) return result;
   const primaryErr = getLastInferenceError();
 
@@ -101,7 +108,7 @@ export async function chatCompletion(opts: ChatCompletionOpts): Promise<string |
     fallback: null,
   };
   lastError = null;
-  const fbResult = await fallback.chat(opts, fallbackCfg, log);
+  const fbResult = await callProviderWithTelemetry(fallback, opts, fallbackCfg);
   if (fbResult !== null) return fbResult;
 
   const fallbackErr = getLastInferenceError();
@@ -120,6 +127,43 @@ export function _resetInference(): void {
   resolved = null;
   log = () => {};
   lastError = null;
+  lastUsage = null;
+}
+
+async function callProviderWithTelemetry(
+  provider: InferenceProvider,
+  opts: ChatCompletionOpts,
+  cfg: ResolvedInferenceConfig,
+): Promise<string | null> {
+  lastUsage = null;
+  const startedAt = Date.now();
+  const result = await provider.chat(opts, cfg, log);
+  const latencyMs = Date.now() - startedAt;
+  const err = result === null ? getLastInferenceError() : null;
+  const usage = lastUsage as ChatCompletionUsage | null;
+  const promptText = opts.messages.map((message) => `${message.role}: ${message.content}`).join("\n\n");
+
+  await writeTelemetry({
+    ts: new Date().toISOString(),
+    prompt: opts.promptName ?? "unknown",
+    model: cfg.model,
+    provider: provider.name,
+    ...(opts.telemetry?.subsystem ? { subsystem: opts.telemetry.subsystem } : {}),
+    ...(opts.telemetry?.session_id ? { session_id: opts.telemetry.session_id } : {}),
+    ...(opts.telemetry?.workstream_key ? { workstream_key: opts.telemetry.workstream_key } : {}),
+    ...(opts.telemetry?.trigger ? { trigger: opts.telemetry.trigger } : {}),
+    ok: result !== null,
+    latency_ms: latencyMs,
+    tokens_in_est: estimateTokens(promptText),
+    tokens_out_est: estimateTokens(result ?? ""),
+    ...(usage?.input_tokens != null ? { tokens_in_actual: usage.input_tokens } : {}),
+    ...(usage?.output_tokens != null ? { tokens_out_actual: usage.output_tokens } : {}),
+    ...(usage?.total_tokens != null ? { tokens_total_actual: usage.total_tokens } : {}),
+    ...(err ? { error: `${err.kind}: ${err.message}` } : {}),
+    ...(usage?.request_id ? { request_id: usage.request_id } : {}),
+  }, log);
+
+  return result;
 }
 
 function pickMoreActionable(a: LlmHttpError | null, b: LlmHttpError | null): LlmHttpError | null {

--- a/src/llm/inference/providers/bedrock.test.ts
+++ b/src/llm/inference/providers/bedrock.test.ts
@@ -1,9 +1,31 @@
-import { describe, it } from "node:test";
+import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
 
-import { bedrockInferenceProvider, _resetBedrockInferenceClient } from "./bedrock.js";
+import { bedrockInferenceProvider, _resetBedrockInferenceClient, _setBedrockInferenceClientForTest } from "./bedrock.js";
+import { chatCompletion, initLLM, _resetInference } from "../index.js";
 
 describe("bedrock inference provider — metadata", () => {
+  let telemetryDir: string;
+  let telemetryFile: string;
+
+  beforeEach(() => {
+    telemetryDir = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-bedrock-telemetry-"));
+    telemetryFile = path.join(telemetryDir, "llm.jsonl");
+    process.env.BIKKY_LLM_LOG = telemetryFile;
+    _resetInference();
+    _resetBedrockInferenceClient();
+  });
+
+  afterEach(() => {
+    delete process.env.BIKKY_LLM_LOG;
+    fs.rmSync(telemetryDir, { recursive: true, force: true });
+    _resetInference();
+    _resetBedrockInferenceClient();
+  });
+
   it("declares the correct name + label", () => {
     assert.strictEqual(bedrockInferenceProvider.name, "bedrock");
     assert.strictEqual(bedrockInferenceProvider.label, "AWS Bedrock (Converse)");
@@ -21,5 +43,36 @@ describe("bedrock inference provider — metadata", () => {
   it("loads the AWS SDK lazily inside chat() (not at module load)", () => {
     assert.strictEqual(typeof bedrockInferenceProvider.chat, "function");
     assert.strictEqual(typeof _resetBedrockInferenceClient, "function");
+  });
+
+  it("exposes Bedrock Converse usage metadata through chatCompletion telemetry", async () => {
+    _setBedrockInferenceClientForTest({
+      client: {
+        async send() {
+          return {
+            output: { message: { content: [{ text: " ok " }] } },
+            usage: { inputTokens: 20, outputTokens: 5, totalTokens: 25 },
+            $metadata: { requestId: "bedrock-request-1" },
+          };
+        },
+      },
+      ConverseCommand: class {
+        constructor(_input: unknown) {}
+      },
+    });
+    initLLM({ config: { provider: "bedrock", model: "test-model" } });
+
+    const out = await chatCompletion({
+      promptName: "bedrock-test@1",
+      messages: [{ role: "user", content: "x" }],
+      telemetry: { subsystem: "unit-test" },
+    });
+
+    assert.equal(out, "ok");
+    const record = JSON.parse(fs.readFileSync(telemetryFile, "utf-8").trim()) as Record<string, unknown>;
+    assert.equal(record.tokens_in_actual, 20);
+    assert.equal(record.tokens_out_actual, 5);
+    assert.equal(record.tokens_total_actual, 25);
+    assert.equal(record.request_id, "bedrock-request-1");
   });
 });

--- a/src/llm/inference/providers/bedrock.ts
+++ b/src/llm/inference/providers/bedrock.ts
@@ -30,10 +30,14 @@ import {
   type LlmErrorDetails,
   type LlmHttpError,
 } from "../../errors.js";
-import { _recordInferenceError } from "../index.js";
+import { _recordInferenceError, _recordInferenceUsage } from "../index.js";
 
-interface BedrockSdk {
-  client: { send(cmd: unknown): Promise<{ output?: { message?: { content?: Array<{ text?: string }> } } }> };
+export interface BedrockSdk {
+  client: { send(cmd: unknown): Promise<{
+    output?: { message?: { content?: Array<{ text?: string }> } };
+    usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number };
+    $metadata?: { requestId?: string };
+  }> };
   // Use any here — the AWS ConverseCommand input type is a deeply-nested SDK
   // type; we only ever pass it shape-checked objects from this file.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -88,6 +92,10 @@ export function _resetBedrockInferenceClient(): void {
   sdk = null;
 }
 
+export function _setBedrockInferenceClientForTest(next: BedrockSdk): void {
+  sdk = next;
+}
+
 export const bedrockInferenceProvider: InferenceProvider = {
   name: "bedrock",
   label: "AWS Bedrock (Converse)",
@@ -124,6 +132,12 @@ export const bedrockInferenceProvider: InferenceProvider = {
       });
       const resp = await client.send(command);
       _recordInferenceError(null);
+      _recordInferenceUsage({
+        input_tokens: resp.usage?.inputTokens,
+        output_tokens: resp.usage?.outputTokens,
+        total_tokens: resp.usage?.totalTokens,
+        request_id: resp.$metadata?.requestId,
+      });
       const content = resp.output?.message?.content;
       const textBlock = content?.find((c) => "text" in c);
       return (textBlock?.text ?? "").trim() || null;

--- a/src/llm/inference/providers/ollama.ts
+++ b/src/llm/inference/providers/ollama.ts
@@ -13,7 +13,7 @@ import type {
 import { registerInferenceProvider } from "../registry.js";
 import { resilientFetch } from "../../fetch.js";
 import { LlmHttpError } from "../../errors.js";
-import { _recordInferenceError } from "../index.js";
+import { _recordInferenceError, _recordInferenceUsage } from "../index.js";
 
 const RETRY_CAP_MS = 5_000;
 
@@ -53,8 +53,18 @@ export const ollamaInferenceProvider: InferenceProvider = {
         provider: "ollama",
         model: cfg.model,
       });
-      const data = (await resp.json()) as { choices?: Array<{ message?: { content?: string } }> };
+      const data = (await resp.json()) as {
+        id?: string;
+        choices?: Array<{ message?: { content?: string } }>;
+        usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+      };
       _recordInferenceError(null);
+      _recordInferenceUsage({
+        input_tokens: data.usage?.prompt_tokens,
+        output_tokens: data.usage?.completion_tokens,
+        total_tokens: data.usage?.total_tokens,
+        request_id: data.id,
+      });
       return data.choices?.[0]?.message?.content?.trim() ?? null;
     } catch (e: unknown) {
       if (e instanceof LlmHttpError) {

--- a/src/llm/inference/providers/openai.test.ts
+++ b/src/llm/inference/providers/openai.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
 
 import { openaiInferenceProvider } from "./openai.js";
+import { chatCompletion, initLLM, _resetInference } from "../index.js";
 import type { ResolvedInferenceConfig } from "../types.js";
 
 const cfg: ResolvedInferenceConfig = {
@@ -20,8 +24,22 @@ const log = () => {};
 
 describe("openai inference provider", () => {
   const realFetch = globalThis.fetch;
-  beforeEach(() => { globalThis.fetch = realFetch; });
-  afterEach(() => { globalThis.fetch = realFetch; });
+  let telemetryDir: string;
+  let telemetryFile: string;
+
+  beforeEach(() => {
+    globalThis.fetch = realFetch;
+    telemetryDir = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-openai-telemetry-"));
+    telemetryFile = path.join(telemetryDir, "llm.jsonl");
+    process.env.BIKKY_LLM_LOG = telemetryFile;
+    _resetInference();
+  });
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    delete process.env.BIKKY_LLM_LOG;
+    fs.rmSync(telemetryDir, { recursive: true, force: true });
+    _resetInference();
+  });
 
   it("sends bearer auth header and forwards json_schema response_format unchanged", async () => {
     let captured: RequestInit | null = null;
@@ -53,5 +71,27 @@ describe("openai inference provider", () => {
     globalThis.fetch = (async () => new Response("nope", { status: 401 })) as unknown as typeof fetch;
     const out = await openaiInferenceProvider.chat({ messages: [{ role: "user", content: "x" }] }, cfg, log);
     assert.strictEqual(out, null);
+  });
+
+  it("exposes OpenAI usage metadata through chatCompletion telemetry", async () => {
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      id: "chatcmpl-1",
+      choices: [{ message: { content: "ok" } }],
+      usage: { prompt_tokens: 12, completion_tokens: 4, total_tokens: 16 },
+    }), { status: 200 })) as unknown as typeof fetch;
+
+    initLLM({ config: { provider: "openai", apiKey: "sk-test", retries: 0 } });
+    const out = await chatCompletion({
+      promptName: "openai-test@1",
+      messages: [{ role: "user", content: "x" }],
+      telemetry: { subsystem: "unit-test" },
+    });
+
+    assert.equal(out, "ok");
+    const record = JSON.parse(fs.readFileSync(telemetryFile, "utf-8").trim()) as Record<string, unknown>;
+    assert.equal(record.tokens_in_actual, 12);
+    assert.equal(record.tokens_out_actual, 4);
+    assert.equal(record.tokens_total_actual, 16);
+    assert.equal(record.request_id, "chatcmpl-1");
   });
 });

--- a/src/llm/inference/providers/openai.ts
+++ b/src/llm/inference/providers/openai.ts
@@ -20,7 +20,7 @@ import {
   LlmHttpError,
   type LlmErrorDetails,
 } from "../../errors.js";
-import { _recordInferenceError } from "../index.js";
+import { _recordInferenceError, _recordInferenceUsage } from "../index.js";
 
 const RETRY_CAP_MS = 5_000;
 
@@ -67,8 +67,18 @@ export const openaiInferenceProvider: InferenceProvider = {
         provider: "openai",
         model: cfg.model,
       });
-      const data = (await resp.json()) as { choices?: Array<{ message?: { content?: string } }> };
+      const data = (await resp.json()) as {
+        id?: string;
+        choices?: Array<{ message?: { content?: string } }>;
+        usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+      };
       _recordInferenceError(null);
+      _recordInferenceUsage({
+        input_tokens: data.usage?.prompt_tokens,
+        output_tokens: data.usage?.completion_tokens,
+        total_tokens: data.usage?.total_tokens,
+        request_id: data.id,
+      });
       return data.choices?.[0]?.message?.content?.trim() ?? null;
     } catch (e: unknown) {
       if (e instanceof LlmHttpError) {

--- a/src/llm/inference/providers/portkey.ts
+++ b/src/llm/inference/providers/portkey.ts
@@ -22,7 +22,7 @@ import {
   LlmHttpError,
   type LlmErrorDetails,
 } from "../../errors.js";
-import { _recordInferenceError } from "../index.js";
+import { _recordInferenceError, _recordInferenceUsage } from "../index.js";
 
 const RETRY_CAP_MS = 5_000;
 
@@ -73,8 +73,18 @@ export const portkeyInferenceProvider: InferenceProvider = {
         provider: "portkey",
         model: cfg.model,
       });
-      const data = (await resp.json()) as { choices?: Array<{ message?: { content?: string } }> };
+      const data = (await resp.json()) as {
+        id?: string;
+        choices?: Array<{ message?: { content?: string } }>;
+        usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+      };
       _recordInferenceError(null);
+      _recordInferenceUsage({
+        input_tokens: data.usage?.prompt_tokens,
+        output_tokens: data.usage?.completion_tokens,
+        total_tokens: data.usage?.total_tokens,
+        request_id: data.id,
+      });
       return data.choices?.[0]?.message?.content?.trim() ?? null;
     } catch (e: unknown) {
       if (e instanceof LlmHttpError) {

--- a/src/llm/inference/types.ts
+++ b/src/llm/inference/types.ts
@@ -47,6 +47,23 @@ export interface ChatCompletionOpts {
   temperature?: number;
   max_tokens?: number;
   response_format?: ResponseFormat;
+  /** id@version prompt stamp from the prompt registry, used for telemetry. */
+  promptName?: string;
+  telemetry?: ChatCompletionTelemetryContext;
+}
+
+export interface ChatCompletionTelemetryContext {
+  subsystem?: string;
+  session_id?: string;
+  workstream_key?: string;
+  trigger?: string;
+}
+
+export interface ChatCompletionUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  total_tokens?: number;
+  request_id?: string;
 }
 
 export interface InferenceProvider {

--- a/src/llm/telemetry.ts
+++ b/src/llm/telemetry.ts
@@ -21,11 +21,18 @@ export interface LLMTelemetryRecord {
   ts: string;
   prompt: string;
   model: string;
-  provider: "ollama" | "openai" | "bedrock";
+  provider: string;
+  subsystem?: string;
+  session_id?: string;
+  workstream_key?: string;
+  trigger?: string;
   ok: boolean;
   latency_ms: number;
   tokens_in_est: number;
   tokens_out_est: number;
+  tokens_in_actual?: number;
+  tokens_out_actual?: number;
+  tokens_total_actual?: number;
   error?: string;
   request_id?: string;
 }

--- a/src/status.test.ts
+++ b/src/status.test.ts
@@ -201,4 +201,40 @@ describe("status diagnostics", () => {
     assert.equal(report.embedding.base_url, "https://embed.example/v1?token=REDACTED");
     assert.equal(report.llm.base_url, "https://llm.example/v1?password=REDACTED");
   });
+
+  it("includes daemon maintenance summaries without making live calls", async () => {
+    const stateDir = path.join(TEST_BIKKY_HOME, "state");
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(path.join(stateDir, "maintenance-state.json"), JSON.stringify({
+      version: 1,
+      jobs: {
+        relation_inference: {
+          last_run_at: "2026-04-27T10:00:00.000Z",
+          cursor_updated_at: "2026-04-27T09:59:00.000Z",
+          recent_attempts: {},
+          last_summary: {
+            job: "relation_inference",
+            ran_at: "2026-04-27T10:00:00.000Z",
+            status: "success",
+            candidates_seen: 3,
+            llm_calls: 2,
+            accepted: 1,
+          },
+        },
+        entity_typing: {
+          last_run_at: null,
+          cursor_updated_at: null,
+          recent_attempts: {},
+          last_summary: null,
+        },
+      },
+    }));
+
+    const report = await collectStatus({ live: false, checkUi: false });
+
+    assert.equal(report.maintenance.status, "ok");
+    assert.equal(report.maintenance.relation_inference.last_summary?.llm_calls, 2);
+    assert.match(formatStatusReport(report), /Maint:/);
+    assert.match(formatStatusReport(report), /relations: success/);
+  });
 });

--- a/src/status.ts
+++ b/src/status.ts
@@ -29,6 +29,12 @@ import {
   type QdrantIndexSpec,
 } from "./lib/qdrant-client.js";
 import { QDRANT_INDEXES } from "./mcp/taxonomy.js";
+import {
+  MAINTENANCE_STATE_PATH,
+  readMaintenanceState,
+  type MaintenanceJobName,
+  type MaintenanceRunSummary,
+} from "./daemon/maintenance-state.js";
 
 export type DiagnosticState = "ok" | "warn" | "error" | "skipped";
 
@@ -81,6 +87,19 @@ export interface DaemonStatusReport {
   pid: number | null;
 }
 
+export interface MaintenanceJobStatus {
+  last_run_at: string | null;
+  cursor_updated_at: string | null;
+  last_summary: MaintenanceRunSummary | null;
+}
+
+export interface MaintenanceStatusReport {
+  status: DiagnosticState;
+  state_path: string;
+  relation_inference: MaintenanceJobStatus;
+  entity_typing: MaintenanceJobStatus;
+}
+
 export interface UiStatusReport {
   status: DiagnosticState;
   checked: boolean;
@@ -96,6 +115,7 @@ export interface BikkyStatusReport {
   embedding: ProviderStatus;
   llm: ProviderStatus;
   daemon: DaemonStatusReport;
+  maintenance: MaintenanceStatusReport;
   ui: UiStatusReport;
   mcp: { status: DiagnosticState; message: string };
 }
@@ -336,6 +356,26 @@ function collectDaemonStatus(): DaemonStatusReport {
   };
 }
 
+function collectMaintenanceStatus(): MaintenanceStatusReport {
+  const state = readMaintenanceState();
+  const jobStatus = (jobName: MaintenanceJobName): MaintenanceJobStatus => {
+    const job = state.jobs[jobName];
+    return {
+      last_run_at: job.last_run_at,
+      cursor_updated_at: job.cursor_updated_at,
+      last_summary: job.last_summary,
+    };
+  };
+  const summaries = [state.jobs.relation_inference.last_summary, state.jobs.entity_typing.last_summary];
+  const hasError = summaries.some((summary) => summary?.status === "error");
+  return {
+    status: hasError ? "warn" : "ok",
+    state_path: MAINTENANCE_STATE_PATH,
+    relation_inference: jobStatus("relation_inference"),
+    entity_typing: jobStatus("entity_typing"),
+  };
+}
+
 async function collectUiStatus(opts: CollectStatusOptions): Promise<UiStatusReport> {
   const url = opts.uiUrl ?? "http://localhost:1422/health";
   const reportedUrl = sanitizeStatusUrl(url) ?? url;
@@ -369,6 +409,7 @@ export async function collectStatus(opts: CollectStatusOptions = {}): Promise<Bi
   );
   const llm = collectLlmStatus(cfg);
   const daemon = collectDaemonStatus();
+  const maintenance = collectMaintenanceStatus();
   const ui = await collectUiStatus(opts);
   const required = [config.status, qdrant.status, embedding.status, llm.status];
 
@@ -379,6 +420,7 @@ export async function collectStatus(opts: CollectStatusOptions = {}): Promise<Bi
     embedding,
     llm,
     daemon,
+    maintenance,
     ui,
     mcp: { status: "ok", message: "managed by your editor (stdio)" },
   };
@@ -413,6 +455,22 @@ function qdrantSummary(qdrant: QdrantStatus): string {
     qdrant.vector_size !== null ? `vector size ${qdrant.vector_size}` : null,
   ].filter(Boolean).join(", ");
   return qdrant.error ? `${details} — ${qdrant.error}` : details;
+}
+
+function maintenanceJobSummary(label: string, job: MaintenanceJobStatus): string {
+  const summary = job.last_summary;
+  if (!summary) return `${label}: never run`;
+  const parts = [
+    `${label}: ${summary.status}`,
+    `last ${summary.ran_at}`,
+    `candidates ${summary.candidates_seen}`,
+    `LLM ${summary.llm_calls}`,
+    `accepted ${summary.accepted}`,
+  ];
+  if (summary.deterministic !== undefined) parts.push(`deterministic ${summary.deterministic}`);
+  if (summary.skipped_reason) parts.push(`reason ${summary.skipped_reason}`);
+  if (summary.error) parts.push(`error ${summary.error}`);
+  return parts.join(", ");
 }
 
 export function formatStatusReport(report: BikkyStatusReport): string {
@@ -452,6 +510,8 @@ export function formatStatusReport(report: BikkyStatusReport): string {
   );
 
   lines.push(`Daemon:   ${icon(report.daemon.status)} ${report.daemon.running ? `running (PID ${report.daemon.pid})` : "stopped"}`);
+  lines.push(`Maint:    ${icon(report.maintenance.status)} ${maintenanceJobSummary("relations", report.maintenance.relation_inference)}`);
+  lines.push(`          ${maintenanceJobSummary("entity typing", report.maintenance.entity_typing)}`);
   lines.push(`UI:       ${icon(report.ui.status)} ${report.ui.checked ? report.ui.url : "not checked"}${report.ui.error ? ` — ${report.ui.error}` : ""}`);
   lines.push(`MCP:      ${icon(report.mcp.status)} ${report.mcp.message}`);
 


### PR DESCRIPTION
## Summary
- Add configurable daemon maintenance intervals, feature flags, and per-run caps for relation inference and entity typing.
- Persist maintenance cursors/run summaries so background work is incremental, retry-aware, and visible in bikky status.
- Wire LLM telemetry through chatCompletion, including prompt/subsystem attribution and provider-actual token usage where available.
- Update relation inference/entity typing to process changed facts with attribution metadata instead of broad global scans.

## Validation
- npm run build -- --pretty false && npm test
- npm run typecheck
- npm run lint is currently blocked by the repo existing ESLint 9 setup: ESLint cannot find eslint.config.(js|mjs|cjs).

Fixes #70