### PR TITLE
chore(ci): add Dependabot, CI, CodeQL; fix lint and CVE

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,69 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "bikky-core"
+    groups:
+      typescript:
+        patterns:
+          - "typescript"
+          - "@types/*"
+          - "ts-*"
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "@typescript-eslint/*"
+      aws-sdk:
+        patterns:
+          - "@aws-sdk/*"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/ui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "bikky-ui"
+    groups:
+      typescript:
+        patterns:
+          - "typescript"
+          - "@types/*"
+          - "ts-*"
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "@typescript-eslint/*"
+      react:
+        patterns:
+          - "react"
+          - "react-*"
+          - "@types/react*"
+      vite:
+        patterns:
+          - "vite"
+          - "vite-*"
+          - "@vitejs/*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bikky-core:
+    name: bikky core (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ["20", "22"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Audit (production deps, fail on high+)
+        run: npm audit --omit=dev --audit-level=high
+
+  bikky-ui:
+    name: bikky-ui (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/ui
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ["20", "22"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+          cache-dependency-path: packages/ui/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Audit (production deps, fail on high+)
+        run: npm audit --omit=dev --audit-level=high

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+          config: |
+            paths-ignore:
+              - dist
+              - packages/ui/dist
+              - packages/ui/app/dist
+              - node_modules
+              - "**/*.test.ts"
+              - "**/*.test.tsx"
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1064,6 +1064,18 @@
         }
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
@@ -2762,9 +2774,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
       "funding": [
         {
           "type": "github",
@@ -2773,9 +2785,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "typescript": "^5.8.0",
     "typescript-eslint": "^8.0.0"
   },
+  "overrides": {
+    "fast-xml-parser": "^5.7.0"
+  },
   "engines": {
     "node": ">=20.0.0"
   },

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1168,7 +1168,7 @@ export function registerTools(mcp: McpServer): void {
         const now = nowISO();
         try {
           const scope = resolveScope(workspace_id);
-          const actor = resolveActorIdentity({ config: loadConfig() });
+          const _actor = resolveActorIdentity({ config: loadConfig() });
         const existing = await getPointForWorkspaceWrite(fact_id, scope);
         if (existing.error) {
           return { content: [{ type: "text", text: JSON.stringify(existing.error, null, 2) }], isError: true };
@@ -1217,7 +1217,7 @@ export function registerTools(mcp: McpServer): void {
       const now = nowISO();
       try {
         const scope = resolveScope(workspace_id);
-        const actor = resolveActorIdentity({ config: loadConfig() });
+        const _actor = resolveActorIdentity({ config: loadConfig() });
         const writable = await getPointForWorkspaceWrite(fact_id, scope);
         if (writable.error) {
           return { content: [{ type: "text", text: JSON.stringify(writable.error, null, 2) }], isError: true };


### PR DESCRIPTION
Public-release prep — Phase 1 (CI/security tooling) + minimum Phase 3 fixes.

Task: tasks/282-bikky-public-release-prep

CI / security tooling:
- .github/dependabot.yml — weekly grouped npm updates for / and /packages/ui plus github-actions
- .github/workflows/ci.yml — PR + push validation on Node 20 and 22 for both packages (typecheck, lint, test, npm audit --audit-level=high)
- .github/workflows/codeql.yml — javascript-typescript security-and-quality scan on PR, push, and weekly schedule

Fixes:
- src/mcp/tools.ts — rename unused actor -> _actor in memory_forget and memory_verify handlers (was blocking lint)
- package.json — add fast-xml-parser >= 5.7.0 override to clear CVE-2026-41650 (medium), transitive via @aws-sdk/xml-builder

Verification:
- npm run lint clean
- npm audit reports 0 vulnerabilities (was: 2 moderate)
- npm test — 535/535 passing
- npm run build clean

Out of scope (follow-up PR): SECURITY.md, CODEOWNERS, issue/PR templates, code-of-conduct, packages/ui lint script, secret-scan sweep.

Note: CodeQL job will be skipped until Code Scanning is enabled (free on public repos, requires Advanced Security on private). Activates automatically when repo is flipped public.