### PR TITLE
chore(docs): add public-release hygiene files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Default owners for everything in the repo.
+# Pull requests automatically request a review from these owners.
+* @saber-zrelli-private
+
+# Workflows / CI changes — extra eyes on anything that touches release or security tooling.
+/.github/        @saber-zrelli-private

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,63 @@
+name: Bug report
+description: Report a reproducible problem in bikky or bikky-ui
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! Please include enough detail to reproduce it.
+
+  - type: input
+    id: package
+    attributes:
+      label: Package and version
+      description: e.g. `bikky@0.3.8` or `bikky-ui@0.1.10`
+      placeholder: bikky@0.3.8
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug. What did you expect, and what did you see instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps that trigger the bug. A small code snippet or command sequence is ideal.
+      placeholder: |
+        1. Run `npx bikky-ui`
+        2. Open http://localhost:3001
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / output
+      description: Paste any relevant log output, stack traces, or error messages. Please redact secrets.
+      render: shell
+
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      description: OS, Node version, and (if relevant) MCP client (Copilot, Claude Code, Cursor, …).
+      placeholder: macOS 14.5, Node 22.3.0, Claude Code
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: hygiene
+    attributes:
+      label: Confirmation
+      options:
+        - label: I have searched existing issues and this is not a duplicate.
+          required: true
+        - label: I am on the latest minor release of the affected package (or have explained why I can't upgrade).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/bikky-dev/bikky/security/advisories/new
+    about: Please report security issues privately via GitHub Security Advisories — do NOT open a public issue.
+  - name: Question or discussion
+    url: https://github.com/bikky-dev/bikky/discussions
+    about: Have a usage question or want to discuss an idea? Start a Discussion instead of an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature request
+description: Suggest a new capability or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the use case, not the solution. What are you trying to do, and why is it hard today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work? CLI flag, MCP tool, UI affordance, config option, …
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you've tried, or other designs you considered.
+
+  - type: checkboxes
+    id: hygiene
+    attributes:
+      label: Confirmation
+      options:
+        - label: I have searched existing issues and discussions for similar requests.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- What does this PR change, and why? Link the issue it fixes (e.g. "fixes #123"). -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change (behaviour or API)
+- [ ] Documentation only
+- [ ] Refactor / internal cleanup
+- [ ] CI / tooling
+
+## Testing
+
+<!-- How did you verify this works? `npm test` output, manual repro steps, screenshots for UI. -->
+
+## Checklist
+
+- [ ] `npm run lint` passes
+- [ ] `npm run typecheck` passes
+- [ ] `npm test` passes
+- [ ] Docs updated (README, CONTRIBUTING, or inline JSDoc) if behaviour changed
+- [ ] No secrets, tokens, or PII in the diff

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,80 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in
+the bikky community a harassment-free experience for everyone, regardless of
+age, body size, visible or invisible disability, ethnicity, sex characteristics,
+gender identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behaviour that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologising to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behaviour:
+
+- The use of sexualised language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards
+of acceptable behaviour and will take appropriate and fair corrective action in
+response to any behaviour that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces (issues, PRs,
+Discussions, Discord/Slack if any), and also applies when an individual is
+officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
+reported to the project maintainers via the GitHub Security Advisories private
+reporting flow at:
+https://github.com/bikky-dev/bikky/security/advisories/new
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All maintainers are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Maintainers will follow these Community Impact Guidelines in determining the
+consequences for any action they deem in violation of this Code of Conduct:
+
+1. **Correction** — Private, written warning. A public apology may be requested.
+2. **Warning** — A warning with consequences for continued behaviour.
+3. **Temporary ban** — A temporary ban from any sort of interaction or public
+   communication with the community.
+4. **Permanent ban** — Permanent ban from any sort of public interaction within
+   the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org/), version 2.1,
+available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,58 @@
+# Security Policy
+
+Thanks for helping keep bikky and its users safe.
+
+## Supported Versions
+
+Security fixes land on the latest minor release of each package:
+
+| Package    | Supported versions       |
+| ---------- | ------------------------ |
+| `bikky`    | latest minor (`0.3.x`)   |
+| `bikky-ui` | latest minor (`0.1.x`)   |
+
+Older versions are not patched. If you're on an old version, please upgrade before reporting a vulnerability that may already be fixed.
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security reports.**
+
+Use GitHub's private vulnerability reporting:
+
+1. Go to https://github.com/bikky-dev/bikky/security/advisories/new
+2. Fill in the details — include reproduction steps, affected versions, and impact.
+3. Submit. We'll get an email and respond from there.
+
+If you can't use GitHub for any reason, open a regular issue titled "Security contact request" (no details) and we'll arrange a private channel.
+
+## What to Expect
+
+| When                                | What happens                                                                  |
+| ----------------------------------- | ----------------------------------------------------------------------------- |
+| Within **3 business days**          | We acknowledge the report and confirm we can reproduce (or ask for more info). |
+| Within **7 business days**          | We share an initial assessment: severity, affected versions, intended fix.    |
+| Within **90 days** (typical)        | We ship a patched release and publish a GitHub Security Advisory with credit.  |
+
+For critical issues actively being exploited, we'll move faster and coordinate disclosure timing with you.
+
+## Scope
+
+In scope:
+- The `bikky` npm package (CLI, MCP server, daemon).
+- The `bikky-ui` npm package (local web UI server + frontend).
+- The default daemon, postinstall scripts, and any code shipped in either tarball.
+
+Out of scope:
+- Vulnerabilities in dependencies that are already tracked upstream (please report to the upstream maintainer).
+- Vulnerabilities that require physical access to the user's machine or already-compromised credentials.
+- Findings from automated scanners with no demonstrated impact.
+- Issues in third-party services bikky integrates with (Qdrant Cloud, OpenAI, etc.) — report those to the respective vendors.
+
+## Safe Harbor
+
+We support good-faith security research. If you make a reasonable effort to comply with this policy, we will:
+- Not pursue legal action against you for the research.
+- Work with you to understand and resolve the issue quickly.
+- Recognise your contribution publicly (with your permission) in the advisory and release notes.
+
+Thank you for helping make bikky safer for everyone.


### PR DESCRIPTION
Public-release prep — Phase 2 (task tasks/282-bikky-public-release-prep). Stacks on top of #87.

Adds the standard files needed before flipping the repo public:

- SECURITY.md — vulnerability disclosure policy, GHSA-based reporting, 90-day coordinated disclosure
- CODE_OF_CONDUCT.md — Contributor Covenant 2.1
- .github/CODEOWNERS — default reviewer assignments
- .github/PULL_REQUEST_TEMPLATE.md — checklist for contributors
- .github/ISSUE_TEMPLATE/bug_report.yml — structured bug template
- .github/ISSUE_TEMPLATE/feature_request.yml — feature template
- .github/ISSUE_TEMPLATE/config.yml — disable blank issues, route security to private advisories and questions to GitHub Discussions

No code or behaviour changes. Safe to merge after #87.