### PR TITLE
Close out memory grounding and watcher path gaps

### DIFF
--- a/packages/ui/src/routes/memory.test.ts
+++ b/packages/ui/src/routes/memory.test.ts
@@ -90,6 +90,19 @@ const sampleFact = (overrides: Record<string, unknown> = {}) => ({
   },
 });
 
+const sampleEntityType = (name: string, type: string, overrides: Record<string, unknown> = {}) => ({
+  id: `entity-type-${name}`,
+  payload: {
+    kind: "entity_type",
+    entity_name: name,
+    entity_type: type,
+    entity_type_confidence: 0.82,
+    entity_type_reasoning: `${name} is classified as ${type}`,
+    classified_at: "2024-01-02T00:00:00Z",
+    ...overrides,
+  },
+});
+
 describe("ui/routes/memory", () => {
   before(() => {
     for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
@@ -360,12 +373,14 @@ describe("ui/routes/memory", () => {
         qdrantHandler: (c) => {
           if (c.path.endsWith("/points/scroll")) {
             scrollCount++;
-            // First: facts. Second: from-relations. Third: to-relations.
+            // First: facts. Second: from-relations. Third: to-relations. Fourth: entity type.
             const points = scrollCount === 1
               ? [sampleFact()]
               : scrollCount === 2
                 ? [sampleFact({ from_entity: "alice", relation_type: "owns", to_entity: "bikky" })]
-                : [sampleFact({ from_entity: "bikky", relation_type: "uses", to_entity: "alice" })];
+                : scrollCount === 3
+                  ? [sampleFact({ from_entity: "bikky", relation_type: "uses", to_entity: "alice" })]
+                  : [];
             return { result: { points, next_page_offset: null } };
           }
           return { result: [] };
@@ -379,6 +394,70 @@ describe("ui/routes/memory", () => {
       assert.equal(body.entity, "alice");
       assert.equal(body.factCount, 1);
       assert.equal(body.relationCount, 2);
+    });
+
+    it("returns daemon-classified entity type metadata when present", async () => {
+      let scrollCount = 0;
+      installMock({
+        qdrantHandler: (c) => {
+          if (c.path.endsWith("/points/scroll")) {
+            scrollCount++;
+            const points = scrollCount === 1
+              ? [sampleFact()]
+              : scrollCount === 4
+                ? [sampleEntityType("alice", "person")]
+                : [];
+            return { result: { points, next_page_offset: null } };
+          }
+          if (c.path.endsWith("/points/count")) return { result: { count: 1 } };
+          return { result: [] };
+        },
+      });
+      const app = buildApp();
+
+      const res = await app.fetch(new Request("http://localhost/api/memory/entities/Alice"));
+      assert.equal(res.status, 200);
+      const body = await res.json() as {
+        entityType: string | null;
+        entityTypeConfidence: number | null;
+        entityTypeReasoning: string | null;
+        entityTypeClassifiedAt: string | null;
+      };
+      assert.equal(body.entityType, "person");
+      assert.equal(body.entityTypeConfidence, 0.82);
+      assert.equal(body.entityTypeReasoning, "alice is classified as person");
+      assert.equal(body.entityTypeClassifiedAt, "2024-01-02T00:00:00Z");
+    });
+  });
+
+  describe("GET /entity-types", () => {
+    it("returns a type map for requested entities", async () => {
+      const log = installMock({
+        qdrantHandler: (c) => {
+          if (c.path.endsWith("/points/scroll")) {
+            return {
+              result: {
+                points: [
+                  sampleEntityType("bikky", "project"),
+                  sampleEntityType("qdrant", "service"),
+                ],
+                next_page_offset: null,
+              },
+            };
+          }
+          return { result: [] };
+        },
+      });
+      const app = buildApp();
+
+      const res = await app.fetch(new Request("http://localhost/api/memory/entity-types?names=BIKKY,qdrant"));
+      assert.equal(res.status, 200);
+      const body = await res.json() as { types: Record<string, string> };
+      assert.deepEqual(body.types, { bikky: "project", qdrant: "service" });
+
+      const scroll = log.calls.find((c) => c.path.endsWith("/points/scroll"));
+      assert.ok(scroll);
+      assert.deepEqual(scroll!.body.filter.must[1].match.any, ["bikky", "qdrant"]);
     });
   });
 

--- a/src/daemon/watcher-health.test.ts
+++ b/src/daemon/watcher-health.test.ts
@@ -8,7 +8,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { looksLikeTempdir, inspectWatcherPaths, formatIssue } from "./watcher-health.js";
+import { looksLikeTempdir, inspectWatcherPaths, formatIssue, repairSuspiciousWatcherPaths } from "./watcher-health.js";
 import { CONFIG_DEFAULTS } from "../config.js";
 
 describe("looksLikeTempdir", () => {
@@ -85,6 +85,35 @@ describe("inspectWatcherPaths", () => {
     for (const i of issues) {
       assert.notStrictEqual(i.watcher, "claude", `claude default path should not be flagged: ${JSON.stringify(i)}`);
     }
+  });
+});
+
+describe("repairSuspiciousWatcherPaths", () => {
+  it("resets enabled tempdir watcher paths to canonical defaults", () => {
+    const cfg = structuredClone(CONFIG_DEFAULTS);
+    const stalePath = "/var/folders/0z/abc/T/bikky-test-sessions-XYZ/mixed-sessions";
+    cfg.watchers.copilot.path = stalePath;
+
+    const repairs = repairSuspiciousWatcherPaths(cfg);
+
+    assert.strictEqual(repairs.length, 1);
+    assert.strictEqual(repairs[0].watcher, "copilot");
+    assert.strictEqual(repairs[0].previousPath, stalePath);
+    assert.strictEqual(repairs[0].repairedPath, CONFIG_DEFAULTS.watchers.copilot.path);
+    assert.strictEqual(cfg.watchers.copilot.path, CONFIG_DEFAULTS.watchers.copilot.path);
+  });
+
+  it("does not rewrite disabled or non-temp custom watcher paths", () => {
+    const cfg = structuredClone(CONFIG_DEFAULTS);
+    cfg.watchers.copilot.enabled = false;
+    cfg.watchers.copilot.path = "/tmp/bikky-test-disabled";
+    cfg.watchers.claude.path = os.homedir();
+
+    const repairs = repairSuspiciousWatcherPaths(cfg);
+
+    assert.strictEqual(repairs.length, 0);
+    assert.strictEqual(cfg.watchers.copilot.path, "/tmp/bikky-test-disabled");
+    assert.strictEqual(cfg.watchers.claude.path, os.homedir());
   });
 });
 

--- a/src/daemon/watcher-health.ts
+++ b/src/daemon/watcher-health.ts
@@ -19,6 +19,13 @@ export interface WatcherPathIssue {
   canonicalDefault: string;
 }
 
+export interface WatcherPathRepair {
+  watcher: "copilot" | "claude";
+  previousPath: string;
+  repairedPath: string;
+  reason: string;
+}
+
 const TEMPDIR_PREFIXES = [
   os.tmpdir(),
   "/tmp/",
@@ -43,6 +50,32 @@ export function looksLikeTempdir(p: string): boolean {
 function canonicalDefault(watcher: "copilot" | "claude"): string {
   if (watcher === "copilot") return path.join(os.homedir(), ".copilot", "session-state");
   return path.join(os.homedir(), ".claude", "projects");
+}
+
+export function repairSuspiciousWatcherPaths(cfg: BikkyConfig): WatcherPathRepair[] {
+  const repairs: WatcherPathRepair[] = [];
+  const entries: Array<["copilot" | "claude", { enabled: boolean; path: string }]> = [
+    ["copilot", cfg.watchers.copilot],
+    ["claude", cfg.watchers.claude],
+  ];
+
+  for (const [name, w] of entries) {
+    if (!w.enabled) continue;
+    const def = canonicalDefault(name);
+    const isDefault = path.resolve(w.path) === path.resolve(def);
+    if (isDefault || !looksLikeTempdir(w.path)) continue;
+
+    const previousPath = w.path;
+    w.path = def;
+    repairs.push({
+      watcher: name,
+      previousPath,
+      repairedPath: def,
+      reason: "path is under an OS tempdir or test fixture",
+    });
+  }
+
+  return repairs;
 }
 
 export function inspectWatcherPaths(cfg: BikkyConfig): WatcherPathIssue[] {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -63,7 +63,7 @@ import {
 } from "./api.js";
 import { saveConfig, loadConfig, EXTRACTION_HEALTH_PATH } from "../config.js";
 import { existsSync, readFileSync } from "node:fs";
-import { inspectWatcherPaths, formatIssue } from "../daemon/watcher-health.js";
+import { inspectWatcherPaths, formatIssue, repairSuspiciousWatcherPaths } from "../daemon/watcher-health.js";
 import {
   addRedactionPayload,
   combineRedactions,
@@ -363,6 +363,11 @@ export function registerTools(mcp: McpServer): void {
         cfg.embedding.api_key = openai_api_key;
         cfg.llm.api_key = openai_api_key;
         results["openai_api_key"] = "stored ✓";
+      }
+
+      const watcherRepairs = repairSuspiciousWatcherPaths(cfg);
+      if (watcherRepairs.length > 0) {
+        results["watcher_path_repairs"] = watcherRepairs;
       }
 
       saveConfig(cfg);


### PR DESCRIPTION
## Summary
- add safe repair of clearly stale temp/test watcher paths during `configure_credentials`
- report watcher path repairs in the configure tool result
- add UI route coverage for daemon-classified entity type lookup and entity detail metadata

## Validation
- `npm run build -- --pretty false && npm test`
- `npm run typecheck`
- `cd packages/ui && npm test`
- `cd packages/ui && npm run typecheck`

`npm run lint` is still blocked by the existing ESLint 9 flat-config migration issue: ESLint cannot find `eslint.config.(js|mjs|cjs)`.

Refs #46
Refs #60