### PR TITLE
feat(workspace): default scope also matches legacy unscoped facts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bikky",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Shared memory for AI coding sessions — MCP server + background daemon",
   "type": "module",
   "license": "AGPL-3.0-or-later",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bikky-ui",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Local web UI for browsing and managing bikky memory",
   "type": "module",
   "license": "AGPL-3.0-or-later",

--- a/packages/ui/src/lib/qdrant.test.ts
+++ b/packages/ui/src/lib/qdrant.test.ts
@@ -328,6 +328,40 @@ describe("ui/lib/qdrant", () => {
       const body = JSON.parse(String(calls[0]!.init.body));
       assert.deepEqual(body.filter, { must: [] });
     });
+
+    it('treats workspaceId="default" as default OR legacy (no workspace_id)', async () => {
+      const client = new QdrantClient("https://q.test:6333", null, "col", "default");
+      const calls = installMock(() => new Response(JSON.stringify({
+        result: { points: [], next_page_offset: null },
+      }), { status: 200 }));
+
+      await client.scroll({ must: [{ key: "kind", match: { value: "fact" } }] });
+      const body = JSON.parse(String(calls[0]!.init.body));
+      assert.deepEqual(body.filter.must, [
+        { key: "kind", match: { value: "fact" } },
+        {
+          should: [
+            { key: "workspace_id", match: { value: "default" } },
+            { is_empty: { key: "workspace_id" } },
+          ],
+        },
+      ]);
+    });
+
+    it('default workspace getPoints includes legacy facts with no workspace_id', async () => {
+      const client = new QdrantClient("https://q.test:6333", null, "col", "default");
+      installMock(() => new Response(JSON.stringify({
+        result: [
+          { id: "1", payload: { workspace_id: "default" } },
+          { id: "2", payload: { workspace_id: "agent00" } },
+          { id: "3", payload: {} },
+          { id: "4", payload: { workspace_id: null } },
+        ],
+      }), { status: 200 }));
+
+      const points = await client.getPoints(["1", "2", "3", "4"]);
+      assert.deepEqual(points.map((p) => p.id), ["1", "3", "4"]);
+    });
   });
 
   it("QdrantNotConfiguredError carries a helpful message", () => {

--- a/packages/ui/src/lib/qdrant.ts
+++ b/packages/ui/src/lib/qdrant.ts
@@ -53,6 +53,12 @@ export interface FilterCondition {
   match?: { value?: string | number; any?: string[] };
   range?: { gte?: string; lte?: string };
   is_null?: { key: string };
+  is_empty?: { key: string };
+  // Nested sub-filter — Qdrant allows must/should/must_not entries to themselves
+  // be filter objects, which are AND/OR-combined like a parenthesised group.
+  must?: FilterCondition[];
+  should?: FilterCondition[];
+  must_not?: FilterCondition[];
 }
 
 export interface QdrantFilter {
@@ -136,13 +142,26 @@ export class QdrantClient {
   }
 
   /**
-   * If a workspace is active, append `workspace_id == <ws>` to the filter's
-   * `must` clauses so every query is scoped to that workspace. Returns the
-   * filter unchanged when no workspace is active.
+   * If a workspace is active, append a workspace filter to the query's `must`
+   * clauses so every query is scoped to that workspace.
+   *
+   * Special case: when the active workspace is the literal name `"default"`,
+   * we also include legacy facts that have no `workspace_id` payload (i.e.
+   * pre-migration data captured before workspaces existed). Implemented as a
+   * nested OR sub-filter so it ANDs cleanly with any existing `should` clauses
+   * (e.g. category alias OR groups) on the parent filter.
    */
   private scoped(filter?: QdrantFilter): QdrantFilter | undefined {
     if (!this.workspaceId) return filter;
-    const cond: FilterCondition = { key: "workspace_id", match: { value: this.workspaceId } };
+    const isDefault = this.workspaceId === "default";
+    const cond: FilterCondition = isDefault
+      ? {
+          should: [
+            { key: "workspace_id", match: { value: "default" } },
+            { is_empty: { key: "workspace_id" } },
+          ],
+        }
+      : { key: "workspace_id", match: { value: this.workspaceId } };
     if (!filter) return { must: [cond] };
     return { ...filter, must: [...filter.must, cond] };
   }
@@ -184,9 +203,11 @@ export class QdrantClient {
       ids, with_payload: true,
     });
     if (!this.workspaceId) return res.result;
+    const isDefault = this.workspaceId === "default";
     // Filter by workspace post-fetch since /points doesn't accept a filter.
     return res.result.filter((p) => {
       const ws = (p.payload as unknown as { workspace_id?: string | null }).workspace_id;
+      if (isDefault) return ws === "default" || ws == null || ws === "";
       return ws === this.workspaceId;
     });
   }

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -16,7 +16,7 @@
 import { describe, it, before, beforeEach, after } from "node:test";
 import assert from "node:assert/strict";
 
-import { registerTools } from "./tools.js";
+import { registerTools, resolveScope } from "./tools.js";
 import {
   setQdrantUrl,
   setQdrantApiKey,
@@ -1005,5 +1005,33 @@ describe("mcp/tools handlers", () => {
       assert.equal(sp.superseded_by, parsed.distilled_id);
       assert.ok(sp.superseded_at);
     });
+  });
+});
+
+describe("resolveScope", () => {
+  const savedEnv = process.env.BIKKY_WORKSPACE;
+  before(() => {
+    delete process.env.BIKKY_WORKSPACE;
+  });
+  after(() => {
+    if (savedEnv === undefined) delete process.env.BIKKY_WORKSPACE;
+    else process.env.BIKKY_WORKSPACE = savedEnv;
+  });
+
+  it("auto-enables includeLegacy when scope resolves to literal 'default'", () => {
+    const scope = resolveScope("default");
+    assert.equal(scope.workspaceId, "default");
+    assert.equal(scope.includeLegacy, true);
+  });
+
+  it("keeps includeLegacy=false for any other named workspace", () => {
+    const scope = resolveScope("agent00");
+    assert.equal(scope.workspaceId, "agent00");
+    assert.equal(scope.includeLegacy, false);
+  });
+
+  it("honours explicit includeLegacyWorkspace=true regardless of workspace name", () => {
+    const scope = resolveScope("agent00", true);
+    assert.equal(scope.includeLegacy, true);
   });
 });

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -100,15 +100,19 @@ interface WorkspaceScope {
   includeLegacy: boolean;
 }
 
-function resolveScope(workspaceId?: string, includeLegacyWorkspace = false, actorId?: string): WorkspaceScope {
+export function resolveScope(workspaceId?: string, includeLegacyWorkspace = false, actorId?: string): WorkspaceScope {
   const resolved = workspaceId?.trim()
     || process.env.BIKKY_WORKSPACE?.trim()
     || loadConfig().default_workspace?.trim()
     || undefined;
+  // The literal "default" workspace also includes legacy facts that have no
+  // workspace_id payload (pre-migration data). Any other named workspace stays
+  // strict. An explicit includeLegacyWorkspace=true from the caller still wins.
+  const isDefault = resolved === "default";
   return {
     workspaceId: resolved,
     actorId: normalizeActorId(actorId),
-    includeLegacy: includeLegacyWorkspace,
+    includeLegacy: includeLegacyWorkspace || isDefault,
   };
 }
 


### PR DESCRIPTION
## Summary

When the active workspace resolves to the literal name `"default"`, queries now match facts with `workspace_id == "default"` **OR** facts with no `workspace_id` payload (pre-migration legacy data). All other named workspaces stay strict.

## Why

Users on the legacy `default` workspace were unable to see their pre-migration facts (which have no `workspace_id` payload at all). UI subtype counts showed 0 for nearly every subtype because the OR-with-unscoped path wasn't wired into the new default-workspace flow.

## Changes

- **core** `src/mcp/tools.ts`: `resolveScope()` auto-enables `includeLegacy` when the resolved scope is exactly `"default"`. `buildFilter` already handled the OR-with-`is_empty` shape via the existing `includeLegacyWorkspace` branch — no changes needed there.
- **ui** `packages/ui/src/lib/qdrant.ts`: `QdrantClient.scoped()` uses a nested Qdrant sub-filter (`should: [match default, is_empty]`) for the default case so it ANDs cleanly with other `should` clauses (e.g. category alias OR groups). `getPoints()` post-filter mirrors the same.
- Tests added on both sides.

## Versions

- `bikky` 0.3.11 → 0.3.12
- `bikky-ui` 0.1.12 → 0.1.13

## Verification

- `npm run build && npm test` (core): 538 / 538 passing
- `npm run build && npm test` (ui): 86 / 86 passing