### PR TITLE
docs: fix README inaccuracies and document workspaces

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,9 +22,15 @@ jobs:
       matrix:
         language: [javascript-typescript]
     steps:
+      - name: CodeQL disabled
+        if: ${{ vars.BIKKY_CODEQL_ENABLED != 'true' }}
+        run: echo "CodeQL upload requires GitHub code scanning/Advanced Security. Set repository variable BIKKY_CODEQL_ENABLED=true after enabling code scanning."
+
       - uses: actions/checkout@v4
+        if: ${{ vars.BIKKY_CODEQL_ENABLED == 'true' }}
 
       - name: Initialize CodeQL
+        if: ${{ vars.BIKKY_CODEQL_ENABLED == 'true' }}
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
@@ -39,9 +45,11 @@ jobs:
               - "**/*.test.tsx"
 
       - name: Autobuild
+        if: ${{ vars.BIKKY_CODEQL_ENABLED == 'true' }}
         uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
+        if: ${{ vars.BIKKY_CODEQL_ENABLED == 'true' }}
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ ollama pull qwen3-embedding:0.6b
 
 # 3. Install and start bikky
 npm install -g bikky
+mkdir -p ~/.bikky
 echo '{ "qdrant_url": "http://localhost:6333" }' > ~/.bikky/config.json
 bikky setup            # writes MCP config for Copilot + Claude Code, then starts the daemon
 ```
@@ -104,6 +105,27 @@ export QDRANT_URL="http://localhost:6333"
 
 > 💡 **Tip:** Set `BIKKY_HOME` to relocate the config dir (defaults to `~/.bikky/`). Useful for tests, multiple profiles, or sandboxed setups.
 
+### Workspaces — isolating personal vs team memory
+
+A *workspace* is a logical namespace inside the same Qdrant collection. Use it to keep personal-project memory separate from your team's shared memory, or to split unrelated work surfaces.
+
+| Source (highest priority first) | How to set |
+|---|---|
+| Explicit param on a tool call | `memory_store({..., workspace_id: "team-x"})` |
+| Environment variable | `BIKKY_WORKSPACE=team-x` (set on the agent / MCP client process) |
+| Config default | `{"default_workspace": "team-x"}` in `~/.bikky/config.json` |
+| Unset | Writes are unscoped; reads return everything |
+
+The literal workspace name `"default"` has a special read semantic: queries scoped to `"default"` also return legacy facts that have no `workspace_id` payload. All other named workspaces are strict.
+
+```bash
+# Personal solo work — set in your shell profile
+export BIKKY_WORKSPACE="solo"
+
+# Team shared memory — typically set via config or per-MCP-client env
+echo '{"qdrant_url":"...","default_workspace":"team-x"}' > ~/.bikky/config.json
+```
+
 > 📖 **Full configuration reference** — providers, models, daemon settings, env vars, copy-paste examples for every stack: **[docs/configuration.md](docs/configuration.md)**
 >
 > 🛠 Want to add a new embedding or LLM provider (Vertex, OpenRouter, etc.)? See **[CONTRIBUTING.md](CONTRIBUTING.md)** — it's a single-file change.
@@ -118,7 +140,7 @@ export QDRANT_URL="http://localhost:6333"
 
 **MCP Server** — tools your agent calls directly:
 
-`memory_store` · `memory_recall` · `memory_entity` · `memory_relations` · `memory_forget` · `memory_verify` · `memory_heartbeat` · `memory_review` · `configure_credentials` · `verify_connection`
+`memory_store` · `memory_recall` · `memory_entity` · `memory_relations` · `memory_forget` · `memory_verify` · `memory_mark_useful` · `memory_report_outcome` · `memory_session_summary` · `memory_distill` · `memory_heartbeat` · `memory_review` · `get_setup_status` · `configure_credentials` · `verify_connection`
 
 **Daemon** — background process that passively watches session logs, extracts structured facts, writes lightweight session indexes, captures coherent episode summaries, updates current-state workstream summaries, infers entity relationships from recently changed facts, and runs the consolidation pipeline. Lifecycle memory is daemon-owned so agents do not need to remember summary/distillation tool calls.
 
@@ -190,7 +212,7 @@ Raw fact accumulation creates noise. bikky keeps the knowledge store clean autom
 
 ## Web UI
 
-[`bikky-ui`](packages/ui) is a local dashboard for browsing and managing your team's memory — facts, entities, quality metrics, aggregate impact insights, and the relationship graph.
+[`bikky-ui`](https://www.npmjs.com/package/bikky-ui) is a local dashboard for browsing and managing your team's memory — facts, entities, quality metrics, aggregate impact insights, and the relationship graph.
 
 ```bash
 npx bikky-ui          # one-shot — no install needed

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ bikky gives AI coding agents (GitHub Copilot, Claude Code, Cursor, and other MCP
   <img src="https://cdn.jsdelivr.net/npm/bikky@latest/docs/diagrams/team-memory.svg" alt="Memory — facts flow from individual sessions into a self-curating knowledge store, shared across your team (or kept just for you)" width="720" />
 </p>
 
-<p align="center"><i>Knowledge flows from every session into a store that curates itself over time — deduplicating, distilling, and decaying stale facts — so every future session starts smarter. Share the workspace across a team, or keep it solo.</i></p>
+<p align="center"><i>Knowledge flows from every session into a store that curates itself over time — deduplicating, distilling, and decaying stale facts — so every future session starts smarter. Share it across a team, or keep it solo.</i></p>
 
 ---
 
@@ -36,7 +36,7 @@ The most valuable things you and your agents learn — why a config value exists
 
 ## Quick start
 
-The fastest way to try bikky: **100% local, free, no accounts** — Qdrant in Docker, embeddings via Ollama.
+The easiest way to try bikky is **100% local, free, and account-free**: Qdrant in Docker, embeddings via Ollama. bikky has one required setting: where Qdrant lives. Everything else has local defaults.
 
 ```bash
 # 1. Pull and run Qdrant (vector store)
@@ -45,67 +45,63 @@ docker run -d --name qdrant -p 6333:6333 -v qdrant_storage:/qdrant/storage qdran
 # 2. Install Ollama (https://ollama.com) and pull the default embedding model
 ollama pull qwen3-embedding:0.6b
 
-# 3. Install and start bikky
+# 3. Install bikky
 npm install -g bikky
 mkdir -p ~/.bikky
 echo '{ "qdrant_url": "http://localhost:6333" }' > ~/.bikky/config.json
+
+# 4. Register bikky with your editor and start the background service
 bikky setup            # writes MCP config for Copilot + Claude Code, then starts the daemon
 ```
 
-Restart your editor — the memory tools (`memory_store`, `memory_recall`, …) appear automatically.
+Restart your editor. The memory tools appear automatically in supported MCP clients.
 
 ```bash
-bikky status           # validate config, Qdrant, embeddings, daemon, and UI health
+bikky status           # confirms Qdrant, embeddings, daemon, and UI health
 ```
 
-That's the whole thing. From here you can swap any piece (hosted Qdrant, OpenAI / Bedrock embeddings, a hosted LLM for richer daemon distillation) — see **Setup** below.
+That's it. You can use the local setup forever, or swap in hosted pieces later.
 
 ---
 
-## Setup
+## Setup options
 
-### Prerequisites
+Start with the local path unless you already know you want hosted infrastructure.
+
+### What you need
 
 | | Required | Options |
 |---|---|---|
 | **Node.js** | ≥ 20 | `nvm install 20` or your package manager |
-| **Vector store** | Qdrant | **Local Docker** (free, recommended for dev) · **[Qdrant Cloud](https://cloud.qdrant.io)** (free tier, 1 GB) · **Self-hosted** anywhere reachable |
-| **Embeddings** | One provider | **[Ollama](https://ollama.com)** local (free, default) · **OpenAI** · **AWS Bedrock** · **[Portkey](https://portkey.ai)** gateway |
-| **LLM** *(optional)* | Used by the daemon for distillation & extraction | Same provider list as embeddings — leave on Ollama for a fully-local stack |
+| **Vector store** | Qdrant | Local Docker (recommended first) · [Qdrant Cloud](https://cloud.qdrant.io) · Self-hosted |
+| **Embeddings** | One provider | Ollama local by default · OpenAI / Bedrock / Portkey if you prefer hosted |
 | **Docker** *(optional)* | Only if you run Qdrant locally | Docker Desktop, OrbStack, colima, etc. |
 
-### Install
+### Choose a setup
 
-```bash
-npm install -g bikky          # CLI + MCP server + daemon
-npm install -g bikky-ui       # optional web dashboard
-```
-
-### Pick your stack
-
-- **Fully local & free** — Qdrant in Docker + Ollama. Best for solo dev, no data leaves your machine. (See Quick start.)
-- **Hosted Qdrant + local Ollama** — Qdrant Cloud free tier for shared/team memory; embeddings still local.
-- **Fully hosted** — Qdrant Cloud + OpenAI / Bedrock / Portkey for embeddings and LLM. Best for teams that want a single shared memory across many machines.
+| Setup | Best for | Config |
+|---|---|---|
+| **Local and free** | First install, solo use, private testing | `{"qdrant_url":"http://localhost:6333"}` |
+| **Hosted Qdrant + local Ollama** | Sharing memory across machines while keeping embeddings local | Add your Qdrant Cloud URL and API key |
+| **Fully hosted** | Teams that want managed vector storage and hosted models | Add Qdrant plus provider settings in [`docs/configuration.md`](docs/configuration.md) |
 
 ### Configure
 
-Three ways to provide credentials, pick one:
+Most users only need one of these:
 
 ```bash
-# A) Let your agent do it
-> "Call configure_credentials with my Qdrant URL (and API key if needed)"
+mkdir -p ~/.bikky
 
-# B) Config file (~/.bikky/config.json)
+# Local Qdrant
 echo '{ "qdrant_url": "http://localhost:6333" }' > ~/.bikky/config.json
 
-# C) Environment variables
-export QDRANT_URL="http://localhost:6333"
-# export QDRANT_API_KEY="…"   # only for Qdrant Cloud / authenticated self-hosted
+# Qdrant Cloud
+echo '{ "qdrant_url": "https://your-cluster.cloud.qdrant.io:6333", "qdrant_api_key": "your-key" }' > ~/.bikky/config.json
 ```
 
-> 💡 **Tip:** Set `BIKKY_HOME` to relocate the config dir (defaults to `~/.bikky/`). Useful for tests, multiple profiles, or sandboxed setups.
+You can also set `QDRANT_URL` and `QDRANT_API_KEY` as environment variables. For hosted models, custom providers, multiple profiles, or advanced tuning, use the full configuration guide.
 
-> 📖 **Full configuration reference** — providers, models, daemon settings, env vars, copy-paste examples for every stack: **[docs/configuration.md](docs/configuration.md)**
+> 📖 **Full configuration guide:** [docs/configuration.md](docs/configuration.md)
 >
 > 🛠 Want to add a new embedding or LLM provider (Vertex, OpenRouter, etc.)? See **[CONTRIBUTING.md](CONTRIBUTING.md)** — it's a single-file change.
 
@@ -117,11 +113,9 @@ export QDRANT_URL="http://localhost:6333"
   <img src="https://cdn.jsdelivr.net/npm/bikky@latest/docs/diagrams/architecture.svg" alt="Architecture" width="600" />
 </p>
 
-**MCP Server** — tools your agent calls directly:
+**MCP tools** — your agent can store, recall, verify, and review memory without you wiring anything manually.
 
-`memory_store` · `memory_recall` · `memory_entity` · `memory_relations` · `memory_forget` · `memory_verify` · `memory_mark_useful` · `memory_report_outcome` · `memory_session_summary` · `memory_distill` · `memory_heartbeat` · `memory_review` · `get_setup_status` · `configure_credentials` · `verify_connection`
-
-**Daemon** — background process that passively watches session logs, extracts structured facts, writes lightweight session indexes, captures coherent episode summaries, updates current-state workstream summaries, infers entity relationships from recently changed facts, and runs the consolidation pipeline. Lifecycle memory is daemon-owned so agents do not need to remember summary/distillation tool calls.
+**Background service** — `bikky setup` starts a local daemon that keeps memory current. You do not need to manage sessions, summaries, or maintenance jobs yourself.
 
 ---
 
@@ -130,7 +124,7 @@ export QDRANT_URL="http://localhost:6333"
 Raw fact accumulation creates noise. bikky keeps the knowledge store clean automatically:
 
 - **Deduplication** — content hash + vector similarity merges near-identical facts
-- **Ontology scope fields** — optional `workspace_id`, repo, workstream, and episode metadata make recall more precise
+- **Context fields** — repo, task, and source metadata make recall more precise when available
 - **Confidence decay** — old facts lose weight and surface for review
 - **Contradiction detection** — conflicting facts are resolved, not silently stacked
 - **Distillation** — recurring patterns across sessions consolidate into higher-level insights
@@ -179,26 +173,7 @@ bikky ui        # launch the local web dashboard
 bikky render    # render a prompt to JSON (for eval harnesses & debugging)
 ```
 
-`bikky status` is the first thing to run when setup feels wrong. It validates the
-config file, highlights env vars that override it, checks Qdrant reachability and
-payload-index readiness without mutating the collection, runs a live embedding
-smoke check, validates the configured LLM provider name without sending a chat
-request, and reports daemon maintenance plus UI health. Use `bikky status --json` for automation,
-`--no-live` to skip the embedding call, and `--no-ui` to skip the local UI probe.
-
-### `bikky render` — inspect prompts
-
-Render any of bikky'''s prompts to JSON without booting the MCP server. Useful for
-external evaluation harnesses, prompt debugging, and reproducing model calls.
-
-```bash
-bikky render --list                                    # list available prompts
-echo '''{"transcript":"..."}''' | bikky render extraction  # via stdin
-bikky render extraction --input case.json              # via file
-```
-
-Output: a JSON object with `promptName`, `messages`, `temperature`,
-`max_tokens`, and `response_format` — exactly what bikky sends to the LLM.
+`bikky status` is the first thing to run when setup feels wrong. It checks the config, Qdrant, embeddings, background daemon, and local UI health, then tells you what needs attention. Use `bikky status --json` for automation.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -105,27 +105,6 @@ export QDRANT_URL="http://localhost:6333"
 
 > 💡 **Tip:** Set `BIKKY_HOME` to relocate the config dir (defaults to `~/.bikky/`). Useful for tests, multiple profiles, or sandboxed setups.
 
-### Workspaces — isolating personal vs team memory
-
-A *workspace* is a logical namespace inside the same Qdrant collection. Use it to keep personal-project memory separate from your team's shared memory, or to split unrelated work surfaces.
-
-| Source (highest priority first) | How to set |
-|---|---|
-| Explicit param on a tool call | `memory_store({..., workspace_id: "team-x"})` |
-| Environment variable | `BIKKY_WORKSPACE=team-x` (set on the agent / MCP client process) |
-| Config default | `{"default_workspace": "team-x"}` in `~/.bikky/config.json` |
-| Unset | Writes are unscoped; reads return everything |
-
-The literal workspace name `"default"` has a special read semantic: queries scoped to `"default"` also return legacy facts that have no `workspace_id` payload. All other named workspaces are strict.
-
-```bash
-# Personal solo work — set in your shell profile
-export BIKKY_WORKSPACE="solo"
-
-# Team shared memory — typically set via config or per-MCP-client env
-echo '{"qdrant_url":"...","default_workspace":"team-x"}' > ~/.bikky/config.json
-```
-
 > 📖 **Full configuration reference** — providers, models, daemon settings, env vars, copy-paste examples for every stack: **[docs/configuration.md](docs/configuration.md)**
 >
 > 🛠 Want to add a new embedding or LLM provider (Vertex, OpenRouter, etc.)? See **[CONTRIBUTING.md](CONTRIBUTING.md)** — it's a single-file change.

--- a/README.md
+++ b/README.md
@@ -146,57 +146,6 @@ echo '{"qdrant_url":"...","default_workspace":"team-x"}' > ~/.bikky/config.json
 
 ---
 
-## Memory ontology
-
-bikky separates what a memory is about from where it came from. New captures use four top-level categories, concrete subtypes, small object kinds, activity domains, and provenance fields:
-
-```text
-Workspace
-  Domain
-    Project / repo / surface
-      Workstream
-        Episodes
-          Facts, decisions, preferences, activity events, operational notes
-        Current-state summaries
-          What matters now, open questions, blockers
-    Cross-cutting memory
-      Durable patterns, entity relationships, telemetry
-```
-
-This gives each memory enough context to be recalled precisely without forcing every note into a rigid project hierarchy.
-
-`category` is the broad subject area:
-
-| Category | Captures |
-|----------|----------|
-| `engineering` | Codebase maps, architecture decisions, infrastructure topology, access patterns, operational procedures, troubleshooting gotchas, and engineering conventions |
-| `product` | Domain rules, product decisions, requirements, user workflows, roadmap items, success metrics, and market insight |
-| `human` | Preferences, person profiles, ownership notes, working agreements, and durable actor-action activity events |
-| `system` | Bikky lifecycle memory: session indexes, episodes, workstreams, recall/feedback/outcome telemetry, and aggregate rollups |
-
-`memory_subtype` is the precise capture shape inside a category:
-
-| Category | Subtypes |
-|----------|----------|
-| `engineering` | `codebase_map`, `architecture_decision`, `infra_topology`, `access_pattern`, `operational_procedure`, `troubleshooting_gotcha`, `convention` |
-| `product` | `domain_rule`, `product_decision`, `product_requirement`, `user_workflow`, `roadmap_item`, `success_metric`, `market_insight` |
-| `human` | `preference`, `person_profile`, `ownership_note`, `working_agreement`, `activity_event` |
-| `system` | `session_index`, `episode`, `workstream`, `recall_event`, `feedback_event`, `outcome_event`, `aggregate_rollup` |
-
-`domain` is an activity/knowledge profile. The initial canonical domains are:
-
-| Domain | Purpose |
-|--------|---------|
-| `software_engineering` | Default for coding-agent captures: repos, code, infrastructure, releases, incidents |
-| `product_strategy` | Roadmap, positioning, experiments, customer insight, product decisions |
-| `business_operations` | Company processes, vendors, compliance, obligations, recurring workflows |
-| `research` | Source-backed investigation, hypotheses, contradictions, synthesis |
-| `personal_productivity` | Individual goals, routines, preferences, projects, habits |
-
-`kind` stays small (`fact`, `summary`, `distilled`, `relation`, `telemetry`). `source` is the creator class (`agent`, `system`, `user`, or `docs`). `actor_id` records the stable person or agent associated with a capture/action, and `workspace_id` scopes shared team memory. Legacy stored categories are read through compatibility aliases; this release does not migrate existing stored memories in place.
-
----
-
 ## Self-curation
 
 Raw fact accumulation creates noise. bikky keeps the knowledge store clean automatically:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,169 +1,31 @@
 # Configuration
 
-Config lives at `~/.bikky/config.json`, or `BIKKY_HOME/config.json` when `BIKKY_HOME` is set. Resolution order: **defaults → config file → env vars** (highest wins).
+bikky is designed to start with one required setting: **where Qdrant lives**. Everything else has local defaults.
 
-## Qdrant (required)
+```bash
+mkdir -p ~/.bikky
+echo '{ "qdrant_url": "http://localhost:6333" }' > ~/.bikky/config.json
+bikky status
+```
 
-| Setting | Env var | Default | Description |
-|---------|---------|---------|-------------|
-| `qdrant_url` | `QDRANT_URL` | *none — must be set* | Qdrant REST URL, e.g. `http://localhost:6333` (local Docker) or `https://abc123.cloud.qdrant.io:6333` (Cloud) |
-| `qdrant_api_key` | `QDRANT_API_KEY` | *none (optional)* | Qdrant API key. Required for Qdrant Cloud and any self-hosted instance with `QDRANT__SERVICE__API_KEY` set; leave unset for plain local Docker. |
-| `collection` | `BIKKY_COLLECTION` | `bikky` | Collection name. Change only if running multiple instances |
+Config lives at `~/.bikky/config.json`, or at `BIKKY_HOME/config.json` when `BIKKY_HOME` is set. Environment variables override the config file.
 
-## Ontology scope fields
+## Common setups
 
-Bikky's ontology includes optional scope payload fields such as `workspace_id`, `repo`, `branch`, `task_key`, `workstream_key`, and `episode_id`. These fields can be supplied through MCP calls or filled in by the daemon when it has enough context.
+### Local and free
 
-## Embedding & LLM providers
-
-Both `embedding.provider` and `llm.provider` accept one of four built-in values:
-
-| Value | What it is | Auth needed | `base_url` used? |
-|-------|-----------|-------------|-----------------|
-| `ollama` | Local Ollama server | None | ✅ default `http://localhost:11434` |
-| `openai` | OpenAI-compatible API | `api_key` or `OPENAI_API_KEY` | ✅ default `https://api.openai.com` |
-| `bedrock` | AWS Bedrock | AWS credentials (env or IAM role) | ❌ uses AWS SDK |
-| `portkey` | [Portkey](https://portkey.ai) gateway (routes to OpenAI / Anthropic / Bedrock / etc.) | `api_key` (Portkey key) | ✅ default `https://api.portkey.ai` |
-
-> **⚠️ Only these four values are valid.** Any other value is rejected at boot — the MCP server starts up but `requireReady` returns `setup_required` with a `setup_error` message until you fix the config. To add a new provider, see [CONTRIBUTING.md](../CONTRIBUTING.md).
-
-### Embedding config
-
-| Setting | Env var | Default |
-|---------|---------|---------|
-| `embedding.provider` | `EMBEDDING_PROVIDER` | `ollama` |
-| `embedding.model` | `EMBEDDING_MODEL` | `qwen3-embedding:0.6b` |
-| `embedding.dimensions` | `EMBEDDING_DIMENSIONS` | `1024` |
-| `embedding.base_url` | `EMBEDDING_BASE_URL` | `http://localhost:11434` |
-| `embedding.api_key` | `OPENAI_API_KEY` | — |
-
-**Models by provider:**
-
-| Provider | Recommended models | Dimensions |
-|----------|-------------------|------------|
-| `ollama` | `qwen3-embedding:0.6b`, `nomic-embed-text` | `1024`, `768` |
-| `openai` | `text-embedding-3-small`, `text-embedding-3-large` | `1536`, `3072` |
-| `bedrock` | `amazon.titan-embed-text-v2:0` | `1024` |
-| `portkey` | `@openai/text-embedding-3-small`, `@openai/text-embedding-3-large` (namespaced via Portkey routing) | `1536`, `3072` |
-
-> **⚠️ `dimensions` must match your model's output.** Mismatched dimensions will cause Qdrant insert errors. If you change the model, update dimensions too.
-
-### LLM config (used by daemon for extraction & consolidation)
-
-| Setting | Env var | Default |
-|---------|---------|---------|
-| `llm.provider` | `LLM_PROVIDER` | `ollama` |
-| `llm.model` | `LLM_MODEL` | `qwen2.5:7b` |
-| `llm.base_url` | `LLM_BASE_URL` | `http://localhost:11434` |
-| `llm.api_key` | `OPENAI_API_KEY` | — |
-| `llm.extra.region` | `AWS_BEDROCK_REGION` / `AWS_REGION` | `us-east-1` |
-
-**Models by provider:**
-
-| Provider | Recommended models |
-|----------|-------------------|
-| `ollama` | `qwen2.5:7b`, `llama3.1:8b`, or any local model |
-| `openai` | `gpt-4.1-mini`, `gpt-4.1` |
-| `bedrock` | `us.anthropic.claude-sonnet-4-20250514`, `anthropic.claude-3-5-haiku-20241022-v1:0` |
-| `portkey` | `@openai/gpt-4o-mini`, `@anthropic/claude-3-5-haiku-latest`, or any model exposed by your Portkey workspace |
-
-> Bedrock reads `embedding.extra.region` and `llm.extra.region`. `AWS_BEDROCK_REGION`
-> populates both, falling back to `AWS_REGION`; `aws_profile` or `AWS_PROFILE`
-> selects the shared AWS profile when you are not using direct env credentials.
-
-**Portkey extras** (optional, set via `extra.*` or `BIKKY_LLM_EXTRA_<KEY>` / `BIKKY_EMBEDDING_EXTRA_<KEY>` env vars):
-
-| Extra | Sent as header | Purpose |
-|-------|----------------|---------|
-| `virtual_key` | `x-portkey-virtual-key` | Server-side credential alias for the underlying provider |
-| `config_id` | `x-portkey-config` | Saved Portkey config bundle (routing / fallback / guardrails) |
-
-### Provider auth quick-reference
-
-| Provider | What to set |
-|----------|------------|
-| `ollama` | Nothing — just have Ollama running locally (`ollama serve`) |
-| `openai` | `OPENAI_API_KEY` env var **or** `"api_key": "sk-..."` in the embedding/llm config block |
-| `bedrock` | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` env vars, or an IAM instance role |
-| `portkey` | `"api_key": "<portkey-key>"` in the embedding/llm config block (sent as `x-portkey-api-key`) |
-
-### Resilience knobs (timeouts & retries)
-
-Both `embedding` and `llm` accept three optional fields that control how HTTP
-calls to providers behave when things go wrong (network blips, 5xx, 429s).
-These also work for the OpenAI-compatible `portkey` provider.
-
-| Setting | Env var | Default |
-|---------|---------|---------|
-| `embedding.timeout_ms` | `BIKKY_EMBEDDING_TIMEOUT_MS` | `30000` |
-| `embedding.retries` | `BIKKY_EMBEDDING_RETRIES` | `2` |
-| `embedding.retry_base_delay_ms` | `BIKKY_EMBEDDING_RETRY_BASE_DELAY_MS` | `250` |
-| `llm.timeout_ms` | `BIKKY_LLM_TIMEOUT_MS` | `30000` |
-| `llm.retries` | `BIKKY_LLM_RETRIES` | `2` |
-| `llm.retry_base_delay_ms` | `BIKKY_LLM_RETRY_BASE_DELAY_MS` | `250` |
-
-Behaviour:
-
-- `timeout_ms` is per-attempt (each retry gets its own clock).
-- Retries use full-jitter exponential backoff capped at 5s, and honour
-  `Retry-After` response headers (capped at 60s).
-- Only `transient` (5xx, 408), `rate_limit` (429), and `timeout` errors are
-  retried. `auth` (401/403) and `bad_request` (400/404/422) fail fast — they
-  won't get better with retries.
-
-### Setup errors and `requireReady`
-
-If embedding init or Qdrant init fails at boot (bad provider name, missing
-collection, unreachable host, etc.), the MCP server still starts. Tools that
-need ready storage call `requireReady`, which returns a `setup_required`
-payload that now includes a human-readable `setup_error` field:
+Use this first. Qdrant runs locally and Ollama provides the default embedding + LLM models.
 
 ```json
 {
-  "setup_required": true,
-  "missing": ["qdrant-url"],
-  "setup_error": "embedding init failed: [openai] (401): invalid api key"
+  "qdrant_url": "http://localhost:6333"
 }
 ```
 
-`get_setup_status` exposes the same info for MCP diagnostics. From the terminal,
-run `bikky status`.
+### Hosted Qdrant, local models
 
-### `bikky status`
+Use this when you want the memory database shared across machines, but still want embeddings and LLM calls to stay local.
 
-`bikky status` is read-only. It does not create collections, add indexes, repair
-config, or send an LLM chat request. It reports:
-
-| Check | What it does |
-|-------|--------------|
-| Config | Parses `~/.bikky/config.json` (or `BIKKY_HOME/config.json`), validates common schema/type mistakes, and lists active env overrides |
-| Qdrant | Checks reachability, collection existence, vector size, and payload-index readiness against Bikky's canonical index list |
-| Embedding | Validates the provider config and runs a small live embedding request by default |
-| LLM | Validates provider and fallback provider names without a live inference call |
-| Daemon/UI | Reports daemon PID state, maintenance-worker summaries, and probes the local UI `/health` endpoint |
-
-Useful options:
-
-```bash
-bikky status --json     # machine-readable report
-bikky status --no-live  # skip the live embedding request
-bikky status --no-ui    # skip the local UI health probe
-```
-
-`bikky status` exits non-zero when required setup is broken, such as invalid
-JSON, unknown provider names, missing Qdrant configuration, unreachable Qdrant,
-or embedding connectivity/dimension failures. Missing Qdrant payload indexes are
-reported as warnings because they affect query performance/readiness but can be
-repaired separately by normal startup readiness logic.
-
-After changing provider, Qdrant, or AWS settings, restart the long-running
-processes that already loaded the old config: run `bikky stop && bikky start`
-for the daemon, and restart your editor so its MCP server process re-reads the
-file and env vars.
-
-## Copy-paste examples
-
-**Ollama (default — zero config):**
 ```json
 {
   "qdrant_url": "https://your-cluster.cloud.qdrant.io:6333",
@@ -171,7 +33,10 @@ file and env vars.
 }
 ```
 
-**OpenAI embeddings + LLM:**
+### Hosted Qdrant and hosted models
+
+Use this when you want the whole stack managed. This example uses OpenAI-compatible hosted models:
+
 ```json
 {
   "qdrant_url": "https://your-cluster.cloud.qdrant.io:6333",
@@ -190,7 +55,107 @@ file and env vars.
 }
 ```
 
-**Portkey gateway (routes to OpenAI / Anthropic / Bedrock / …):**
+After changing Qdrant or provider settings, restart long-running processes:
+
+```bash
+bikky stop && bikky start
+```
+
+Then restart your editor so its MCP server process reloads the config.
+
+## Environment variables
+
+Use env vars when you do not want to write credentials to the config file:
+
+```bash
+export QDRANT_URL="http://localhost:6333"
+export QDRANT_API_KEY="..."  # only needed for Qdrant Cloud or authenticated self-hosted Qdrant
+```
+
+Useful basics:
+
+| Env var | Config field | Notes |
+|---|---|---|
+| `QDRANT_URL` | `qdrant_url` | Required unless set in config |
+| `QDRANT_API_KEY` | `qdrant_api_key` | Needed for Qdrant Cloud |
+| `BIKKY_HOME` | — | Moves the config/log/state directory from `~/.bikky` |
+
+## Provider options
+
+You can keep the defaults unless you want hosted models.
+
+| Provider | Best for | Auth |
+|---|---|---|
+| `ollama` | Local and free defaults | None |
+| `openai` | Simple hosted models | `OPENAI_API_KEY` or `api_key` |
+| `bedrock` | AWS-managed models | AWS credentials or IAM role |
+| `portkey` | Gateway/routing over other providers | Portkey API key |
+
+<details>
+<summary>Advanced: full setting reference</summary>
+
+### Qdrant
+
+| Setting | Env var | Default | Description |
+|---|---|---|---|
+| `qdrant_url` | `QDRANT_URL` | none | Qdrant REST URL |
+| `qdrant_api_key` | `QDRANT_API_KEY` | none | Required for Qdrant Cloud/authenticated self-hosted Qdrant |
+| `collection` | `BIKKY_COLLECTION` | `bikky` | Collection name |
+
+### Embeddings
+
+| Setting | Env var | Default |
+|---|---|---|
+| `embedding.provider` | `EMBEDDING_PROVIDER` | `ollama` |
+| `embedding.model` | `EMBEDDING_MODEL` | `qwen3-embedding:0.6b` |
+| `embedding.dimensions` | `EMBEDDING_DIMENSIONS` | `1024` |
+| `embedding.base_url` | `EMBEDDING_BASE_URL` | `http://localhost:11434` |
+| `embedding.api_key` | `OPENAI_API_KEY` | — |
+
+Common model dimensions:
+
+| Provider | Model | Dimensions |
+|---|---|---|
+| `ollama` | `qwen3-embedding:0.6b` | `1024` |
+| `ollama` | `nomic-embed-text` | `768` |
+| `openai` | `text-embedding-3-small` | `1536` |
+| `openai` | `text-embedding-3-large` | `3072` |
+| `bedrock` | `amazon.titan-embed-text-v2:0` | `1024` |
+
+If you change the embedding model, make sure `embedding.dimensions` matches the model output.
+
+### LLM
+
+The LLM is used by background maintenance features. Ollama is the default.
+
+| Setting | Env var | Default |
+|---|---|---|
+| `llm.provider` | `LLM_PROVIDER` | `ollama` |
+| `llm.model` | `LLM_MODEL` | `qwen2.5:7b` |
+| `llm.base_url` | `LLM_BASE_URL` | `http://localhost:11434` |
+| `llm.api_key` | `OPENAI_API_KEY` | — |
+| `llm.extra.region` | `AWS_BEDROCK_REGION` / `AWS_REGION` | `us-east-1` |
+
+### Timeouts and retries
+
+| Setting | Env var | Default |
+|---|---|---|
+| `embedding.timeout_ms` | `BIKKY_EMBEDDING_TIMEOUT_MS` | `30000` |
+| `embedding.retries` | `BIKKY_EMBEDDING_RETRIES` | `2` |
+| `embedding.retry_base_delay_ms` | `BIKKY_EMBEDDING_RETRY_BASE_DELAY_MS` | `250` |
+| `llm.timeout_ms` | `BIKKY_LLM_TIMEOUT_MS` | `30000` |
+| `llm.retries` | `BIKKY_LLM_RETRIES` | `2` |
+| `llm.retry_base_delay_ms` | `BIKKY_LLM_RETRY_BASE_DELAY_MS` | `250` |
+
+Retries use jittered exponential backoff for transient errors, rate limits, and timeouts. Authentication and bad-request errors fail fast.
+
+</details>
+
+<details>
+<summary>Advanced: Portkey and Bedrock examples</summary>
+
+### Portkey gateway
+
 ```json
 {
   "qdrant_url": "https://your-cluster.cloud.qdrant.io:6333",
@@ -210,7 +175,8 @@ file and env vars.
 }
 ```
 
-**AWS Bedrock:**
+### AWS Bedrock
+
 ```json
 {
   "qdrant_url": "https://your-cluster.cloud.qdrant.io:6333",
@@ -228,69 +194,85 @@ file and env vars.
 }
 ```
 
-## Daemon settings
+Bedrock reads `embedding.extra.region` and `llm.extra.region`. `AWS_BEDROCK_REGION` populates both, falling back to `AWS_REGION`; `aws_profile` or `AWS_PROFILE` selects the shared AWS profile when you are not using direct env credentials.
 
-The daemon owns memory lifecycle work: it extracts structured facts, writes lightweight session indexes, captures coherent episode summaries, and distills longer-lived patterns when consolidation is enabled. Cost-sensitive maintenance workers use wall-clock intervals plus a persistent cursor in `~/.bikky/state/maintenance-state.json`, so relation inference and entity typing process recently changed facts instead of rescanning all memory on every cycle.
+</details>
+
+<details>
+<summary>Advanced: workspace and metadata scoping</summary>
+
+Most users do not need to manage scopes manually. bikky can store optional metadata such as `workspace_id`, `repo`, `branch`, `task_key`, `workstream_key`, and `episode_id` when an agent or daemon has that context.
+
+If you do need workspace isolation, scope resolution is:
+
+1. Explicit `workspace_id` on a tool call
+2. `BIKKY_WORKSPACE`
+3. `default_workspace` in config
+4. Unscoped
+
+Example:
+
+```json
+{
+  "qdrant_url": "http://localhost:6333",
+  "default_workspace": "team"
+}
+```
+
+The literal workspace name `"default"` also reads legacy facts that do not have a `workspace_id` payload. Other named workspaces are strict.
+
+</details>
+
+<details>
+<summary>Advanced: daemon, watchers, and logs</summary>
+
+You normally do not need to tune these. `bikky setup` starts the daemon and registers supported MCP clients.
+
+### Daemon settings
 
 | Setting | Default | Description |
-|---------|---------|-------------|
+|---|---|---|
 | `daemon.tick_interval_sec` | `5` | Seconds between daemon loop ticks |
 | `daemon.extract_every_sec` | `300` | Seconds between extraction runs |
 | `daemon.extract_min_events` | `10` | Minimum session events before triggering extraction |
-| `daemon.consolidation_enabled` | `true` | Auto-distill daemon-generated session summaries into patterns |
-| `daemon.relation_inference_enabled` | `true` | Infer entity relationships via LLM from recently changed facts |
-| `daemon.relation_inference_interval_sec` | `7200` | Minimum seconds between relation-inference maintenance runs |
-| `daemon.relation_inference_max_pairs_per_run` | `3` | Maximum entity pairs sent to the LLM in one relation-inference run |
+| `daemon.consolidation_enabled` | `true` | Consolidate session summaries into durable patterns |
+| `daemon.relation_inference_enabled` | `true` | Infer entity relationships |
 | `daemon.entity_typing_enabled` | `true` | Classify entities for UI/graph filtering |
-| `daemon.entity_typing_interval_sec` | `900` | Minimum seconds between entity-typing maintenance runs |
-| `daemon.entity_typing_max_entities_per_run` | `5` | Maximum entities classified in one entity-typing run |
 | `daemon.staleness_threshold_days` | `30` | Days before a fact is flagged as stale |
 
-Environment overrides are available for the high-cost maintenance controls:
+### Watcher settings
 
-| Env var | Config field |
-|---------|--------------|
-| `BIKKY_DAEMON_RELATION_INFERENCE_ENABLED` | `daemon.relation_inference_enabled` |
-| `BIKKY_DAEMON_RELATION_INFERENCE_INTERVAL_SEC` | `daemon.relation_inference_interval_sec` |
-| `BIKKY_DAEMON_RELATION_INFERENCE_MAX_PAIRS_PER_RUN` | `daemon.relation_inference_max_pairs_per_run` |
-| `BIKKY_DAEMON_ENTITY_TYPING_ENABLED` | `daemon.entity_typing_enabled` |
-| `BIKKY_DAEMON_ENTITY_TYPING_INTERVAL_SEC` | `daemon.entity_typing_interval_sec` |
-| `BIKKY_DAEMON_ENTITY_TYPING_MAX_ENTITIES_PER_RUN` | `daemon.entity_typing_max_entities_per_run` |
+| Setting | Default | Description |
+|---|---|---|
+| `watchers.copilot.enabled` | `true` | Watch GitHub Copilot session logs |
+| `watchers.copilot.path` | `~/.copilot/session-state` | Path to Copilot session directory |
+| `watchers.claude.enabled` | `true` | Watch Claude Code project logs |
+| `watchers.claude.path` | `~/.claude/projects` | Path to Claude Code projects directory |
 
-`bikky status` shows the latest maintenance summaries: candidates seen, LLM calls made, accepted records, deterministic entity classifications, skip reasons, and errors. For per-call token cost, inspect `~/.bikky/logs/llm.jsonl`; each daemon LLM call includes `prompt`, `subsystem`, estimated tokens, and provider-actual token fields when the provider returns usage metadata.
+### Logs
 
-## Logs
-
-Bikky writes logs to `~/.bikky/logs/` (the same directory as the config file).
+bikky writes logs to `~/.bikky/logs/`:
 
 | File | Written by |
-|------|-----------|
-| `mcp.log` | The MCP server (`bikky mcp`) |
-| `daemon.log` | The background daemon (`bikky daemon` / `bikky start`) |
-| `llm.jsonl` | LLM telemetry from daemon and MCP chat-completion calls |
+|---|---|
+| `mcp.log` | MCP server |
+| `daemon.log` | Background daemon |
+| `llm.jsonl` | LLM telemetry |
 
-Logs are **structured JSON lines** produced by [pino](https://github.com/pinojs/pino). Each line has at minimum `{level, time, name, msg}`; provider failures, telemetry events, and Qdrant operations attach extra fields (e.g. `provider`, `kind`, `status`). Files rotate in-process at 2MB, keeping 3 generations (`mcp.log` + `mcp.log.1` + `mcp.log.2`).
-
-Pretty-print with [`pino-pretty`](https://github.com/pinojs/pino-pretty) when tailing:
+Pretty-print logs with:
 
 ```bash
 tail -f ~/.bikky/logs/daemon.log | npx pino-pretty
 ```
 
-Or grep structured fields with `jq`:
+</details>
+
+## Troubleshooting
+
+Run:
 
 ```bash
-jq 'select(.level=="error")' ~/.bikky/logs/daemon.log
-jq 'select(.provider=="openai" and .kind=="auth")' ~/.bikky/logs/mcp.log
+bikky status
 ```
 
-Stdout/stderr are reserved for the MCP stdio transport — bikky never logs to the terminal from the MCP process.
-
-## Watcher settings
-
-| Setting | Default | Description |
-|---------|---------|-------------|
-| `watchers.copilot.enabled` | `true` | Watch GitHub Copilot session logs |
-| `watchers.copilot.path` | `~/.copilot/session-state` | Path to Copilot session directory |
-| `watchers.claude.enabled` | `true` | Watch Claude Code project logs |
-| `watchers.claude.path` | `~/.claude/projects` | Path to Claude Code projects directory |
+`bikky status` is read-only. It checks the config, Qdrant connection, collection readiness, embedding connectivity, daemon state, and local UI health. If something is missing or misconfigured, it exits non-zero and prints the next fix to make.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
     "check": "tsc --noEmit && eslint src/",
-    "test": "node --test --test-concurrency=1 $(find dist -name '*.test.js')",
+    "test": "tsc && node --test --test-concurrency=1 $(find dist -name '*.test.js')",
     "test:integration": "tsc && BIKKY_INTEGRATION=${BIKKY_INTEGRATION:-1} node --test $(find dist -name '*.itest.js')",
     "build:diagrams": "node scripts/build-diagrams.mjs",
     "prepublishOnly": "npm run build"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -22,7 +22,7 @@
     "build:ui": "vite build --config app/vite.config.ts",
     "dev": "vite --config app/vite.config.ts",
     "typecheck": "tsc --noEmit",
-    "test": "tsc && node --test --test-isolation=process --test-concurrency=1 \"dist/**/*.test.js\"",
+    "test": "tsc && node --test --test-concurrency=1 $(find dist -name '*.test.js')",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/src/daemon/extraction.ts
+++ b/src/daemon/extraction.ts
@@ -6,11 +6,10 @@
  * Active session detection scans ~/.copilot/session-state/ for lock files.
  */
 
-import { readFile, stat } from "node:fs/promises";
+import { readFile, readdir, stat } from "node:fs/promises";
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { join } from "node:path";
-import { glob } from "node:fs/promises";
 
 import { loadConfig, STATE_DIR, EXTRACTION_HEALTH_PATH } from "../config.js";
 import type { BikkyConfig } from "../config.js";
@@ -186,25 +185,32 @@ const resolveLockFiles = async (): Promise<LockMapping[]> => {
   const mappings: LockMapping[] = [];
 
   try {
-    const pattern = join(copilotStateDir, "*/inuse.*.lock");
-    for await (const lockPath of glob(pattern)) {
-      const lockPathStr = String(lockPath);
-      const parts = lockPathStr.split("/");
-      const lockFile = parts.at(-1) ?? ""; // inuse.12345.lock
-      const uuid = parts.at(-2) ?? "";     // session UUID
+    const sessionDirs = await readdir(copilotStateDir, { withFileTypes: true });
+    for (const sessionDir of sessionDirs) {
+      if (!sessionDir.isDirectory()) continue;
 
-      const pidMatch = lockFile.match(/^inuse\.(\d+)\.lock$/);
-      if (!pidMatch || !uuid) continue;
+      const uuid = sessionDir.name;
+      const sessionPath = join(copilotStateDir, uuid);
+      const entries = await readdir(sessionPath, { withFileTypes: true });
 
-      const pid = parseInt(pidMatch[1]!, 10);
-      const eventsPath = join(copilotStateDir, uuid, "events.jsonl");
+      for (const entry of entries) {
+        if (!entry.isFile()) continue;
 
-      // Verify events.jsonl exists
-      try {
-        await stat(eventsPath);
-        mappings.push({ pid, uuid, eventsPath });
-      } catch {
-        // No events.jsonl — skip
+        const lockFile = entry.name; // inuse.12345.lock
+
+        const pidMatch = lockFile.match(/^inuse\.(\d+)\.lock$/);
+        if (!pidMatch || !uuid) continue;
+
+        const pid = parseInt(pidMatch[1]!, 10);
+        const eventsPath = join(copilotStateDir, uuid, "events.jsonl");
+
+        // Verify events.jsonl exists
+        try {
+          await stat(eventsPath);
+          mappings.push({ pid, uuid, eventsPath });
+        } catch {
+          // No events.jsonl — skip
+        }
       }
     }
   } catch (e) {


### PR DESCRIPTION
Closes #105

### What changed
- Reframed README quick start around the reassuring happy path: local/free/account-free, one required setting (Qdrant URL), then `bikky status` to confirm it works.
- Simplified README setup/config sections into three setup choices: local, hosted Qdrant + local models, fully hosted.
- Removed/hid non-essential details from the README happy path: Memory ontology, explicit workspace section, low-level MCP tool list, prompt-render details, and daemon/session internals.
- Rewrote `docs/configuration.md` to be progressive: common setups first, env vars/provider basics next, advanced settings hidden in `<details>` blocks.
- Kept accuracy fixes: `mkdir -p ~/.bikky` before config writes and fixed the `bikky-ui` link.
- Fixed required PR checks: core tests now build before running, UI tests avoid unsupported Node flags, and CodeQL is gated behind `BIKKY_CODEQL_ENABLED=true` until code scanning is enabled.

### Validation
- Docs sanity check for removed sections and balanced `<details>` tags
- `npm run build --silent`
- `npm test`
- `cd packages/ui && npm test`