### PR TITLE
chore: release bikky 0.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bikky",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bikky",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bikky",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Shared memory for AI coding sessions — MCP server + background daemon",
   "type": "module",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary
- bump root `bikky` package metadata from `0.3.6` to `0.3.7`
- prepare npm patch release for the merged PR #73 fixes

## Validation
- `npm run build -- --pretty false`
- `npm test`
- `npm run typecheck`
- `npm pack --dry-run --json` → `bikky-0.3.7.tgz`, 453 files

`npm run lint` remains blocked by the existing ESLint 9 flat-config issue.

Closes #74