### PR TITLE
chore: add eslint flat config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,37 @@
+import tseslint from "typescript-eslint";
+
+export default [
+  {
+    ignores: [
+      "dist/**",
+      "node_modules/**",
+      "packages/*/dist/**",
+      "packages/*/node_modules/**",
+    ],
+  },
+  {
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+      },
+    },
+    plugins: {
+      "@typescript-eslint": tseslint.plugin,
+    },
+    rules: {
+      "no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": ["error", {
+        argsIgnorePattern: "^_",
+        caughtErrorsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+      }],
+      "prefer-const": "error",
+      eqeqeq: ["error", "always", { null: "ignore" }],
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/consistent-type-imports": "error",
+    },
+  },
+];

--- a/src/daemon/consolidation.ts
+++ b/src/daemon/consolidation.ts
@@ -17,18 +17,18 @@ import { createHash } from "node:crypto";
 import * as qdrant from "./qdrant.js";
 import { chatCompletion } from "../llm/index.js";
 import { categoryValues, normalizeCategory, normalizeDomain } from "../mcp/taxonomy.js";
+import type { ALLOWED_BRIEF_HEADINGS } from "../prompts/index.js";
 import {
   distillPrompt,
   DISTILL_PROMPT_DESCRIPTOR,
   contradictionPrompt,
   briefPrompt,
   BRIEF_PROMPT_DESCRIPTOR,
-  ALLOWED_BRIEF_HEADINGS,
   safeParseJson,
 } from "../prompts/index.js";
 import { STATE_DIR } from "../config.js";
 import type { BikkyConfig } from "../config.js";
-import type { LogFn, QdrantPayload, StoreFact } from "./qdrant.js";
+import type { LogFn, QdrantPayload } from "./qdrant.js";
 
 // ---------------------------------------------------------------------------
 // Local types

--- a/src/daemon/extraction.ts
+++ b/src/daemon/extraction.ts
@@ -7,7 +7,7 @@
  */
 
 import { readFile, stat } from "node:fs/promises";
-import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { join } from "node:path";
 import { glob } from "node:fs/promises";

--- a/src/daemon/loop.test.ts
+++ b/src/daemon/loop.test.ts
@@ -17,7 +17,7 @@ const configPath = path.join(os.homedir(), ".bikky", "config.json");
 const qdrantEnvKeys = ["QDRANT_URL", "QDRANT_API_KEY"] as const;
 
 let savedConfig: string | null = null;
-let savedQdrantEnv: Record<string, string | undefined> = {};
+const savedQdrantEnv: Record<string, string | undefined> = {};
 let savedFetch: typeof fetch;
 let calls: FetchCall[] = [];
 

--- a/src/daemon/loop.ts
+++ b/src/daemon/loop.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { loadConfig, LOG_DIR } from "../config.js";
 import { createLogger } from "../logger.js";
 import { initLLM } from "../llm/index.js";
+import type { LogFn as InferenceLogFn } from "../llm/index.js";
 import type { LogFn } from "./qdrant.js";
 
 // Import daemon modules
@@ -55,7 +56,7 @@ export async function startDaemon(): Promise<void> {
       retries: cfg.llm.retries,
       retryBaseDelayMs: cfg.llm.retry_base_delay_ms,
     },
-    logger: log as unknown as import("../llm/index.js").LogFn,
+    logger: log as unknown as InferenceLogFn,
   });
 
   // Initialize Qdrant client

--- a/src/daemon/qdrant.test.ts
+++ b/src/daemon/qdrant.test.ts
@@ -31,7 +31,7 @@ const realFetch = globalThis.fetch;
 
 // Env vars that override config — must be cleared for null-credential tests
 const QDRANT_ENV_KEYS = ["QDRANT_URL", "QDRANT_API_KEY"];
-let savedQdrantEnv: Record<string, string | undefined> = {};
+const savedQdrantEnv: Record<string, string | undefined> = {};
 
 describe("daemon/qdrant", () => {
   before(() => {
@@ -163,7 +163,7 @@ describe("daemon/qdrant", () => {
   describe("setLogger", () => {
     it("does not throw when called with a function", () => {
       assert.doesNotThrow(() => {
-        setLogger((level: string, ...args: unknown[]) => {
+        setLogger((_level: string, ..._args: unknown[]) => {
           // noop logger
         });
       });

--- a/src/daemon/session-summary.ts
+++ b/src/daemon/session-summary.ts
@@ -9,7 +9,6 @@ import { createHash } from "node:crypto";
 
 import type { BikkyConfig } from "../config.js";
 import { loadConfig } from "../config.js";
-import { chatCompletion } from "../llm/index.js";
 import { DEFAULT_CAPTURE_CONTEXT, CAPTURE_POLICY_VERSION, PROMPT_VERSIONS } from "./capture-policy.js";
 import { segmentTranscriptIntoEpisodes, updateEpisodeSummary } from "./episode-summary.js";
 import { buildSessionIndexFilter, updateSessionIndex } from "./session-index.js";
@@ -210,40 +209,6 @@ export const buildSessionSummaryPayload = (input: {
   }
 
   return { payload, redaction };
-};
-
-const redactionOptions = (_config: BikkyConfig): { enabled: boolean; redactPii: boolean } => ({
-  enabled: true,
-  redactPii: false,
-});
-
-const summarizeTranscript = async (input: {
-  transcript: string;
-  existingSummary?: string | null;
-}): Promise<SessionSummaryDraft> => {
-  const result = await chatCompletion({
-    promptName: `session-index@${PROMPT_VERSIONS.sessionIndex}`,
-    messages: buildSessionSummaryMessages(input),
-    temperature: 0.2,
-    max_tokens: 1500,
-    response_format: { type: "json_object" },
-    telemetry: { subsystem: "summary", trigger: "session_index" },
-  });
-  if (!result) throw new Error("Session summary LLM returned null");
-  return parseSessionSummaryDraft(result);
-};
-
-const findExistingSummary = async (
-  sessionId: string,
-  scope: WorkspaceScope,
-): Promise<ExistingSummary | null> => {
-  const result = await qdrant.qdrantRequest("POST", `/collections/${qdrant.collection}/points/scroll`, {
-    filter: buildSessionSummaryFilter(sessionId, scope),
-    limit: 1,
-    with_payload: true,
-  }) as { result?: { points?: ExistingSummary[] } };
-
-  return result.result?.points?.[0] ?? null;
 };
 
 export const updateSessionSummary = async (input: {

--- a/src/daemon/watcher.test.ts
+++ b/src/daemon/watcher.test.ts
@@ -16,7 +16,7 @@ import os from "node:os";
 const TEST_BIKKY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-home-watcher-"));
 process.env.BIKKY_HOME = TEST_BIKKY_HOME;
 
-const { resetConfig, loadConfig, saveConfig, CONFIG_DEFAULTS } = await import("../config.js");
+const { resetConfig, saveConfig, CONFIG_DEFAULTS } = await import("../config.js");
 const { discoverSessions } = await import("./watcher.js");
 
 // ---------------------------------------------------------------------------

--- a/src/lib/qdrant-client.test.ts
+++ b/src/lib/qdrant-client.test.ts
@@ -5,7 +5,7 @@
  * scripted responses or throw scripted errors.
  */
 
-import { describe, it, beforeEach, afterEach } from "node:test";
+import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
 
 import {

--- a/src/llm/inference/index.ts
+++ b/src/llm/inference/index.ts
@@ -26,7 +26,7 @@ import type {
   LogFn,
   ResolvedInferenceConfig,
 } from "./types.js";
-import { LlmHttpError } from "../errors.js";
+import type { LlmHttpError } from "../errors.js";
 import { estimateTokens, writeTelemetry } from "../telemetry.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;

--- a/src/mcp/taxonomy.ts
+++ b/src/mcp/taxonomy.ts
@@ -576,7 +576,6 @@ export function getDecayHalfLife(input: {
   if (kind === "relation" || kind === "telemetry") return null;
 
   const rawCategory = normalizeToken(input.category);
-  const rawDomain = normalizeToken(input.domain);
   const categoryWasProvided = rawCategory.length > 0;
   const categoryIsKnown =
     rawCategory in CATEGORIES ||

--- a/src/mcp/tools.integration.itest.ts
+++ b/src/mcp/tools.integration.itest.ts
@@ -167,7 +167,7 @@ describe("mcp/tools — Qdrant integration", { skip: !enabled }, () => {
         match,
         `expected paraphrase to reinforce or appear in similar_facts; got ${JSON.stringify(r)}`,
       );
-      // eslint-disable-next-line no-console
+
       console.warn(`[integration] paraphrase landed in related band (score=${match!.score}) — consider tuning THRESHOLD_DUPLICATE for this embedding model`);
     }
   });


### PR DESCRIPTION
## Summary
- add an ESLint 9 flat config for the root `src/**/*.ts` lint gate
- restore `npm run lint` and `npm run check`
- resolve the focused non-curly findings surfaced by enabling lint
- leave broad `curly` enforcement as follow-up backlog because it currently touches hundreds of existing lines

## Validation
- `npm run lint`
- `npm run check`
- `npm run build -- --pretty false`
- `npm test`
- `git diff --check`

Closes #76