### PR TITLE
Add grouped memory subtype navigation

### DIFF
--- a/packages/ui/app/src/components/FactCard.tsx
+++ b/packages/ui/app/src/components/FactCard.tsx
@@ -1,6 +1,7 @@
 import Badge from "./Badge";
 import { EntityChip } from "./EntityChip";
 import { relativeTime, truncate, CATEGORY_COLORS, KIND_COLORS } from "../lib/format";
+import { ontologyLabel } from "../lib/ontology";
 
 export interface Fact {
   id: string;
@@ -8,6 +9,7 @@ export interface Fact {
   category: string;
   domain?: string;
   kind?: string;
+  memory_subtype?: string | null;
   entities: string[];
   source?: string;
   confidence: number;
@@ -42,12 +44,15 @@ export default function FactCard({ fact, onClick }: FactCardProps) {
       </p>
 
       <div className="mt-3 flex flex-wrap items-center gap-2">
-        <Badge label={fact.category} color={CATEGORY_COLORS[fact.category]} />
+        <Badge label={ontologyLabel(fact.category)} color={CATEGORY_COLORS[fact.category]} />
         {fact.kind && fact.kind !== "fact" && (
-          <Badge label={fact.kind} color={KIND_COLORS[fact.kind]} />
+          <Badge label={ontologyLabel(fact.kind)} color={KIND_COLORS[fact.kind]} />
         )}
-        {fact.domain && fact.domain !== "work" && (
-          <Badge label={fact.domain} color="green" />
+        {fact.memory_subtype && (
+          <Badge label={ontologyLabel(fact.memory_subtype)} color={CATEGORY_COLORS[fact.category]} />
+        )}
+        {fact.domain && fact.domain !== "software_engineering" && (
+          <Badge label={ontologyLabel(fact.domain)} color="green" />
         )}
         {fact.entities.map((e) => (
           <EntityChip key={e} name={e} link={false} />

--- a/packages/ui/app/src/lib/format.ts
+++ b/packages/ui/app/src/lib/format.ts
@@ -19,11 +19,17 @@ export function truncate(str: string, max: number): string {
 }
 
 export const CATEGORY_COLORS: Record<string, string> = {
+  codebase: "blue",
   infrastructure: "blue",
+  operations: "orange",
   decisions: "purple",
-  observation: "amber",
+  product_domain: "indigo",
+  observations: "amber",
   preferences: "green",
   projects: "cyan",
+  people: "pink",
+  // Legacy facts may still carry pre-ontology category values.
+  observation: "amber",
   team: "pink",
 };
 
@@ -32,4 +38,5 @@ export const KIND_COLORS: Record<string, string> = {
   summary: "indigo",
   distilled: "violet",
   relation: "orange",
+  telemetry: "red",
 };

--- a/packages/ui/app/src/lib/ontology.ts
+++ b/packages/ui/app/src/lib/ontology.ts
@@ -1,0 +1,134 @@
+export interface OntologyOption {
+  value: string;
+  label: string;
+  description?: string;
+}
+
+export interface MemorySubtypeOption extends OntologyOption {
+  kind: string;
+  category: string;
+}
+
+export interface OntologyGroup {
+  id: string;
+  label: string;
+  description: string;
+  categories: string[];
+  subtypes: string[];
+}
+
+export const CATEGORY_OPTIONS: OntologyOption[] = [
+  { value: "codebase", label: "Codebase", description: "Repos, modules, files, APIs, and code navigation knowledge." },
+  { value: "infrastructure", label: "Infrastructure", description: "Cloud, deployment, runtime, databases, CI/CD, and environments." },
+  { value: "operations", label: "Operations", description: "Runbooks, incidents, maintenance, debugging steps, and gotchas." },
+  { value: "decisions", label: "Decisions", description: "Architecture, product, process, and technical decisions with rationale." },
+  { value: "product_domain", label: "Product domain", description: "Product concepts, workflows, business rules, and domain vocabulary." },
+  { value: "projects", label: "Projects", description: "Goals, milestones, current state, blockers, and active workstreams." },
+  { value: "people", label: "People", description: "Ownership, roles, collaboration patterns, and responsibilities." },
+  { value: "preferences", label: "Preferences", description: "User, team, or workspace preferences about style, defaults, and tooling." },
+  { value: "observations", label: "Observations", description: "Validated evidence, troubleshooting notes, and learned facts." },
+];
+
+export const DOMAIN_OPTIONS: OntologyOption[] = [
+  { value: "software_engineering", label: "Software engineering" },
+  { value: "product_strategy", label: "Product strategy" },
+  { value: "business_operations", label: "Business operations" },
+  { value: "research", label: "Research" },
+  { value: "personal_productivity", label: "Personal productivity" },
+];
+
+export const KIND_OPTIONS: OntologyOption[] = [
+  { value: "fact", label: "Fact" },
+  { value: "summary", label: "Summary" },
+  { value: "distilled", label: "Distilled" },
+  { value: "relation", label: "Relation" },
+  { value: "telemetry", label: "Telemetry" },
+];
+
+export const SOURCE_OPTIONS: OntologyOption[] = [
+  { value: "agent", label: "Agent" },
+  { value: "system", label: "System" },
+  { value: "user", label: "User" },
+  { value: "docs", label: "Docs" },
+];
+
+export const MEMORY_SUBTYPE_OPTIONS: MemorySubtypeOption[] = [
+  { value: "codebase_map", label: "Codebase map", kind: "fact", category: "codebase" },
+  { value: "architecture_decision", label: "Architecture decision", kind: "fact", category: "decisions" },
+  { value: "infra_topology", label: "Infrastructure topology", kind: "fact", category: "infrastructure" },
+  { value: "access_pattern", label: "Access pattern", kind: "fact", category: "infrastructure" },
+  { value: "operational_procedure", label: "Operational procedure", kind: "fact", category: "operations" },
+  { value: "domain_rule", label: "Domain rule", kind: "fact", category: "product_domain" },
+  { value: "troubleshooting_gotcha", label: "Troubleshooting gotcha", kind: "fact", category: "operations" },
+  { value: "preference", label: "Preference", kind: "fact", category: "preferences" },
+  { value: "session_index", label: "Session index", kind: "summary", category: "projects" },
+  { value: "episode", label: "Episode", kind: "summary", category: "projects" },
+  { value: "workstream", label: "Workstream", kind: "summary", category: "projects" },
+  { value: "convention", label: "Convention", kind: "distilled", category: "observations" },
+  { value: "recall_event", label: "Recall event", kind: "telemetry", category: "observations" },
+  { value: "feedback_event", label: "Feedback event", kind: "telemetry", category: "observations" },
+  { value: "outcome_event", label: "Outcome event", kind: "telemetry", category: "observations" },
+  { value: "aggregate_rollup", label: "Aggregate rollup", kind: "telemetry", category: "observations" },
+];
+
+export const ONTOLOGY_GROUPS: OntologyGroup[] = [
+  {
+    id: "codebase",
+    label: "Codebase & architecture",
+    description: "Where things live, how systems are structured, and why technical choices were made.",
+    categories: ["codebase", "decisions"],
+    subtypes: ["codebase_map", "architecture_decision"],
+  },
+  {
+    id: "infra-ops",
+    label: "Infrastructure & operations",
+    description: "Runtime topology, access paths, runbooks, and debugging knowledge.",
+    categories: ["infrastructure", "operations"],
+    subtypes: ["infra_topology", "access_pattern", "operational_procedure", "troubleshooting_gotcha"],
+  },
+  {
+    id: "product-projects",
+    label: "Product & projects",
+    description: "Product rules plus task, session, episode, and workstream continuity.",
+    categories: ["product_domain", "projects"],
+    subtypes: ["domain_rule", "session_index", "episode", "workstream"],
+  },
+  {
+    id: "people-preferences",
+    label: "People & preferences",
+    description: "Ownership, collaboration context, and preferred ways of working.",
+    categories: ["people", "preferences"],
+    subtypes: ["preference"],
+  },
+  {
+    id: "observations-learning",
+    label: "Observations & learning",
+    description: "Evidence, reusable conventions, and durable lessons learned.",
+    categories: ["observations"],
+    subtypes: ["convention"],
+  },
+  {
+    id: "telemetry-feedback",
+    label: "Telemetry & feedback",
+    description: "Memory-use signals, feedback events, outcomes, and aggregate quality rollups.",
+    categories: ["observations"],
+    subtypes: ["recall_event", "feedback_event", "outcome_event", "aggregate_rollup"],
+  },
+];
+
+export const SUBTYPE_BY_VALUE = Object.fromEntries(
+  MEMORY_SUBTYPE_OPTIONS.map((subtype) => [subtype.value, subtype]),
+) as Record<string, MemorySubtypeOption>;
+
+const allOptions = [
+  ...CATEGORY_OPTIONS,
+  ...DOMAIN_OPTIONS,
+  ...KIND_OPTIONS,
+  ...SOURCE_OPTIONS,
+  ...MEMORY_SUBTYPE_OPTIONS,
+];
+
+export function ontologyLabel(value: string | null | undefined): string {
+  if (!value) return "";
+  return allOptions.find((option) => option.value === value)?.label ?? value.replace(/_/g, " ");
+}

--- a/packages/ui/app/src/lib/statsCache.ts
+++ b/packages/ui/app/src/lib/statsCache.ts
@@ -6,6 +6,7 @@ export interface MemoryStats {
   superseded: number;
   byCategory: Record<string, number>;
   byKind: Record<string, number>;
+  bySubtype: Record<string, number>;
 }
 
 const TTL_MS = 30_000;

--- a/packages/ui/app/src/pages/Dashboard.tsx
+++ b/packages/ui/app/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router";
 import { ApiError } from "../lib/api";
 import { getStats, type MemoryStats } from "../lib/statsCache";
 import { CATEGORY_COLORS } from "../lib/format";
+import { MEMORY_SUBTYPE_OPTIONS, ONTOLOGY_GROUPS, SUBTYPE_BY_VALUE, ontologyLabel } from "../lib/ontology";
 import Badge from "../components/Badge";
 
 type LoadState<T> = { loading: true } | { loading: false; data: T } | { loading: false; error: string };
@@ -31,7 +32,7 @@ function CategoryBar({ category, count, max }: { category: string; count: number
   };
   return (
     <div className="flex items-center gap-3">
-      <span className="text-xs text-zinc-400 w-28 shrink-0 capitalize">{category}</span>
+      <span className="text-xs text-zinc-400 w-36 shrink-0">{ontologyLabel(category)}</span>
       <div className="flex-1 h-5 bg-zinc-800 rounded-full overflow-hidden">
         <div className={`h-full rounded-full ${bgMap[color] ?? "bg-zinc-500"}`} style={{ width: `${pct}%` }} />
       </div>
@@ -88,8 +89,9 @@ export default function Dashboard() {
     );
   }
 
-  const { active, superseded, total, byCategory, byKind } = stats.data;
+  const { active, superseded, total, byCategory, byKind, bySubtype } = stats.data;
   const maxCat = Math.max(...Object.values(byCategory), 1);
+  const subtypeTotal = Object.values(bySubtype ?? {}).reduce((sum, count) => sum + count, 0);
 
   return (
     <div>
@@ -100,7 +102,7 @@ export default function Dashboard() {
         <StatCard label="Active Facts" value={active} />
         <StatCard label="Total Stored" value={total} sub={`${superseded} superseded`} />
         <StatCard label="Categories" value={Object.keys(byCategory).length} />
-        <StatCard label="Kinds" value={Object.keys(byKind).length} />
+        <StatCard label="Subtypes" value={Object.keys(bySubtype ?? {}).length} sub={`${subtypeTotal.toLocaleString()} typed`} />
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
@@ -130,11 +132,51 @@ export default function Dashboard() {
                   to={`/memory?kind=${kind}`}
                   className="flex items-center justify-between px-3 py-2 rounded-md hover:bg-zinc-800 transition-colors"
                 >
-                  <Badge label={kind} color={kind === "fact" ? "blue" : kind === "summary" ? "purple" : kind === "distilled" ? "amber" : "cyan"} />
+                  <Badge label={ontologyLabel(kind)} color={kind === "fact" ? "blue" : kind === "summary" ? "purple" : kind === "distilled" ? "amber" : kind === "telemetry" ? "red" : "cyan"} />
                   <span className="text-sm text-zinc-300">{count}</span>
                 </Link>
               ))}
           </div>
+        </div>
+      </div>
+
+      {/* Subtype navigation */}
+      <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-5 mb-8">
+        <h3 className="text-sm font-medium text-zinc-400 mb-4">Browse by memory subtype</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+          {ONTOLOGY_GROUPS.map((group) => (
+            <div key={group.id} className="rounded-md border border-zinc-800 bg-zinc-950/50 p-3">
+              <p className="text-sm font-medium text-zinc-200">{group.label}</p>
+              <div className="mt-3 flex flex-wrap gap-1.5">
+                {group.subtypes.map((subtypeValue) => {
+                  const subtype = SUBTYPE_BY_VALUE[subtypeValue];
+                  if (!subtype) return null;
+                  const count = bySubtype?.[subtype.value] ?? 0;
+                  return (
+                    <Link
+                      key={subtype.value}
+                      to={`/memory?category=${subtype.category}&kind=${subtype.kind}&memory_subtype=${subtype.value}`}
+                      className="inline-flex items-center gap-1 rounded-md border border-zinc-800 bg-zinc-900 px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-800 transition-colors"
+                    >
+                      <span>{subtype.label}</span>
+                      <span className="text-zinc-500">{count.toLocaleString()}</span>
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="mt-4 flex flex-wrap gap-2">
+          {MEMORY_SUBTYPE_OPTIONS.map((subtype) => (
+            <Link
+              key={subtype.value}
+              to={`/memory?category=${subtype.category}&kind=${subtype.kind}&memory_subtype=${subtype.value}`}
+              className="text-xs text-zinc-500 hover:text-zinc-300"
+            >
+              {subtype.label}
+            </Link>
+          ))}
         </div>
       </div>
 

--- a/packages/ui/app/src/pages/Graph.tsx
+++ b/packages/ui/app/src/pages/Graph.tsx
@@ -56,11 +56,16 @@ interface SharedResponse {
 }
 
 const CATEGORY_HEX: Record<string, string> = {
+  codebase: "#3b82f6",
   infrastructure: "#3b82f6",
+  operations: "#f97316",
   decisions: "#a855f7",
+  product_domain: "#6366f1",
+  observations: "#f59e0b",
   observation: "#f59e0b",
   preferences: "#22c55e",
   projects: "#06b6d4",
+  people: "#ec4899",
   team: "#ec4899",
 };
 

--- a/packages/ui/app/src/pages/Memory.tsx
+++ b/packages/ui/app/src/pages/Memory.tsx
@@ -4,11 +4,16 @@ import { Search, Loader2, Database, ArrowUpDown } from "lucide-react";
 import { apiFetch } from "../lib/api";
 import { getStats, type MemoryStats as Stats } from "../lib/statsCache";
 import FactCard, { type Fact } from "../components/FactCard";
+import {
+  CATEGORY_OPTIONS,
+  DOMAIN_OPTIONS,
+  KIND_OPTIONS,
+  ONTOLOGY_GROUPS,
+  SOURCE_OPTIONS,
+  SUBTYPE_BY_VALUE,
+  ontologyLabel,
+} from "../lib/ontology";
 
-const CATEGORIES = ["infrastructure", "decisions", "observation", "preferences", "projects", "team"];
-const DOMAINS = ["work", "personal"];
-const KINDS = ["fact", "summary", "distilled", "relation"];
-const SOURCES = ["agent", "system", "user", "docs"];
 const SORT_OPTIONS = [
   { value: "newest", label: "Newest first" },
   { value: "oldest", label: "Oldest first" },
@@ -54,6 +59,7 @@ export default function Memory() {
   const [category, setCategory] = useState(searchParams.get("category") ?? "");
   const [domain, setDomain] = useState(searchParams.get("domain") ?? "");
   const [kind, setKind] = useState(searchParams.get("kind") ?? "");
+  const [memorySubtype, setMemorySubtype] = useState(searchParams.get("memory_subtype") ?? "");
   const [source, setSource] = useState(searchParams.get("source") ?? "");
   const [entity, setEntity] = useState(searchParams.get("entity") ?? "");
   const [sort, setSort] = useState(searchParams.get("sort") ?? "newest");
@@ -78,13 +84,14 @@ export default function Memory() {
     if (category) p.category = category;
     if (domain) p.domain = domain;
     if (kind) p.kind = kind;
+    if (memorySubtype) p.memory_subtype = memorySubtype;
     if (source) p.source = source;
     if (entity) p.entity = entity;
     if (sort) p.sort = sort;
     if (since) p.since = since;
     if (until) p.until = until;
     return p;
-  }, [query, category, domain, kind, source, entity, sort, since, until]);
+  }, [query, category, domain, kind, memorySubtype, source, entity, sort, since, until]);
 
   const fetchResults = useCallback(
     async (append = false, offset = 0) => {
@@ -97,6 +104,7 @@ export default function Memory() {
           if (category) params.set("category", category);
           if (domain) params.set("domain", domain);
           if (kind) params.set("kind", kind);
+          if (memorySubtype) params.set("memory_subtype", memorySubtype);
           if (source) params.set("source", source);
           if (entity) params.set("entity", entity);
           params.set("limit", String(append ? results.length + PAGE_SIZE : PAGE_SIZE));
@@ -113,6 +121,7 @@ export default function Memory() {
           if (category) params.set("category", category);
           if (domain) params.set("domain", domain);
           if (kind) params.set("kind", kind);
+          if (memorySubtype) params.set("memory_subtype", memorySubtype);
           if (source) params.set("source", source);
           if (entity) params.set("entity", entity);
           if (sort) params.set("sort", sort);
@@ -132,7 +141,7 @@ export default function Memory() {
         setLoading(false);
       }
     },
-    [query, category, domain, kind, source, entity, sort, since, until, results],
+    [query, category, domain, kind, memorySubtype, source, entity, sort, since, until, results],
   );
 
   // Initial load and filter changes
@@ -140,7 +149,7 @@ export default function Memory() {
     fetchResults();
     setSearchParams(buildParams(), { replace: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [category, domain, kind, source, entity, sort, since, until]);
+  }, [category, domain, kind, memorySubtype, source, entity, sort, since, until]);
 
   const handleSearch = () => {
     setSearchParams(buildParams(), { replace: true });
@@ -157,6 +166,42 @@ export default function Memory() {
 
   const selectCls =
     "bg-zinc-900 border border-zinc-700 rounded-md px-2 py-1.5 text-sm text-zinc-300 focus:outline-none focus:border-zinc-500";
+
+  const applyCategory = (value: string) => {
+    setCategory(value);
+    setMemorySubtype("");
+  };
+
+  const applyKind = (value: string) => {
+    setKind(value);
+    setMemorySubtype("");
+  };
+
+  const applySubtype = (value: string) => {
+    setMemorySubtype(value);
+    const subtype = SUBTYPE_BY_VALUE[value];
+    if (subtype) {
+      setKind(subtype.kind);
+      setCategory(subtype.category);
+    }
+  };
+
+  const clearOntologyFilters = () => {
+    setCategory("");
+    setDomain("");
+    setKind("");
+    setMemorySubtype("");
+    setSource("");
+  };
+
+  const pillCls = (active: boolean) =>
+    "px-2 py-1 rounded-md border text-xs transition-colors " +
+    (active
+      ? "bg-zinc-700 border-zinc-500 text-zinc-100"
+      : "bg-zinc-950 border-zinc-800 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200");
+
+  const categoryCount = (value: string) => stats?.byCategory?.[value] ?? 0;
+  const subtypeCount = (value: string) => stats?.bySubtype?.[value] ?? 0;
 
   return (
     <div>
@@ -197,30 +242,55 @@ export default function Memory() {
 
       {/* Filters */}
       <div className="flex flex-wrap gap-2 mb-4">
-        <select value={category} onChange={(e) => setCategory(e.target.value)} className={selectCls}>
+        <select value={category} onChange={(e) => applyCategory(e.target.value)} className={selectCls}>
           <option value="">All categories</option>
-          {CATEGORIES.map((c) => (
-            <option key={c} value={c}>{c}</option>
+          {CATEGORY_OPTIONS.map((c) => (
+            <option key={c.value} value={c.value}>{c.label}</option>
           ))}
         </select>
         <select value={domain} onChange={(e) => setDomain(e.target.value)} className={selectCls}>
           <option value="">All domains</option>
-          {DOMAINS.map((d) => (
-            <option key={d} value={d}>{d}</option>
+          {DOMAIN_OPTIONS.map((d) => (
+            <option key={d.value} value={d.value}>{d.label}</option>
           ))}
         </select>
-        <select value={kind} onChange={(e) => setKind(e.target.value)} className={selectCls}>
+        <select value={kind} onChange={(e) => applyKind(e.target.value)} className={selectCls}>
           <option value="">All kinds</option>
-          {KINDS.map((k) => (
-            <option key={k} value={k}>{k}</option>
+          {KIND_OPTIONS.map((k) => (
+            <option key={k.value} value={k.value}>{k.label}</option>
+          ))}
+        </select>
+        <select value={memorySubtype} onChange={(e) => applySubtype(e.target.value)} className={selectCls}>
+          <option value="">All subtypes</option>
+          {ONTOLOGY_GROUPS.map((group) => (
+            <optgroup key={group.id} label={group.label}>
+              {group.subtypes.map((subtypeValue) => {
+                const subtype = SUBTYPE_BY_VALUE[subtypeValue];
+                if (!subtype) return null;
+                return (
+                  <option key={subtype.value} value={subtype.value}>
+                    {subtype.label}
+                  </option>
+                );
+              })}
+            </optgroup>
           ))}
         </select>
         <select value={source} onChange={(e) => setSource(e.target.value)} className={selectCls}>
           <option value="">All sources</option>
-          {SOURCES.map((s) => (
-            <option key={s} value={s}>{s}</option>
+          {SOURCE_OPTIONS.map((s) => (
+            <option key={s.value} value={s.value}>{s.label}</option>
           ))}
         </select>
+        {(category || domain || kind || memorySubtype || source) && (
+          <button
+            type="button"
+            onClick={clearOntologyFilters}
+            className="px-2.5 py-1.5 rounded-md text-sm text-zinc-500 hover:text-zinc-300"
+          >
+            Clear ontology
+          </button>
+        )}
         {entity && (
           <div className="flex items-center gap-1.5 px-2.5 py-1.5 bg-zinc-800 border border-zinc-700 rounded-md text-sm text-zinc-300">
             entity: {entity}
@@ -232,6 +302,67 @@ export default function Memory() {
             </button>
           </div>
         )}
+      </div>
+
+      {/* Ontology navigation */}
+      <div className="mb-6 rounded-lg border border-zinc-800 bg-zinc-900/60 p-4">
+        <div className="flex items-start justify-between gap-4 mb-3">
+          <div>
+            <h3 className="text-sm font-medium text-zinc-200">Explore by memory ontology</h3>
+            <p className="text-xs text-zinc-500 mt-0.5">
+              Grouped by the canonical Bikky taxonomy so codebase, projects, observations, and telemetry are easy to browse.
+            </p>
+          </div>
+          {memorySubtype && (
+            <button
+              type="button"
+              onClick={() => setMemorySubtype("")}
+              className="text-xs text-zinc-500 hover:text-zinc-300"
+            >
+              Clear subtype
+            </button>
+          )}
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+          {ONTOLOGY_GROUPS.map((group) => (
+            <div key={group.id} className="rounded-lg border border-zinc-800 bg-zinc-950/60 p-3">
+              <p className="text-sm font-medium text-zinc-200">{group.label}</p>
+              <p className="text-xs text-zinc-500 mt-1 min-h-8">{group.description}</p>
+              <div className="mt-3 flex flex-wrap gap-1.5">
+                {group.categories.map((cat) => (
+                  <button
+                    key={cat}
+                    type="button"
+                    onClick={() => applyCategory(cat)}
+                    className={pillCls(category === cat && !memorySubtype)}
+                    title={`${categoryCount(cat).toLocaleString()} facts`}
+                  >
+                    {ontologyLabel(cat)}
+                    {stats && <span className="ml-1 text-zinc-500">{categoryCount(cat).toLocaleString()}</span>}
+                  </button>
+                ))}
+              </div>
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {group.subtypes.map((subtypeValue) => {
+                  const subtype = SUBTYPE_BY_VALUE[subtypeValue];
+                  if (!subtype) return null;
+                  return (
+                    <button
+                      key={subtype.value}
+                      type="button"
+                      onClick={() => applySubtype(subtype.value)}
+                      className={pillCls(memorySubtype === subtype.value)}
+                      title={`${subtype.kind} / ${ontologyLabel(subtype.category)}`}
+                    >
+                      {subtype.label}
+                      {stats && <span className="ml-1 text-zinc-500">{subtypeCount(subtype.value).toLocaleString()}</span>}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
 
       {/* Sort & date range */}

--- a/packages/ui/app/src/pages/MemoryFact.tsx
+++ b/packages/ui/app/src/pages/MemoryFact.tsx
@@ -3,12 +3,10 @@ import { useParams, useNavigate, Link } from "react-router";
 import { ArrowLeft, Pencil, Trash2, Loader2, Save, X } from "lucide-react";
 import { apiFetch, ApiError } from "../lib/api";
 import { relativeTime, CATEGORY_COLORS, KIND_COLORS } from "../lib/format";
+import { CATEGORY_OPTIONS, DOMAIN_OPTIONS, ontologyLabel } from "../lib/ontology";
 import Badge from "../components/Badge";
 import { EntityChip } from "../components/EntityChip";
 import type { Fact } from "../components/FactCard";
-
-const CATEGORIES = ["infrastructure", "decisions", "observation", "preferences", "projects", "team"];
-const DOMAINS = ["work", "personal"];
 
 export default function MemoryFact() {
   const { id } = useParams<{ id: string }>();
@@ -36,7 +34,7 @@ export default function MemoryFact() {
         setFact(f);
         setEditContent(f.content);
         setEditCategory(f.category);
-        setEditDomain(f.domain ?? "work");
+        setEditDomain(f.domain ?? "software_engineering");
         setEditEntities(f.entities.join(", "));
       })
       .catch((e) => setError(e instanceof ApiError ? e.message : "Failed to load fact"))
@@ -83,7 +81,7 @@ export default function MemoryFact() {
     setEditing(false);
     setEditContent(fact.content);
     setEditCategory(fact.category);
-    setEditDomain(fact.domain ?? "work");
+    setEditDomain(fact.domain ?? "software_engineering");
     setEditEntities(fact.entities.join(", "));
   };
 
@@ -113,6 +111,12 @@ export default function MemoryFact() {
 
   const selectCls =
     "bg-zinc-900 border border-zinc-700 rounded-md px-2 py-1.5 text-sm text-zinc-300 focus:outline-none focus:border-zinc-500";
+  const categoryOptions = CATEGORY_OPTIONS.some((c) => c.value === editCategory) || !editCategory
+    ? CATEGORY_OPTIONS
+    : [{ value: editCategory, label: `Legacy: ${editCategory}` }, ...CATEGORY_OPTIONS];
+  const domainOptions = DOMAIN_OPTIONS.some((d) => d.value === editDomain) || !editDomain
+    ? DOMAIN_OPTIONS
+    : [{ value: editDomain, label: `Legacy: ${editDomain}` }, ...DOMAIN_OPTIONS];
 
   return (
     <div>
@@ -206,22 +210,23 @@ export default function MemoryFact() {
           {editing ? (
             <>
               <select value={editCategory} onChange={(e) => setEditCategory(e.target.value)} className={selectCls}>
-                {CATEGORIES.map((c) => (
-                  <option key={c} value={c}>{c}</option>
+                {categoryOptions.map((c) => (
+                  <option key={c.value} value={c.value}>{c.label}</option>
                 ))}
               </select>
               <select value={editDomain} onChange={(e) => setEditDomain(e.target.value)} className={selectCls}>
-                {DOMAINS.map((d) => (
-                  <option key={d} value={d}>{d}</option>
+                {domainOptions.map((d) => (
+                  <option key={d.value} value={d.value}>{d.label}</option>
                 ))}
               </select>
             </>
           ) : (
             <>
-              <Badge label={fact.category} color={CATEGORY_COLORS[fact.category]} size="md" />
-              {fact.kind && <Badge label={fact.kind} color={KIND_COLORS[fact.kind]} size="md" />}
-              {fact.domain && <Badge label={fact.domain} color={fact.domain === "personal" ? "green" : "zinc"} size="md" />}
-              {fact.source && <Badge label={fact.source} size="md" />}
+              <Badge label={ontologyLabel(fact.category)} color={CATEGORY_COLORS[fact.category]} size="md" />
+              {fact.kind && <Badge label={ontologyLabel(fact.kind)} color={KIND_COLORS[fact.kind]} size="md" />}
+              {fact.memory_subtype && <Badge label={ontologyLabel(fact.memory_subtype)} color={CATEGORY_COLORS[fact.category]} size="md" />}
+              {fact.domain && <Badge label={ontologyLabel(fact.domain)} color={fact.domain === "personal_productivity" ? "green" : "zinc"} size="md" />}
+              {fact.source && <Badge label={ontologyLabel(fact.source)} size="md" />}
             </>
           )}
         </div>

--- a/packages/ui/src/lib/qdrant.test.ts
+++ b/packages/ui/src/lib/qdrant.test.ts
@@ -46,12 +46,13 @@ describe("ui/lib/qdrant", () => {
       assert.deepEqual(f.must, [{ is_null: { key: "superseded_by" } }]);
     });
 
-    it("adds match conditions for category, domain, kind, source", () => {
-      const f = buildFilter({ category: "infra", domain: "work", kind: "fact", source: "agent" });
+    it("adds match conditions for category, domain, kind, subtype, source", () => {
+      const f = buildFilter({ category: "infra", domain: "work", kind: "fact", memorySubtype: "codebase_map", source: "agent" });
       assert.deepEqual(f.must, [
         { key: "category", match: { value: "infra" } },
         { key: "domain", match: { value: "work" } },
         { key: "kind", match: { value: "fact" } },
+        { key: "memory_subtype", match: { value: "codebase_map" } },
         { key: "source", match: { any: ["agent", "cortex"] } },
       ]);
     });

--- a/packages/ui/src/lib/qdrant.ts
+++ b/packages/ui/src/lib/qdrant.ts
@@ -12,6 +12,7 @@ export interface FactPayload {
   category: string;
   domain?: string;
   kind?: string;
+  memory_subtype?: string | null;
   entities: string[];
   source?: string;
   confidence: number;
@@ -166,6 +167,7 @@ export function buildFilter(opts: {
   category?: string;
   domain?: string;
   kind?: string;
+  memorySubtype?: string;
   entity?: string;
   source?: string;
   since?: string;
@@ -179,6 +181,7 @@ export function buildFilter(opts: {
   if (opts.category) must.push({ key: "category", match: { value: opts.category } });
   if (opts.domain) must.push({ key: "domain", match: { value: opts.domain } });
   if (opts.kind) must.push({ key: "kind", match: { value: opts.kind } });
+  if (opts.memorySubtype) must.push({ key: "memory_subtype", match: { value: opts.memorySubtype } });
   if (opts.entity) must.push({ key: "entities", match: { value: opts.entity.toLowerCase() } });
   if (opts.source) must.push({ key: "source", match: sourceFilterValue(opts.source) });
   if (opts.since) must.push({ key: "created_at", range: { gte: opts.since } });

--- a/packages/ui/src/routes/memory.test.ts
+++ b/packages/ui/src/routes/memory.test.ts
@@ -164,7 +164,7 @@ describe("ui/routes/memory", () => {
       });
       const app = buildApp();
 
-      const res = await app.fetch(new Request("http://localhost/api/memory/search?q=hello&category=infrastructure&source=system&limit=5"));
+      const res = await app.fetch(new Request("http://localhost/api/memory/search?q=hello&category=infrastructure&memory_subtype=codebase_map&source=system&limit=5"));
       assert.equal(res.status, 200);
       const body = await res.json() as { results: any[]; count: number };
       assert.equal(body.count, 1);
@@ -176,6 +176,10 @@ describe("ui/routes/memory", () => {
       assert.equal(search!.body.limit, 5);
       assert.equal(search!.body.filter.must[0].match.value, "infrastructure");
       assert.deepEqual(search!.body.filter.must[1], {
+        key: "memory_subtype",
+        match: { value: "codebase_map" },
+      });
+      assert.deepEqual(search!.body.filter.must[2], {
         key: "source",
         match: { any: ["system", "daemon"] },
       });
@@ -216,6 +220,19 @@ describe("ui/routes/memory", () => {
       await app.fetch(new Request("http://localhost/api/memory/browse?offset=cursor-1"));
       const scroll = log.calls.find((c) => c.path.endsWith("/points/scroll"));
       assert.equal(scroll!.body.offset, "cursor-1");
+    });
+
+    it("forwards memory_subtype to Qdrant filters", async () => {
+      const log = installMock({
+        qdrantHandler: () => ({ result: { points: [], next_page_offset: null } }),
+      });
+      const app = buildApp();
+
+      await app.fetch(new Request("http://localhost/api/memory/browse?memory_subtype=workstream"));
+      const scroll = log.calls.find((c) => c.path.endsWith("/points/scroll"));
+      assert.ok(scroll!.body.filter.must.some((cond: any) =>
+        cond.key === "memory_subtype" && cond.match?.value === "workstream",
+      ));
     });
   });
 
@@ -536,7 +553,7 @@ describe("ui/routes/memory", () => {
   });
 
   describe("GET /stats", () => {
-    it("returns total/active/superseded counts and per-category/per-kind breakdowns", async () => {
+    it("returns total/active/superseded counts and ontology breakdowns", async () => {
       let pointsCount = 100;
       installMock({
         qdrantHandler: (c) => {
@@ -556,12 +573,20 @@ describe("ui/routes/memory", () => {
 
       const res = await app.fetch(new Request("http://localhost/api/memory/stats"));
       assert.equal(res.status, 200);
-      const body = await res.json() as { total: number; active: number; superseded: number; byCategory: Record<string, number>; byKind: Record<string, number> };
+      const body = await res.json() as {
+        total: number;
+        active: number;
+        superseded: number;
+        byCategory: Record<string, number>;
+        byKind: Record<string, number>;
+        bySubtype: Record<string, number>;
+      };
       assert.equal(body.total, 100);
       assert.equal(body.active, 90);
       assert.equal(body.superseded, 10);
-      assert.equal(body.byCategory.infrastructure, 10);
+      assert.equal(body.byCategory.codebase, 10);
       assert.equal(body.byKind.fact, 10);
+      assert.equal(body.bySubtype.codebase_map, 10);
     });
   });
 });

--- a/packages/ui/src/routes/memory.ts
+++ b/packages/ui/src/routes/memory.ts
@@ -10,6 +10,39 @@ import { addRedactionPayload, combineRedactions, redactStorageText } from "../li
 
 export const memoryRoutes = new Hono();
 
+const CATEGORY_VALUES = [
+  "codebase",
+  "infrastructure",
+  "operations",
+  "decisions",
+  "product_domain",
+  "projects",
+  "people",
+  "preferences",
+  "observations",
+] as const;
+
+const KIND_VALUES = ["fact", "summary", "distilled", "relation", "telemetry"] as const;
+
+const MEMORY_SUBTYPE_VALUES = [
+  "codebase_map",
+  "architecture_decision",
+  "infra_topology",
+  "access_pattern",
+  "operational_procedure",
+  "domain_rule",
+  "troubleshooting_gotcha",
+  "preference",
+  "session_index",
+  "episode",
+  "workstream",
+  "convention",
+  "recall_event",
+  "feedback_event",
+  "outcome_event",
+  "aggregate_rollup",
+] as const;
+
 function formatPoint(p: QdrantPoint) {
   return { id: p.id, score: p.score ?? null, ...p.payload };
 }
@@ -48,7 +81,7 @@ function cacheSet<T>(key: string, value: T, ttlMs: number): void {
 const STATS_TTL_MS = 30_000;
 const GRAPH_TTL_MS = 60_000;
 
-// GET /api/memory/search?q=...&category=...&entity=...&domain=...&kind=...&limit=...
+// GET /api/memory/search?q=...&category=...&entity=...&domain=...&kind=...&memory_subtype=...&limit=...
 memoryRoutes.get("/search", async (c) => {
   const q = c.req.query("q");
   if (!q) return c.json({ error: "Missing query parameter 'q'" }, 400);
@@ -64,6 +97,7 @@ memoryRoutes.get("/search", async (c) => {
     category: c.req.query("category"),
     domain: c.req.query("domain"),
     kind: c.req.query("kind"),
+    memorySubtype: c.req.query("memory_subtype"),
     entity: c.req.query("entity"),
     source: c.req.query("source"),
     excludeEntityType: true,
@@ -76,7 +110,7 @@ memoryRoutes.get("/search", async (c) => {
   return c.json({ results: points.map(formatPoint), count: points.length });
 });
 
-// GET /api/memory/browse?category=...&entity=...&kind=...&domain=...&source=...&since=...&until=...&sort=...&limit=...&offset=...
+// GET /api/memory/browse?category=...&entity=...&kind=...&memory_subtype=...&domain=...&source=...&since=...&until=...&sort=...&limit=...&offset=...
 memoryRoutes.get("/browse", async (c) => {
   const qdrant = createQdrantClient();
 
@@ -84,6 +118,7 @@ memoryRoutes.get("/browse", async (c) => {
     category: c.req.query("category"),
     domain: c.req.query("domain"),
     kind: c.req.query("kind"),
+    memorySubtype: c.req.query("memory_subtype"),
     entity: c.req.query("entity"),
     source: c.req.query("source"),
     since: c.req.query("since"),
@@ -552,14 +587,12 @@ memoryRoutes.get("/stats", async (c) => {
     try { return await qdrant.count(filter); } catch { return 0; }
   };
 
-  const categories = ["infrastructure", "decisions", "observation", "preferences", "projects", "team"];
-  const kinds = ["fact", "summary", "distilled", "relation"];
-
-  // All counts in one Promise.all instead of three sequential awaits.
-  const [info, catCounts, kindCounts, allCount] = await Promise.all([
+  // All counts in one Promise.all instead of several sequential awaits.
+  const [info, catCounts, kindCounts, subtypeCounts, allCount] = await Promise.all([
     qdrant.collectionInfo(),
-    Promise.all(categories.map(async (cat) => [cat, await safeCount(buildFilter({ category: cat }))] as const)),
-    Promise.all(kinds.map(async (k) => [k, await safeCount(buildFilter({ kind: k }))] as const)),
+    Promise.all(CATEGORY_VALUES.map(async (cat) => [cat, await safeCount(buildFilter({ category: cat }))] as const)),
+    Promise.all(KIND_VALUES.map(async (k) => [k, await safeCount(buildFilter({ kind: k }))] as const)),
+    Promise.all(MEMORY_SUBTYPE_VALUES.map(async (subtype) => [subtype, await safeCount(buildFilter({ memorySubtype: subtype }))] as const)),
     safeCount({ must: [] }),
   ]);
 
@@ -569,6 +602,7 @@ memoryRoutes.get("/stats", async (c) => {
     superseded: info.points_count - allCount,
     byCategory: Object.fromEntries(catCounts),
     byKind: Object.fromEntries(kindCounts),
+    bySubtype: Object.fromEntries(subtypeCounts),
   };
   cacheSet(cacheKey, payload, STATS_TTL_MS);
   return c.json(payload);


### PR DESCRIPTION
## Summary
- add canonical UI ontology metadata for categories, domains, kinds, sources, and memory subtypes
- support memory_subtype filtering/searching and subtype stats in the UI API
- add grouped ontology navigation, subtype badges, dashboard subtype browsing, and canonical labels while preserving legacy fact values in edit selectors

## Verification
- cd packages/ui && npm run build && npm test
- temporary UI server smoke on port 1423 for /health, subtype stats, and memory_subtype browse filtering

Closes #82