### PR TITLE
fix(ci): build before test in bikky-core job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Build
+        run: npm run build
+
       - name: Test
         run: npm test
 


### PR DESCRIPTION
Follow-up to #87. The CI run on main failed because the root test script greps for compiled dist/**/*.test.js files; on a fresh CI checkout dist/ is empty, so node --test falls back to scanning src/**/*.test.ts and can't resolve compiled .js imports.

Adding an explicit `npm run build` step before `npm test` in the bikky-core job. The bikky-ui job already runs `tsc &&` inline as part of its test script, so no change needed there.