### PR TITLE
Add JSON output for memory_recall

### DIFF
--- a/src/mcp/helpers.ts
+++ b/src/mcp/helpers.ts
@@ -8,6 +8,43 @@ import crypto from "node:crypto";
 import type { FactPayload, FilterParams, QdrantFilter, QdrantPoint } from "./types.js";
 import { DEFAULT_DOMAIN, getDecayHalfLife, STALENESS_DAYS } from "./taxonomy.js";
 
+export interface StructuredFact {
+  id: string;
+  content: string;
+  category: string;
+  domain?: string;
+  kind?: string;
+  memory_subtype?: string | null;
+  workspace_id?: string;
+  source?: string;
+  entities: string[];
+  confidence?: number;
+  effective_confidence?: number;
+  importance?: number;
+  reinforcement_count?: number;
+  verification_count?: number;
+  useful_count?: number;
+  not_useful_count?: number;
+  redaction?: FactPayload["redaction"];
+  metadata?: FactPayload["metadata"];
+  workstream_key?: string | null;
+  episode_id?: string | null;
+  task_key?: string | null;
+  repo?: string | null;
+  branch?: string | null;
+  created_at?: string;
+  updated_at?: string;
+  last_activity_at?: string;
+  stale: boolean;
+  score?: number;
+  rank?: number;
+  relation?: {
+    from_entity?: string;
+    type?: string;
+    to_entity?: string;
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Hashing
 // ---------------------------------------------------------------------------
@@ -242,4 +279,57 @@ export function formatFact(point: QdrantPoint): string {
   if (point.score !== undefined) parts.push(`score: ${point.score.toFixed(3)}`);
   if (point._combinedScore !== undefined) parts.push(`rank: ${point._combinedScore.toFixed(3)}`);
   return parts.join(" | ");
+}
+
+function roundMetric(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) return undefined;
+  return Math.round(value * 1000) / 1000;
+}
+
+/** Convert a Qdrant point into a stable structured object for agent parsing. */
+export function structuredFact(point: QdrantPoint): StructuredFact {
+  const p = point.payload;
+  const confidence = typeof p.confidence === "number" ? p.confidence : undefined;
+  const effectiveConfidence = confidence === undefined ? undefined : computeEffectiveConfidence(p);
+  const relation =
+    p.from_entity || p.relation_type || p.to_entity
+      ? {
+        ...(p.from_entity ? { from_entity: p.from_entity } : {}),
+        ...(p.relation_type ? { type: p.relation_type } : {}),
+        ...(p.to_entity ? { to_entity: p.to_entity } : {}),
+      }
+      : undefined;
+
+  return {
+    id: point.id,
+    content: p.content,
+    category: p.category,
+    ...(p.domain ? { domain: p.domain } : {}),
+    ...(p.kind ? { kind: p.kind } : {}),
+    ...(p.memory_subtype ? { memory_subtype: p.memory_subtype } : {}),
+    ...(p.workspace_id ? { workspace_id: p.workspace_id } : {}),
+    ...(p.source ? { source: p.source } : {}),
+    entities: p.entities ?? [],
+    ...(confidence !== undefined ? { confidence } : {}),
+    ...(effectiveConfidence !== undefined ? { effective_confidence: effectiveConfidence } : {}),
+    ...(p.importance !== undefined ? { importance: p.importance } : {}),
+    ...(p.reinforcement_count !== undefined ? { reinforcement_count: p.reinforcement_count } : {}),
+    ...(p.verification_count !== undefined ? { verification_count: p.verification_count } : {}),
+    ...(p.useful_count !== undefined ? { useful_count: p.useful_count } : {}),
+    ...(p.not_useful_count !== undefined ? { not_useful_count: p.not_useful_count } : {}),
+    ...(p.redaction ? { redaction: p.redaction } : {}),
+    ...(p.metadata && Object.keys(p.metadata).length > 0 ? { metadata: p.metadata } : {}),
+    ...(p.workstream_key ? { workstream_key: p.workstream_key } : {}),
+    ...(p.episode_id ? { episode_id: p.episode_id } : {}),
+    ...(p.task_key ? { task_key: p.task_key } : {}),
+    ...(p.repo ? { repo: p.repo } : {}),
+    ...(p.branch ? { branch: p.branch } : {}),
+    ...(p.created_at ? { created_at: p.created_at } : {}),
+    ...(p.updated_at ? { updated_at: p.updated_at } : {}),
+    ...(lastActivityDate(p) ? { last_activity_at: lastActivityDate(p) } : {}),
+    stale: isStale(p),
+    ...(roundMetric(point.score) !== undefined ? { score: roundMetric(point.score) } : {}),
+    ...(roundMetric(point._combinedScore) !== undefined ? { rank: roundMetric(point._combinedScore) } : {}),
+    ...(relation ? { relation } : {}),
+  };
 }

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -86,7 +86,7 @@ export async function startMcpServer(): Promise<void> {
     instructions: [
       "Bikky provides persistent memory across AI coding sessions. Use it as a working loop, not a database:",
       "  • STORE when you learn something durable (a service detail, a decision, a workaround, a user preference). Call memory_store with one atomic fact per call — dedup is automatic, so don't pre-check.",
-      "  • RECALL before acting. At session start, call memory_recall with a broad briefing query. For each new user prompt about an unfamiliar topic, recall again with a focused query. Recall before storing too, to surface conflicts.",
+      "  • RECALL before acting. At session start, call memory_recall with a broad briefing query. For each new user prompt about an unfamiliar topic, recall again with a focused query. Use memory_recall(output_format: \"json\") when you need stable IDs/metadata for follow-up actions. Recall before storing only when you intentionally need a conflict/replacement check; memory_store deduplication is automatic.",
       "  • VERIFY when stale. memory_heartbeat surfaces stale fact IDs every ~3 calls; confirm them with memory_verify, retire them with memory_forget, or replace them with memory_store(supersedes: <id>).",
       "  • ENTITY-FIRST queries. When the user asks 'tell me about X', prefer memory_entity over memory_recall.",
       "If the system is not configured, call get_setup_status for guidance.",

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -434,6 +434,17 @@ describe("mcp/tools handlers", () => {
       assert.match(textOf(result), /No matching facts found/);
     });
 
+    it("returns parseable empty JSON when output_format=json and search has no results", async () => {
+      on("/points/search", () => ({ result: [] }));
+      const result = await invoke("memory_recall", { query: "nothing", output_format: "json" });
+      const parsed = JSON.parse(textOf(result));
+      assert.equal(parsed.query, "nothing");
+      assert.equal(parsed.result_count, 0);
+      assert.equal(parsed.related_count, 0);
+      assert.deepEqual(parsed.results, []);
+      assert.deepEqual(parsed.related, []);
+    });
+
     it("passes category, domain, kind, entity, since, until, and metadata into the Qdrant filter", async () => {
       let searchBody: Record<string, unknown> | null = null;
       on("/points/search", (call) => {
@@ -491,6 +502,81 @@ describe("mcp/tools handlers", () => {
       assert.match(lines[1]!, /\bC\b/);
     });
 
+    it("returns structured JSON with stable fact fields when output_format=json", async () => {
+      const now = new Date().toISOString();
+      on("/points/search", () => ({
+        result: [{
+          id: "fact-json",
+          score: 0.91,
+          payload: {
+            content: "JSON recall should be easy to parse",
+            category: "infrastructure",
+            domain: "work",
+            kind: "fact",
+            source: "user",
+            entities: ["mcp", "recall"],
+            confidence: 0.88,
+            importance: 0.7,
+            reinforcement_count: 2,
+            verification_count: 1,
+            useful_count: 3,
+            not_useful_count: 0,
+            metadata: { project: "bikky" },
+            created_at: now,
+            updated_at: now,
+          },
+        }],
+      }));
+
+      const result = await invoke("memory_recall", { query: "json recall", output_format: "json" });
+      const parsed = JSON.parse(textOf(result));
+      assert.equal(parsed.query, "json recall");
+      assert.equal(parsed.requested_limit, 10);
+      assert.equal(parsed.effective_limit, 10);
+      assert.equal(parsed.limit_clamped, false);
+      assert.equal(parsed.result_count, 1);
+      assert.equal(parsed.related_count, 0);
+      assert.equal(parsed.results.length, 1);
+      assert.equal(parsed.results[0].id, "fact-json");
+      assert.equal(parsed.results[0].content, "JSON recall should be easy to parse");
+      assert.equal(parsed.results[0].category, "infrastructure");
+      assert.deepEqual(parsed.results[0].entities, ["mcp", "recall"]);
+      assert.equal(parsed.results[0].confidence, 0.88);
+      assert.equal(parsed.results[0].score, 0.91);
+      assert.deepEqual(parsed.related, []);
+    });
+
+    it("clamps large recall limits and reports the effective limit in JSON", async () => {
+      const now = new Date().toISOString();
+      on("/points/search", () => {
+        return {
+          result: Array.from({ length: 60 }, (_, i) => ({
+            id: `fact-${i}`,
+            score: 1 - i / 100,
+            payload: {
+              content: `fact ${i}`,
+              category: "infrastructure",
+              entities: [],
+              confidence: 0.9,
+              reinforcement_count: 1,
+              created_at: now,
+            },
+          })),
+        };
+      });
+
+      const result = await invoke("memory_recall", { query: "many", limit: 999, output_format: "json" });
+      const parsed = JSON.parse(textOf(result));
+      const searchBody = callsTo("/points/search")[0]?.body as Record<string, unknown> | undefined;
+      assert.equal(searchBody?.limit, 100);
+      assert.equal(parsed.requested_limit, 999);
+      assert.equal(parsed.effective_limit, 50);
+      assert.equal(parsed.max_limit, 50);
+      assert.equal(parsed.limit_clamped, true);
+      assert.equal(parsed.results.length, 50);
+      assert.equal(parsed.result_count, 50);
+    });
+
     it("appends 1-hop related facts when graph_depth=1", async () => {
       // Primary search returns one fact mentioning entity 'a'.
       on("/points/search", () => ({
@@ -532,6 +618,64 @@ describe("mcp/tools handlers", () => {
       assert.match(text, /primary/);
       assert.match(text, /Related \(1-hop\)/);
       assert.match(text, /b is interesting/);
+    });
+
+    it("separates primary and 1-hop related facts in JSON output", async () => {
+      on("/points/search", () => ({
+        result: [{
+          id: "p1",
+          score: 0.9,
+          payload: {
+            content: "primary",
+            category: "infrastructure",
+            entities: ["a"],
+            confidence: 0.9,
+            reinforcement_count: 1,
+            created_at: new Date().toISOString(),
+          },
+        }],
+      }));
+      on("/points/scroll", (call) => {
+        const body = call.body as { filter: { must: Array<Record<string, unknown>> } };
+        const conditions = body.filter.must;
+        const fromCond = conditions.find((c) => c.key === "from_entity") as { match: { value: string } } | undefined;
+        const toCond = conditions.find((c) => c.key === "to_entity") as { match: { value: string } } | undefined;
+        const entitiesCond = conditions.find((c) => c.key === "entities") as { match: { value: string } } | undefined;
+
+        if (fromCond?.match.value === "a") {
+          return { result: { points: [{
+            id: "rel1",
+            payload: { content: "a -> b", category: "team", entities: ["a", "b"], from_entity: "a", to_entity: "b", relation_type: "uses", reinforcement_count: 1 },
+          }] } };
+        }
+        if (toCond?.match.value === "a") {
+          return { result: { points: [] } };
+        }
+        if (entitiesCond?.match.value === "b") {
+          return { result: { points: [{
+            id: "neighbor",
+            score: 0.7,
+            payload: {
+              content: "b is interesting",
+              category: "infrastructure",
+              entities: ["b"],
+              confidence: 0.8,
+              reinforcement_count: 1,
+              created_at: new Date().toISOString(),
+            },
+          }] } };
+        }
+        return { result: { points: [] } };
+      });
+
+      const result = await invoke("memory_recall", { query: "q", graph_depth: 1, limit: 5, output_format: "json" });
+      const parsed = JSON.parse(textOf(result));
+      assert.equal(parsed.graph_depth, 1);
+      assert.equal(parsed.result_count, 1);
+      assert.equal(parsed.related_count, 1);
+      assert.equal(parsed.results[0].id, "p1");
+      assert.equal(parsed.related[0].id, "neighbor");
+      assert.equal(parsed.related[0].content, "b is interesting");
     });
   });
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -39,6 +39,7 @@ import {
   computeCombinedScore,
   buildFilter,
   formatFact,
+  structuredFact,
   MEMORY_RECALL_EXCLUDED_KINDS,
 } from "./helpers.js";
 import {
@@ -75,6 +76,8 @@ import {
 // ---------------------------------------------------------------------------
 
 const NUDGE_INTERVAL_MS = 10 * 60 * 1000;
+const MEMORY_RECALL_DEFAULT_LIMIT = 10;
+const MEMORY_RECALL_MAX_LIMIT = 50;
 let lastStoreTime = Date.now();
 let heartbeatCount = 0;
 
@@ -168,10 +171,22 @@ function buildMemoryNudge(): string | null {
     "If yes, call memory_store now so future sessions inherit the knowledge.";
 }
 
+function clampRecallLimit(limit: number | undefined): number {
+  const rawLimit = limit ?? MEMORY_RECALL_DEFAULT_LIMIT;
+  const integerLimit = Math.trunc(rawLimit);
+  if (!Number.isFinite(integerLimit)) return MEMORY_RECALL_DEFAULT_LIMIT;
+  return Math.min(Math.max(integerLimit, 1), MEMORY_RECALL_MAX_LIMIT);
+}
+
+interface GraphTraversalResult {
+  points: QdrantPoint[];
+  error?: string;
+}
+
 /**
  * Entity-graph traversal for memory_recall.
  */
-async function graphTraversal(primaryResults: QdrantPoint[], limit: number, scope: WorkspaceScope): Promise<string[]> {
+async function graphTraversal(primaryResults: QdrantPoint[], limit: number, scope: WorkspaceScope): Promise<GraphTraversalResult> {
   try {
     const primaryEntities = new Set<string>();
     const primaryIds = new Set<string>();
@@ -182,7 +197,7 @@ async function graphTraversal(primaryResults: QdrantPoint[], limit: number, scop
       }
     }
 
-    if (primaryEntities.size === 0) return [];
+    if (primaryEntities.size === 0) return { points: [] };
 
     const relatedEntities = new Set<string>();
     for (const entity of primaryEntities) {
@@ -204,7 +219,7 @@ async function graphTraversal(primaryResults: QdrantPoint[], limit: number, scop
     }
 
     for (const e of primaryEntities) relatedEntities.delete(e);
-    if (relatedEntities.size === 0) return [];
+    if (relatedEntities.size === 0) return { points: [] };
 
     const relatedFacts: QdrantPoint[] = [];
     const maxPerEntity = Math.max(2, Math.floor(limit / relatedEntities.size));
@@ -222,11 +237,9 @@ async function graphTraversal(primaryResults: QdrantPoint[], limit: number, scop
       if (relatedFacts.length >= limit) break;
     }
 
-    return relatedFacts
-      .slice(0, Math.ceil(limit / 2))
-      .map((r) => formatFact(r));
+    return { points: relatedFacts.slice(0, Math.ceil(limit / 2)) };
   } catch (e) {
-    return [`(graph traversal failed: ${e instanceof Error ? e.message : String(e)})`];
+    return { points: [], error: e instanceof Error ? e.message : String(e) };
   }
 }
 
@@ -444,7 +457,7 @@ export function registerTools(mcp: McpServer): void {
     [
       "Persist one atomic fact to long-term memory.",
       "Call this whenever you learn something a future session would need: a service detail, a decision rationale, a workaround, a user preference, an ownership fact, a task-resume pointer. One fact per call — split compound observations into separate calls.",
-      "Dedup is automatic (content hash + vector similarity), so you do NOT need to recall first. The tool returns one of: inserted (new fact), reinforced (exact or near-duplicate found — counters bumped), or — if there are similar-but-different facts — a list of potential conflicts so you can decide whether to use 'supersedes'.",
+      "Dedup is automatic (content hash + vector similarity), so you do NOT need to recall first for deduplication. Recall first only when you intentionally need broader context to decide whether a new fact supersedes an older one. The tool returns one of: inserted (new fact), reinforced (exact or near-duplicate found — counters bumped), or — if there are similar-but-different facts — a list of potential conflicts so you can decide whether to use 'supersedes'.",
       "To create a typed edge between two entities at the same time, set the optional 'relation' field — no separate tool call needed.",
       "Do NOT use for ephemeral state (current cursor, in-flight todo). Use the harness task folder instead.",
     ].join(" "),
@@ -771,9 +784,10 @@ export function registerTools(mcp: McpServer): void {
       "Three main uses:",
       "  1. Session-start briefing — broad query like 'session briefing: user preferences, active projects, recent decisions'.",
       "  2. Per-prompt contextual recall — focused query derived from what the user just asked.",
-      "  3. Pre-store conflict check — recall similar facts before storing, so you can use 'supersedes' if the new fact replaces an older one.",
+      "  3. Conflict/replacement check — recall similar facts when you suspect new information may supersede an older fact. Deduplication during memory_store is automatic.",
       "Combine the natural-language query with structured filters (category, domain, entity, date range, metadata) for tighter results.",
       "If you have a known entity name and want everything about it, prefer memory_entity. For 'what does X own/use?' style questions, prefer memory_relations.",
+      `By default output is human-readable text. Use output_format=json for machine-parseable results with separate results and related arrays. Default limit is ${MEMORY_RECALL_DEFAULT_LIMIT}; maximum effective limit is ${MEMORY_RECALL_MAX_LIMIT}.`,
     ].join("\n"),
     {
       query: z.string().describe(
@@ -810,9 +824,14 @@ export function registerTools(mcp: McpServer): void {
       ),
       since: z.string().optional().describe("Only facts created on or after this ISO 8601 date or datetime."),
       until: z.string().optional().describe("Only facts created on or before this ISO 8601 date or datetime."),
-      limit: z.number().optional().default(10).describe("Max results to return (default 10)."),
+      limit: z.number().optional().default(MEMORY_RECALL_DEFAULT_LIMIT).describe(
+        `Max primary results to return (default ${MEMORY_RECALL_DEFAULT_LIMIT}, maximum ${MEMORY_RECALL_MAX_LIMIT}). Values above the maximum are clamped.`,
+      ),
       graph_depth: z.number().optional().default(0).describe(
-        "Entity-graph traversal depth. 0 = vector search only (fast, default). 1 = also surface 1-hop entity-related facts (slower; use when the user asks 'what's connected to X?').",
+        "Entity-graph traversal depth. 0 = vector search only (fast, default). 1 = also surface up to ceil(limit / 2) extra 1-hop entity-related facts (slower; use when the user asks 'what's connected to X?'). In JSON output these are returned separately as related.",
+      ),
+      output_format: z.enum(["text", "json"]).optional().default("text").describe(
+        "Response format. text = backward-compatible human-readable lines (default). json = parseable object with query, limit metadata, results, related, counts, and optional nudge.",
       ),
       metadata_filter: z.record(z.string(), z.string()).optional().describe(
         "Exact-match filter on the metadata map stored with each fact. All key/value pairs must match (AND logic).",
@@ -837,11 +856,13 @@ export function registerTools(mcp: McpServer): void {
       until,
       limit,
       graph_depth,
+      output_format,
       metadata_filter,
     }): Promise<McpToolResult> => {
       const guard = requireReady();
       if (guard) return guard;
-      const requestedLimit = limit ?? 10;
+      const requestedLimit = limit ?? MEMORY_RECALL_DEFAULT_LIMIT;
+      const effectiveLimit = clampRecallLimit(limit);
       const scope = resolveScope(workspace_id, include_legacy_workspace);
       const redactedQuery = redactStorageText(query);
       const vector = await embed(redactedQuery.text);
@@ -874,10 +895,26 @@ export function registerTools(mcp: McpServer): void {
         metadata: metadata_filter,
         excludeKinds: MEMORY_RECALL_EXCLUDED_KINDS,
       });
-      const results = await qdrantSearch(vector, filter, requestedLimit * 2);
+      const results = await qdrantSearch(vector, filter, effectiveLimit * 2);
 
       if (!results.result?.length) {
         const nudge = buildMemoryNudge();
+        if (output_format === "json") {
+          return { content: [{ type: "text", text: JSON.stringify({
+            query: redactedQuery.text,
+            requested_limit: requestedLimit,
+            effective_limit: effectiveLimit,
+            max_limit: MEMORY_RECALL_MAX_LIMIT,
+            limit_clamped: effectiveLimit !== requestedLimit,
+            graph_depth: graph_depth ?? 0,
+            result_count: 0,
+            related_count: 0,
+            results: [],
+            related: [],
+            ...(nudge ? { nudge } : {}),
+            ...(redactedQuery.redacted ? { query_redaction: redactedQuery } : {}),
+          }, null, 2) }] };
+        }
         const text = nudge ? `No matching facts found.\n\n${nudge}` : "No matching facts found.";
         return { content: [{ type: "text", text }] };
       }
@@ -885,20 +922,40 @@ export function registerTools(mcp: McpServer): void {
       const ranked = results.result
         .map((r) => ({ ...r, _combinedScore: computeCombinedScore(r) }))
         .sort((a, b) => b._combinedScore - a._combinedScore)
-        .slice(0, requestedLimit);
+        .slice(0, effectiveLimit);
 
       const lines = ranked.map((r) => formatFact(r));
+      let related: GraphTraversalResult = { points: [] };
 
       if ((graph_depth ?? 0) >= 1) {
-        const relatedLines = await graphTraversal(ranked, requestedLimit, scope);
-        if (relatedLines.length > 0) {
+        related = await graphTraversal(ranked, effectiveLimit, scope);
+        if (related.points.length > 0) {
           lines.push("", "── Related (1-hop) ──");
-          lines.push(...relatedLines);
+          lines.push(...related.points.map((r) => formatFact(r)));
+        } else if (related.error) {
+          lines.push("", `(graph traversal failed: ${related.error})`);
         }
       }
 
       const nudge = buildMemoryNudge();
       if (nudge) lines.push("", nudge);
+      if (output_format === "json") {
+        return { content: [{ type: "text", text: JSON.stringify({
+          query: redactedQuery.text,
+          requested_limit: requestedLimit,
+          effective_limit: effectiveLimit,
+          max_limit: MEMORY_RECALL_MAX_LIMIT,
+          limit_clamped: effectiveLimit !== requestedLimit,
+          graph_depth: graph_depth ?? 0,
+          result_count: ranked.length,
+          related_count: related.points.length,
+          results: ranked.map((r) => structuredFact(r)),
+          related: related.points.map((r) => structuredFact(r)),
+          ...(related.error ? { graph_error: related.error } : {}),
+          ...(nudge ? { nudge } : {}),
+          ...(redactedQuery.redacted ? { query_redaction: redactedQuery } : {}),
+        }, null, 2) }] };
+      }
       return { content: [{ type: "text", text: lines.join("\n") }] };
     },
   );


### PR DESCRIPTION
## Summary
- add optional `output_format: "json"` for `memory_recall` while preserving text output by default
- return structured primary `results` and 1-hop `related` arrays with IDs, metadata, counts, limit metadata, and optional nudges
- clamp recall limits to a documented maximum of 50 and align recall/store guidance around conflict checks

Closes #80

## Validation
- `npm run build && npm test`
- `npm run check`