### PR TITLE
docs: simplify how bikky solves it

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Subtypes keep recall precise without making setup harder:
 
 ## Quick start
 
-The recommended first-time setup is **local Qdrant + hosted models**: Qdrant runs on your machine, while hosted embeddings and LLM calls give you the best extraction and recall quality out of the box.
+This quick start uses **local Qdrant + hosted models**: Qdrant runs on your machine, while hosted embeddings and LLM calls provide strong extraction and recall quality without running local LLMs.
 
 ```bash
 # 1. Pull and run Qdrant (vector store)
@@ -84,20 +84,20 @@ bikky status           # confirms Qdrant, embeddings, daemon, and UI health
 
 That's it. You can keep Qdrant local forever, or move the vector store to Qdrant Cloud later.
 
-Prefer 100% local and account-free? Use the [local and free config](docs/config/local.md). It is best for private testing rather than long-term team use, and extraction, embedding, and curation performance depends on the local models and hardware you run.
+For 100% local and account-free setup, use the [local and free config](docs/config/local.md). It is best for private testing rather than long-term team use, and extraction, embedding, and curation performance depends on the local models and hardware you run.
 
 ---
 
 ## Setup options
 
-Start with the recommended first-time path for the best extraction and embedding quality. Choose the local path when privacy, offline use, or zero hosted-model cost matters most.
+bikky supports four common setup shapes. Pick based on where you want Qdrant to run and where model calls should happen.
 
 ### What you need
 
 | Component               | Required                       | Options                                                                                  |
 | ----------------------- | ------------------------------ | ---------------------------------------------------------------------------------------- |
 | **Node.js**             | ≥ 20                           | `nvm install 20` or your package manager                                                 |
-| **Vector store**        | Qdrant                         | Local Docker (recommended first) · [Qdrant Cloud](https://cloud.qdrant.io) · Self-hosted |
+| **Vector store**        | Qdrant                         | Local Docker · [Qdrant Cloud](https://cloud.qdrant.io) · Self-hosted                     |
 | **Embeddings**          | One provider                   | OpenAI · Ollama · Bedrock · Portkey                                                     |
 | **LLM**                 | One provider                   | OpenAI · Ollama · Bedrock · Portkey                                                     |
 | **Docker** *(optional)* | Only if you run Qdrant locally | Docker Desktop, OrbStack, colima, etc.                                                   |
@@ -106,10 +106,10 @@ Start with the recommended first-time path for the best extraction and embedding
 
 | Setup                            | Best for                                                       | Config                                                                    |
 | -------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| **Recommended first-time**       | Best extraction and embedding quality with local Qdrant        | [Hosted models config](docs/config/hosted-models.md)                      |
+| **Fully hosted**                 | Best performance and teams; managed vector storage and models  | [Fully hosted config](docs/config/fully-hosted.md)                        |
+| **Local Qdrant + hosted models** | Local vector storage with hosted extraction and embedding      | [Hosted models config](docs/config/hosted-models.md)                      |
 | **Local and free**               | Private/free testing; quality depends on local models          | [Local config guide](docs/config/local.md)                                |
-| **Hosted Qdrant + local Ollama** | Sharing memory across machines while keeping model calls local | [Hosted Qdrant + local models](docs/config/hosted-qdrant-local-models.md) |
-| **Fully hosted**                 | Teams that want managed vector storage and hosted models       | [Fully hosted config](docs/config/fully-hosted.md)                        |
+| **Hosted Qdrant + local Ollama** | Shared vector storage while keeping model calls local          | [Hosted Qdrant + local models](docs/config/hosted-qdrant-local-models.md) |
 
 ### Configure
 

--- a/README.md
+++ b/README.md
@@ -94,22 +94,22 @@ Start with the recommended first-time path for the best extraction and embedding
 
 ### What you need
 
-| Component | Required | Options |
-|---|---|---|
-| **Node.js** | ≥ 20 | `nvm install 20` or your package manager |
-| **Vector store** | Qdrant | Local Docker (recommended first) · [Qdrant Cloud](https://cloud.qdrant.io) · Self-hosted |
-| **Embeddings** | One provider | Hosted models recommended first · Ollama local for private/free use |
-| **LLM** | One provider | Hosted models recommended first · Ollama local for private/free use |
-| **Docker** *(optional)* | Only if you run Qdrant locally | Docker Desktop, OrbStack, colima, etc. |
+| Component               | Required                       | Options                                                                                  |
+| ----------------------- | ------------------------------ | ---------------------------------------------------------------------------------------- |
+| **Node.js**             | ≥ 20                           | `nvm install 20` or your package manager                                                 |
+| **Vector store**        | Qdrant                         | Local Docker (recommended first) · [Qdrant Cloud](https://cloud.qdrant.io) · Self-hosted |
+| **Embeddings**          | One provider                   | OpenAI · Ollama · Bedrock · Portkey                                                     |
+| **LLM**                 | One provider                   | OpenAI · Ollama · Bedrock · Portkey                                                     |
+| **Docker** *(optional)* | Only if you run Qdrant locally | Docker Desktop, OrbStack, colima, etc.                                                   |
 
 ### Choose a setup
 
-| Setup | Best for | Config |
-|---|---|---|
-| **Recommended first-time** | Best extraction and embedding quality with local Qdrant | [Hosted models config](docs/config/hosted-models.md) |
-| **Local and free** | Private, free testing and local-first use | [Local config guide](docs/config/local.md) |
+| Setup                            | Best for                                                       | Config                                                                    |
+| -------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| **Recommended first-time**       | Best extraction and embedding quality with local Qdrant        | [Hosted models config](docs/config/hosted-models.md)                      |
+| **Local and free**               | Private, free testing and local-first use                      | [Local config guide](docs/config/local.md)                                |
 | **Hosted Qdrant + local Ollama** | Sharing memory across machines while keeping model calls local | [Hosted Qdrant + local models](docs/config/hosted-qdrant-local-models.md) |
-| **Fully hosted** | Teams that want managed vector storage and hosted models | [Fully hosted config](docs/config/fully-hosted.md) |
+| **Fully hosted**                 | Teams that want managed vector storage and hosted models       | [Fully hosted config](docs/config/fully-hosted.md)                        |
 
 ### Configure
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,20 @@ The most valuable things you and your agents learn — why a config value exists
 
 ### How bikky solves it
 
-bikky gives your agent memory tools and runs a small background service after `bikky setup`. You keep working normally; bikky captures useful facts, recalls them in future sessions, and keeps the store tidy over time.
+bikky gives your agent memory tools and runs a small background service after `bikky setup`. You keep working normally; bikky captures useful facts, organizes them, recalls them in future sessions, and keeps the store tidy over time.
 
 - **Capture** — Facts are extracted automatically from session transcripts; no manual docs to write.
+- **Classify** — Memories are grouped as **engineering**, **product**, **human**, or **system** so they stay easy to browse and filter.
 - **Recall** — Every new session, yours or a teammate's, recalls from the same store via semantic search.
-- **Curate** — bikky deduplicates repeats, fades stale facts, resolves contradictions, and distills recurring patterns automatically.
+- **Curate** — bikky merges duplicates, fades stale facts, resolves contradictions, distills recurring patterns, and builds an entity graph over time.
 - **Compound** — Session 50 is dramatically better than session 1 because memory accumulates.
+
+Subtypes keep recall precise without making setup harder:
+
+- **Engineering** — codebase maps, architecture decisions, infra topology, access patterns, operational procedures, troubleshooting gotchas, and conventions.
+- **Product** — domain rules, product decisions, requirements, user workflows, roadmap items, success metrics, and market insights.
+- **Human** — preferences, person profiles, ownership notes, working agreements, and activity events.
+- **System** — session indexes, episodes, workstreams, and feedback signals.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ bikky supports four common setup shapes. Pick based on where you want Qdrant to 
 | **LLM**                 | One provider                   | OpenAI · Ollama · Bedrock · Portkey                                                     |
 | **Docker** *(optional)* | Only if you run Qdrant locally | Docker Desktop, OrbStack, colima, etc.                                                   |
 
+Both `embedding.provider` and `llm.provider` accept the same values: `ollama`, `openai`, `bedrock`, or `portkey`.
+
 ### Choose a setup
 
 | Setup                            | Best for                                                       | Config                                                                    |

--- a/README.md
+++ b/README.md
@@ -87,25 +87,15 @@ Start with the local path unless you already know you want hosted infrastructure
 
 | Setup | Best for | Config |
 |---|---|---|
-| **Local and free** | First install, solo use, private testing | `{"qdrant_url":"http://localhost:6333"}` |
-| **Hosted Qdrant + local Ollama** | Sharing memory across machines while keeping embeddings local | Add your Qdrant Cloud URL and API key |
-| **Fully hosted** | Teams that want managed vector storage and hosted models | Add Qdrant plus provider settings in [`docs/configuration.md`](docs/configuration.md) |
+| **Local and free** | First install, solo use, private testing | [Local config guide](docs/config/local.md) |
+| **Hosted Qdrant + local Ollama** | Sharing memory across machines while keeping embeddings local | [Hosted Qdrant + local models](docs/config/hosted-qdrant-local-models.md) |
+| **Fully hosted** | Teams that want managed vector storage and hosted models | [Fully hosted config](docs/config/fully-hosted.md) |
 
 ### Configure
 
-Most users only need one of these:
+Pick the setup guide above for the copy-paste config. Config lives at `~/.bikky/config.json`, and you can also set `QDRANT_URL` and `QDRANT_API_KEY` as environment variables.
 
-```bash
-mkdir -p ~/.bikky
-
-# Local Qdrant
-echo '{ "qdrant_url": "http://localhost:6333" }' > ~/.bikky/config.json
-
-# Qdrant Cloud
-echo '{ "qdrant_url": "https://your-cluster.cloud.qdrant.io:6333", "qdrant_api_key": "your-key" }' > ~/.bikky/config.json
-```
-
-You can also set `QDRANT_URL` and `QDRANT_API_KEY` as environment variables. For hosted models, custom providers, multiple profiles, or advanced tuning, use the full configuration guide.
+For hosted models, custom providers, multiple profiles, or advanced tuning, use the full configuration guide.
 
 > 📖 **Full configuration guide:** [docs/configuration.md](docs/configuration.md)
 >

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ bikky status           # confirms Qdrant, embeddings, daemon, and UI health
 
 That's it. You can keep Qdrant local forever, or move the vector store to Qdrant Cloud later.
 
-Prefer 100% local and account-free? Use the [local and free config](docs/config/local.md). Local Ollama models are great for private testing, but extraction and embedding quality depends on the models you run.
+Prefer 100% local and account-free? Use the [local and free config](docs/config/local.md). It is best for private testing rather than long-term team use, and extraction, embedding, and curation performance depends on the local models and hardware you run.
 
 ---
 
@@ -107,7 +107,7 @@ Start with the recommended first-time path for the best extraction and embedding
 | Setup                            | Best for                                                       | Config                                                                    |
 | -------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------- |
 | **Recommended first-time**       | Best extraction and embedding quality with local Qdrant        | [Hosted models config](docs/config/hosted-models.md)                      |
-| **Local and free**               | Private, free testing and local-first use                      | [Local config guide](docs/config/local.md)                                |
+| **Local and free**               | Private/free testing; quality depends on local models          | [Local config guide](docs/config/local.md)                                |
 | **Hosted Qdrant + local Ollama** | Sharing memory across machines while keeping model calls local | [Hosted Qdrant + local models](docs/config/hosted-qdrant-local-models.md) |
 | **Fully hosted**                 | Teams that want managed vector storage and hosted models       | [Fully hosted config](docs/config/fully-hosted.md)                        |
 

--- a/README.md
+++ b/README.md
@@ -69,11 +69,13 @@ bikky status           # confirms Qdrant, embeddings, daemon, and UI health
 
 That's it. You can use the local setup forever, or swap in hosted pieces later.
 
+Local Ollama models are great for private, free testing, but extraction and embedding quality depends on the models you run. If you're evaluating bikky for a team or want the strongest first impression, use the [fully hosted config](docs/config/fully-hosted.md) with hosted models.
+
 ---
 
 ## Setup options
 
-Start with the local path unless you already know you want hosted infrastructure.
+Start with the local path for private, free testing. If you want the best extraction and embedding quality while evaluating bikky, choose the fully hosted setup.
 
 ### What you need
 
@@ -88,7 +90,7 @@ Start with the local path unless you already know you want hosted infrastructure
 
 | Setup | Best for | Config |
 |---|---|---|
-| **Local and free** | First install, solo use, private testing | [Local config guide](docs/config/local.md) |
+| **Local and free** | Private, free testing and local-first use | [Local config guide](docs/config/local.md) |
 | **Hosted Qdrant + local Ollama** | Sharing memory across machines while keeping embeddings local | [Hosted Qdrant + local models](docs/config/hosted-qdrant-local-models.md) |
 | **Fully hosted** | Teams that want managed vector storage and hosted models | [Fully hosted config](docs/config/fully-hosted.md) |
 

--- a/README.md
+++ b/README.md
@@ -42,22 +42,37 @@ Subtypes keep recall precise without making setup harder:
 
 ## Quick start
 
-The easiest way to try bikky is **100% local, free, and account-free**: Qdrant in Docker, embeddings via Ollama. bikky has one required setting: where Qdrant lives. Everything else has local defaults.
+The recommended first-time setup is **local Qdrant + hosted models**: Qdrant runs on your machine, while hosted embeddings and LLM calls give you the best extraction and recall quality out of the box.
 
 ```bash
 # 1. Pull and run Qdrant (vector store)
 docker run -d --name qdrant -p 6333:6333 -v qdrant_storage:/qdrant/storage qdrant/qdrant
 
-# 2. Install Ollama (https://ollama.com) and pull the default embedding model
-ollama pull qwen3-embedding:0.6b
-
-# 3. Install bikky
+# 2. Install bikky
 npm install -g bikky
 mkdir -p ~/.bikky
-echo '{ "qdrant_url": "http://localhost:6333", "qdrant_api_key": "" }' > ~/.bikky/config.json
+# Replace sk-... below with your hosted model API key.
+cat > ~/.bikky/config.json <<'JSON'
+{
+  "qdrant_url": "http://localhost:6333",
+  "qdrant_api_key": "",
+  "embedding": {
+    "provider": "openai",
+    "model": "text-embedding-3-small",
+    "dimensions": 1536,
+    "api_key": "sk-..."
+  },
+  "llm": {
+    "provider": "openai",
+    "model": "gpt-4.1-mini",
+    "api_key": "sk-..."
+  }
+}
+JSON
 # qdrant_api_key is optional; leave it empty or omit it for local Qdrant.
+# Prefer env vars? Omit api_key above and set OPENAI_API_KEY instead.
 
-# 4. Register bikky with your editor and start the background service
+# 3. Register bikky with your editor and start the background service
 bikky setup            # writes MCP config for Copilot + Claude Code, then starts the daemon
 ```
 
@@ -67,15 +82,15 @@ Restart your editor. The memory tools appear automatically in supported MCP clie
 bikky status           # confirms Qdrant, embeddings, daemon, and UI health
 ```
 
-That's it. You can use the local setup forever, or swap in hosted pieces later.
+That's it. You can keep Qdrant local forever, or move the vector store to Qdrant Cloud later.
 
-Local Ollama models are great for private, free testing, but extraction and embedding quality depends on the models you run. If you're evaluating bikky for a team or want the strongest first impression, use the [fully hosted config](docs/config/fully-hosted.md) with hosted models.
+Prefer 100% local and account-free? Use the [local and free config](docs/config/local.md). Local Ollama models are great for private testing, but extraction and embedding quality depends on the models you run.
 
 ---
 
 ## Setup options
 
-Start with the local path for private, free testing. If you want the best extraction and embedding quality while evaluating bikky, choose the fully hosted setup.
+Start with the recommended first-time path for the best extraction and embedding quality. Choose the local path when privacy, offline use, or zero hosted-model cost matters most.
 
 ### What you need
 
@@ -83,15 +98,17 @@ Start with the local path for private, free testing. If you want the best extrac
 |---|---|---|
 | **Node.js** | ≥ 20 | `nvm install 20` or your package manager |
 | **Vector store** | Qdrant | Local Docker (recommended first) · [Qdrant Cloud](https://cloud.qdrant.io) · Self-hosted |
-| **Embeddings** | One provider | Ollama local by default · OpenAI / Bedrock / Portkey if you prefer hosted |
+| **Embeddings** | One provider | Hosted models recommended first · Ollama local for private/free use |
+| **LLM** | One provider | Hosted models recommended first · Ollama local for private/free use |
 | **Docker** *(optional)* | Only if you run Qdrant locally | Docker Desktop, OrbStack, colima, etc. |
 
 ### Choose a setup
 
 | Setup | Best for | Config |
 |---|---|---|
+| **Recommended first-time** | Best extraction and embedding quality with local Qdrant | [Hosted models config](docs/config/hosted-models.md) |
 | **Local and free** | Private, free testing and local-first use | [Local config guide](docs/config/local.md) |
-| **Hosted Qdrant + local Ollama** | Sharing memory across machines while keeping embeddings local | [Hosted Qdrant + local models](docs/config/hosted-qdrant-local-models.md) |
+| **Hosted Qdrant + local Ollama** | Sharing memory across machines while keeping model calls local | [Hosted Qdrant + local models](docs/config/hosted-qdrant-local-models.md) |
 | **Fully hosted** | Teams that want managed vector storage and hosted models | [Fully hosted config](docs/config/fully-hosted.md) |
 
 ### Configure

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ ollama pull qwen3-embedding:0.6b
 # 3. Install bikky
 npm install -g bikky
 mkdir -p ~/.bikky
-echo '{ "qdrant_url": "http://localhost:6333" }' > ~/.bikky/config.json
+echo '{ "qdrant_url": "http://localhost:6333", "qdrant_api_key": "" }' > ~/.bikky/config.json
+# qdrant_api_key is optional; leave it empty or omit it for local Qdrant.
 
 # 4. Register bikky with your editor and start the background service
 bikky setup            # writes MCP config for Copilot + Claude Code, then starts the daemon

--- a/README.md
+++ b/README.md
@@ -6,10 +6,8 @@ bikky gives AI coding agents (GitHub Copilot, Claude Code, Cursor, and other MCP
 
 ### Who it's for
 
-| | |
-|---|---|
-| 👥 **Teams & software factories** | What one engineer's agent learns today, every agent on the team can recall tomorrow. Shared memory turns institutional knowledge into something queryable instead of tribal — onboarding accelerates, conventions stop drifting, and the same lesson never gets re-learned twice. |
-| 🧑‍💻 **Solo AI power devs** | You run multiple Cursor / Claude Code / Copilot sessions every day and you're tired of re-explaining the codebase, the conventions, and last week's decisions to each new agent. bikky remembers across every session and every tool. |
+- 👥 **Teams & software factories** — What one engineer's agent learns today, every agent on the team can recall tomorrow. Shared memory turns institutional knowledge into something queryable instead of tribal — onboarding accelerates, conventions stop drifting, and the same lesson never gets re-learned twice.
+- 🧑‍💻 **Solo AI power devs** — You run multiple Cursor / Claude Code / Copilot sessions every day and you're tired of re-explaining the codebase, the conventions, and last week's decisions to each new agent. bikky remembers across every session and every tool.
 
 <p align="center">
   <img src="https://cdn.jsdelivr.net/npm/bikky@latest/docs/diagrams/team-memory.svg" alt="Memory — facts flow from individual sessions into a self-curating knowledge store, shared across your team (or kept just for you)" width="720" />
@@ -27,12 +25,10 @@ The most valuable things you and your agents learn — why a config value exists
 
 bikky gives your agent memory tools and runs a small background service after `bikky setup`. You keep working normally; bikky captures useful facts, recalls them in future sessions, and keeps the store tidy over time.
 
-| | |
-|---|---|
-| **Capture** | Facts are extracted automatically from session transcripts — no manual docs to write |
-| **Recall** | Every new session — yours or a teammate's — recalls from the same store via semantic search |
-| **Curate** | Deduplication, confidence decay, contradiction detection, and distillation run autonomously |
-| **Compound** | Session 50 is dramatically better than session 1 — accumulated memory, not better prompts |
+- **Capture** — Facts are extracted automatically from session transcripts; no manual docs to write.
+- **Recall** — Every new session, yours or a teammate's, recalls from the same store via semantic search.
+- **Curate** — bikky deduplicates repeats, fades stale facts, resolves contradictions, and distills recurring patterns automatically.
+- **Compound** — Session 50 is dramatically better than session 1 because memory accumulates.
 
 ---
 
@@ -72,7 +68,7 @@ Start with the local path unless you already know you want hosted infrastructure
 
 ### What you need
 
-| | Required | Options |
+| Component | Required | Options |
 |---|---|---|
 | **Node.js** | ≥ 20 | `nvm install 20` or your package manager |
 | **Vector store** | Qdrant | Local Docker (recommended first) · [Qdrant Cloud](https://cloud.qdrant.io) · Self-hosted |
@@ -106,19 +102,6 @@ You can also set `QDRANT_URL` and `QDRANT_API_KEY` as environment variables. For
 > 📖 **Full configuration guide:** [docs/configuration.md](docs/configuration.md)
 >
 > 🛠 Want to add a new embedding or LLM provider (Vertex, OpenRouter, etc.)? See **[CONTRIBUTING.md](CONTRIBUTING.md)** — it's a single-file change.
-
----
-
-## Self-curation
-
-Raw fact accumulation creates noise. bikky keeps the knowledge store clean automatically:
-
-- **Deduplication** — content hash + vector similarity merges near-identical facts
-- **Context fields** — repo, task, and source metadata make recall more precise when available
-- **Confidence decay** — old facts lose weight and surface for review
-- **Contradiction detection** — conflicting facts are resolved, not silently stacked
-- **Distillation** — recurring patterns across sessions consolidate into higher-level insights
-- **Entity graph** — relationships between concepts are inferred incrementally for richer recall
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The most valuable things you and your agents learn — why a config value exists
 
 ### How bikky solves it
 
+bikky gives your agent memory tools and runs a small background service after `bikky setup`. You keep working normally; bikky captures useful facts, recalls them in future sessions, and keeps the store tidy over time.
+
 | | |
 |---|---|
 | **Capture** | Facts are extracted automatically from session transcripts — no manual docs to write |
@@ -104,18 +106,6 @@ You can also set `QDRANT_URL` and `QDRANT_API_KEY` as environment variables. For
 > 📖 **Full configuration guide:** [docs/configuration.md](docs/configuration.md)
 >
 > 🛠 Want to add a new embedding or LLM provider (Vertex, OpenRouter, etc.)? See **[CONTRIBUTING.md](CONTRIBUTING.md)** — it's a single-file change.
-
----
-
-## How it works
-
-<p align="center">
-  <img src="https://cdn.jsdelivr.net/npm/bikky@latest/docs/diagrams/architecture.svg" alt="Architecture" width="600" />
-</p>
-
-**MCP tools** — your agent can store, recall, verify, and review memory without you wiring anything manually.
-
-**Background service** — `bikky setup` starts a local daemon that keeps memory current. You do not need to manage sessions, summaries, or maintenance jobs yourself.
 
 ---
 

--- a/docs/config/fully-hosted.md
+++ b/docs/config/fully-hosted.md
@@ -8,6 +8,8 @@ Best for performance and teams. This setup uses Qdrant Cloud for managed vector 
 - A Qdrant API key.
 - An OpenAI API key, or another hosted provider configured in the full configuration guide.
 
+For both `embedding.provider` and `llm.provider`, possible values are `openai`, `bedrock`, or `portkey` for hosted models. `ollama` is also supported when you want local model calls.
+
 ## Config
 
 Save this as `~/.bikky/config.json`:

--- a/docs/config/fully-hosted.md
+++ b/docs/config/fully-hosted.md
@@ -1,0 +1,52 @@
+# Fully hosted config
+
+Use this path when you want managed vector storage and hosted models. This example uses Qdrant Cloud and OpenAI-compatible hosted models.
+
+## What you need
+
+- A Qdrant Cloud cluster URL.
+- A Qdrant API key.
+- An OpenAI API key, or another hosted provider configured in the full configuration guide.
+
+## Config
+
+Save this as `~/.bikky/config.json`:
+
+```json
+{
+  "qdrant_url": "https://your-cluster.cloud.qdrant.io:6333",
+  "qdrant_api_key": "your-qdrant-api-key",
+  "embedding": {
+    "provider": "openai",
+    "model": "text-embedding-3-small",
+    "dimensions": 1536
+  },
+  "llm": {
+    "provider": "openai",
+    "model": "gpt-4.1-mini"
+  }
+}
+```
+
+Set the API key as an environment variable so it does not have to live in the config file:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+```
+
+## Check it
+
+```bash
+bikky status
+```
+
+After changing Qdrant or provider settings, restart long-running processes:
+
+```bash
+bikky stop && bikky start
+```
+
+Then restart your editor so its MCP process reloads.
+
+For Bedrock, Portkey, custom base URLs, or model-specific dimensions, see the [full configuration guide](../configuration.md).
+

--- a/docs/config/fully-hosted.md
+++ b/docs/config/fully-hosted.md
@@ -28,6 +28,8 @@ Save this as `~/.bikky/config.json`:
 }
 ```
 
+`qdrant_api_key` is optional only for unauthenticated self-hosted Qdrant. Qdrant Cloud usually requires it.
+
 Set the API key as an environment variable so it does not have to live in the config file:
 
 ```bash
@@ -49,4 +51,3 @@ bikky stop && bikky start
 Then restart your editor so its MCP process reloads.
 
 For Bedrock, Portkey, custom base URLs, or model-specific dimensions, see the [full configuration guide](../configuration.md).
-

--- a/docs/config/fully-hosted.md
+++ b/docs/config/fully-hosted.md
@@ -1,6 +1,6 @@
 # Fully hosted config
 
-Use this path when you want managed vector storage and hosted models. This example uses Qdrant Cloud and OpenAI-compatible hosted models.
+Best for performance and teams. This setup uses Qdrant Cloud for managed vector storage and OpenAI-compatible hosted models for extraction, curation, and recall.
 
 ## What you need
 

--- a/docs/config/hosted-models.md
+++ b/docs/config/hosted-models.md
@@ -1,6 +1,6 @@
-# Hosted models config
+# Local Qdrant + hosted models config
 
-Use this path for the best first-time experience: Qdrant runs locally, while hosted embeddings and LLM calls give bikky stronger extraction, curation, and recall quality out of the box.
+This setup keeps Qdrant local while hosted embeddings and LLM calls handle extraction, curation, and recall.
 
 ## What you need
 

--- a/docs/config/hosted-models.md
+++ b/docs/config/hosted-models.md
@@ -1,11 +1,10 @@
-# Fully hosted config
+# Hosted models config
 
-Use this path when you want managed vector storage and hosted models. This example uses Qdrant Cloud and OpenAI-compatible hosted models.
+Use this path for the best first-time experience: Qdrant runs locally, while hosted embeddings and LLM calls give bikky stronger extraction, curation, and recall quality out of the box.
 
 ## What you need
 
-- A Qdrant Cloud cluster URL.
-- A Qdrant API key.
+- Qdrant running locally, usually with Docker.
 - An OpenAI API key, or another hosted provider configured in the full configuration guide.
 
 ## Config
@@ -14,8 +13,8 @@ Save this as `~/.bikky/config.json`:
 
 ```json
 {
-  "qdrant_url": "https://your-cluster.cloud.qdrant.io:6333",
-  "qdrant_api_key": "your-qdrant-api-key",
+  "qdrant_url": "http://localhost:6333",
+  "qdrant_api_key": "",
   "embedding": {
     "provider": "openai",
     "model": "text-embedding-3-small",
@@ -30,7 +29,7 @@ Save this as `~/.bikky/config.json`:
 }
 ```
 
-`qdrant_api_key` is optional only for unauthenticated self-hosted Qdrant. Qdrant Cloud usually requires it.
+`qdrant_api_key` is optional. Leave it empty or omit it for local or unauthenticated self-hosted Qdrant.
 
 Prefer not to store hosted model keys in the config file? Omit `api_key` above and set:
 
@@ -44,12 +43,6 @@ export OPENAI_API_KEY="sk-..."
 bikky status
 ```
 
-After changing Qdrant or provider settings, restart long-running processes:
-
-```bash
-bikky stop && bikky start
-```
-
-Then restart your editor so its MCP process reloads.
+If you started from a fresh install, run `bikky setup` after writing the config, then restart your editor so its MCP process reloads.
 
 For Bedrock, Portkey, custom base URLs, or model-specific dimensions, see the [full configuration guide](../configuration.md).

--- a/docs/config/hosted-models.md
+++ b/docs/config/hosted-models.md
@@ -7,6 +7,8 @@ This setup keeps Qdrant local while hosted embeddings and LLM calls handle extra
 - Qdrant running locally, usually with Docker.
 - An OpenAI API key, or another hosted provider configured in the full configuration guide.
 
+For both `embedding.provider` and `llm.provider`, possible values are `openai`, `bedrock`, or `portkey` for hosted models. `ollama` is also supported when you want local model calls.
+
 ## Config
 
 Save this as `~/.bikky/config.json`:

--- a/docs/config/hosted-qdrant-local-models.md
+++ b/docs/config/hosted-qdrant-local-models.md
@@ -1,0 +1,38 @@
+# Hosted Qdrant + local models
+
+Use this path when you want memory shared across machines, but you still want embeddings and background curation to run through local Ollama.
+
+## What you need
+
+- A Qdrant Cloud cluster URL.
+- A Qdrant API key.
+- Ollama installed locally.
+- The default embedding model pulled with `ollama pull qwen3-embedding:0.6b`.
+
+## Config
+
+Save this as `~/.bikky/config.json`:
+
+```json
+{
+  "qdrant_url": "https://your-cluster.cloud.qdrant.io:6333",
+  "qdrant_api_key": "your-qdrant-api-key"
+}
+```
+
+bikky will store memory in hosted Qdrant and keep model calls local through Ollama.
+
+## Check it
+
+```bash
+bikky status
+```
+
+After changing Qdrant settings, restart long-running processes:
+
+```bash
+bikky stop && bikky start
+```
+
+Then restart your editor so its MCP process reloads.
+

--- a/docs/config/hosted-qdrant-local-models.md
+++ b/docs/config/hosted-qdrant-local-models.md
@@ -22,6 +22,8 @@ Save this as `~/.bikky/config.json`:
 
 bikky will store memory in hosted Qdrant and keep model calls local through Ollama.
 
+`qdrant_api_key` is optional only for unauthenticated self-hosted Qdrant. Qdrant Cloud usually requires it.
+
 ## Check it
 
 ```bash
@@ -35,4 +37,3 @@ bikky stop && bikky start
 ```
 
 Then restart your editor so its MCP process reloads.
-

--- a/docs/config/local.md
+++ b/docs/config/local.md
@@ -1,0 +1,30 @@
+# Local and free config
+
+Use this path first if you want the simplest setup: Qdrant runs on your machine, and Ollama handles local models.
+
+## What you need
+
+- Qdrant running locally, usually with Docker.
+- Ollama installed locally.
+- The default embedding model pulled with `ollama pull qwen3-embedding:0.6b`.
+
+## Config
+
+Save this as `~/.bikky/config.json`:
+
+```json
+{
+  "qdrant_url": "http://localhost:6333"
+}
+```
+
+That's the whole config. bikky uses local Ollama defaults for embeddings and background curation.
+
+## Check it
+
+```bash
+bikky status
+```
+
+If you started from a fresh install, run `bikky setup` after writing the config, then restart your editor so its MCP process reloads.
+

--- a/docs/config/local.md
+++ b/docs/config/local.md
@@ -2,7 +2,7 @@
 
 Use this path if you want a private, free setup: Qdrant runs on your machine, and Ollama handles local models.
 
-This setup is great for private testing, but it is usually not the best long-term choice for teams. Extraction, embedding, and curation performance depends on the local models and hardware you run. If you're evaluating bikky for a team or want the strongest quality, use the [hosted models config](hosted-models.md).
+This setup is best for private/free testing rather than long-term team use. Extraction, embedding, and curation performance depends on the local models and hardware you run.
 
 ## What you need
 

--- a/docs/config/local.md
+++ b/docs/config/local.md
@@ -1,6 +1,8 @@
 # Local and free config
 
-Use this path first if you want the simplest setup: Qdrant runs on your machine, and Ollama handles local models.
+Use this path first if you want a private, free setup: Qdrant runs on your machine, and Ollama handles local models.
+
+Local model quality depends on the models you run. This setup is great for local-first use, but if you're evaluating bikky for a team or want the strongest extraction and embedding quality, use the [fully hosted config](fully-hosted.md).
 
 ## What you need
 

--- a/docs/config/local.md
+++ b/docs/config/local.md
@@ -14,11 +14,14 @@ Save this as `~/.bikky/config.json`:
 
 ```json
 {
-  "qdrant_url": "http://localhost:6333"
+  "qdrant_url": "http://localhost:6333",
+  "qdrant_api_key": ""
 }
 ```
 
 That's the whole config. bikky uses local Ollama defaults for embeddings and background curation.
+
+`qdrant_api_key` is optional. Leave it empty or omit it for local or unauthenticated self-hosted Qdrant.
 
 ## Check it
 
@@ -27,4 +30,3 @@ bikky status
 ```
 
 If you started from a fresh install, run `bikky setup` after writing the config, then restart your editor so its MCP process reloads.
-

--- a/docs/config/local.md
+++ b/docs/config/local.md
@@ -2,7 +2,7 @@
 
 Use this path first if you want a private, free setup: Qdrant runs on your machine, and Ollama handles local models.
 
-Local model quality depends on the models you run. This setup is great for local-first use, but if you're evaluating bikky for a team or want the strongest extraction and embedding quality, use the [fully hosted config](fully-hosted.md).
+Local model quality depends on the models you run. This setup is great for local-first use, but if you're evaluating bikky for a team or want the strongest extraction and embedding quality, use the [hosted models config](hosted-models.md).
 
 ## What you need
 

--- a/docs/config/local.md
+++ b/docs/config/local.md
@@ -1,8 +1,8 @@
 # Local and free config
 
-Use this path first if you want a private, free setup: Qdrant runs on your machine, and Ollama handles local models.
+Use this path if you want a private, free setup: Qdrant runs on your machine, and Ollama handles local models.
 
-Local model quality depends on the models you run. This setup is great for local-first use, but if you're evaluating bikky for a team or want the strongest extraction and embedding quality, use the [hosted models config](hosted-models.md).
+This setup is great for private testing, but it is usually not the best long-term choice for teams. Extraction, embedding, and curation performance depends on the local models and hardware you run. If you're evaluating bikky for a team or want the strongest quality, use the [hosted models config](hosted-models.md).
 
 ## What you need
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,7 +65,7 @@ Use this when you want the best first impression: Qdrant runs locally, while hos
 
 Use this for private, free, account-free testing. Qdrant runs locally and Ollama provides the default embedding + LLM models.
 
-Local model quality depends on the models you run. For the strongest extraction and embedding quality while evaluating bikky, use the [hosted models config](config/hosted-models.md).
+This setup is usually not the best long-term choice for teams. Extraction, embedding, and curation performance depends on the local models and hardware you run. For the strongest quality while evaluating bikky, use the [hosted models config](config/hosted-models.md).
 
 ```json
 {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,14 +140,14 @@ Useful basics:
 
 ## Provider options
 
-You can keep the defaults unless you want hosted models.
+Use these exact values in `embedding.provider` and `llm.provider`. Both fields accept the same provider values, and you can choose them independently.
 
-| Provider  | Best for                                | Auth                              |
-| --------- | --------------------------------------- | --------------------------------- |
-| `ollama`  | Local and free defaults                 | None                              |
-| `openai`  | Simple hosted models                    | `OPENAI_API_KEY` or `api_key`     |
-| `bedrock` | AWS-managed models                      | AWS credentials or IAM role       |
-| `portkey` | Gateway/routing over other providers    | Portkey API key                   |
+| Provider value | Works for embeddings | Works for LLM | Best for                             | Auth                              |
+| -------------- | -------------------- | ------------- | ------------------------------------ | --------------------------------- |
+| `ollama`       | Yes                  | Yes           | Local and free defaults              | None                              |
+| `openai`       | Yes                  | Yes           | Simple hosted models                 | `OPENAI_API_KEY` or `api_key`     |
+| `bedrock`      | Yes                  | Yes           | AWS-managed models                   | AWS credentials or IAM role       |
+| `portkey`      | Yes                  | Yes           | Gateway/routing over other providers | Portkey API key                   |
 
 ## Advanced configuration
 
@@ -169,7 +169,7 @@ These sections are optional references for custom providers, tuning, scoping, an
 
 | Setting                | Env var                | Default                  | Notes                                           |
 | ---------------------- | ---------------------- | ------------------------ | ----------------------------------------------- |
-| `embedding.provider`   | `EMBEDDING_PROVIDER`   | `ollama`                 | Embedding provider                              |
+| `embedding.provider`   | `EMBEDDING_PROVIDER`   | `ollama`                 | One of `ollama`, `openai`, `bedrock`, `portkey` |
 | `embedding.model`      | `EMBEDDING_MODEL`      | `qwen3-embedding:0.6b`   | Embedding model name                            |
 | `embedding.dimensions` | `EMBEDDING_DIMENSIONS` | `1024`                   | Must match the selected model output            |
 | `embedding.base_url`   | `EMBEDDING_BASE_URL`   | `http://localhost:11434` | Used by local or OpenAI-compatible providers    |
@@ -193,7 +193,7 @@ The LLM is used by background maintenance features. Ollama is the default.
 
 | Setting            | Env var                              | Default                  | Notes                                        |
 | ------------------ | ------------------------------------ | ------------------------ | -------------------------------------------- |
-| `llm.provider`     | `LLM_PROVIDER`                       | `ollama`                 | LLM provider                                 |
+| `llm.provider`     | `LLM_PROVIDER`                       | `ollama`                 | One of `ollama`, `openai`, `bedrock`, `portkey` |
 | `llm.model`        | `LLM_MODEL`                          | `qwen2.5:7b`             | LLM model name                               |
 | `llm.base_url`     | `LLM_BASE_URL`                       | `http://localhost:11434` | Used by local or OpenAI-compatible providers |
 | `llm.api_key`      | `OPENAI_API_KEY`                     | —                        | Provider API key; can also be set in config  |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,14 @@ Config lives at `~/.bikky/config.json`, or at `BIKKY_HOME/config.json` when `BIK
 
 ## Common setups
 
+If you know which path you want, start with the focused guide:
+
+| Scenario | Guide |
+|---|---|
+| Local and free | [Local config guide](config/local.md) |
+| Hosted Qdrant + local models | [Hosted Qdrant + local models](config/hosted-qdrant-local-models.md) |
+| Fully hosted | [Fully hosted config](config/fully-hosted.md) |
+
 ### Local and free
 
 Use this first. Qdrant runs locally and Ollama provides the default embedding + LLM models.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-bikky is designed to keep setup small. For the best first-time experience, run Qdrant locally and use hosted models for embeddings and extraction quality. For private, free, account-free testing, you can use local Ollama models instead.
+bikky is designed to keep setup small. The example below keeps Qdrant local and uses hosted models; the focused guides list the other common setup shapes.
 
 ```bash
 mkdir -p ~/.bikky
@@ -30,16 +30,40 @@ Config lives at `~/.bikky/config.json`, or at `BIKKY_HOME/config.json` when `BIK
 
 If you know which path you want, start with the focused guide:
 
-| Scenario | Guide |
-|---|---|
-| Recommended first-time | [Hosted models config](config/hosted-models.md) |
-| Local and free | [Local config guide](config/local.md) |
-| Hosted Qdrant + local models | [Hosted Qdrant + local models](config/hosted-qdrant-local-models.md) |
-| Fully hosted | [Fully hosted config](config/fully-hosted.md) |
+| Setup | Best for | Guide |
+|---|---|---|
+| Fully hosted | Best performance and teams; managed vector storage and models | [Fully hosted config](config/fully-hosted.md) |
+| Local Qdrant + hosted models | Local vector storage with hosted extraction and embedding | [Hosted models config](config/hosted-models.md) |
+| Local and free | Private/free testing; quality depends on local models | [Local config guide](config/local.md) |
+| Hosted Qdrant + local models | Shared vector storage while keeping model calls local | [Hosted Qdrant + local models](config/hosted-qdrant-local-models.md) |
 
-### Recommended first-time
+### Fully hosted
 
-Use this when you want the best first impression: Qdrant runs locally, while hosted embeddings and LLM calls provide stronger extraction and recall quality than small local models.
+Best for performance and teams. Qdrant Cloud stores vectors, and hosted embeddings + LLM calls handle extraction, curation, and recall.
+
+```json
+{
+  "qdrant_url": "https://your-cluster.cloud.qdrant.io:6333",
+  "qdrant_api_key": "your-key",
+  "embedding": {
+    "provider": "openai",
+    "model": "text-embedding-3-small",
+    "dimensions": 1536,
+    "api_key": "sk-..."
+  },
+  "llm": {
+    "provider": "openai",
+    "model": "gpt-4.1-mini",
+    "api_key": "sk-..."
+  }
+}
+```
+
+`qdrant_api_key` is optional only for unauthenticated self-hosted Qdrant. Qdrant Cloud usually requires it.
+
+### Local Qdrant + hosted models
+
+Best for local vector storage with hosted extraction and embedding quality.
 
 ```json
 {
@@ -65,7 +89,7 @@ Use this when you want the best first impression: Qdrant runs locally, while hos
 
 Use this for private, free, account-free testing. Qdrant runs locally and Ollama provides the default embedding + LLM models.
 
-This setup is usually not the best long-term choice for teams. Extraction, embedding, and curation performance depends on the local models and hardware you run. For the strongest quality while evaluating bikky, use the [hosted models config](config/hosted-models.md).
+This setup is usually not the best long-term choice for teams. Extraction, embedding, and curation performance depends on the local models and hardware you run.
 
 ```json
 {
@@ -84,30 +108,6 @@ Use this when you want the memory database shared across machines, but still wan
 {
   "qdrant_url": "https://your-cluster.cloud.qdrant.io:6333",
   "qdrant_api_key": "your-key"
-}
-```
-
-`qdrant_api_key` is optional only for unauthenticated self-hosted Qdrant. Qdrant Cloud usually requires it.
-
-### Hosted Qdrant and hosted models
-
-Use this when you want the whole stack managed. This example uses OpenAI-compatible hosted models:
-
-```json
-{
-  "qdrant_url": "https://your-cluster.cloud.qdrant.io:6333",
-  "qdrant_api_key": "your-key",
-  "embedding": {
-    "provider": "openai",
-    "model": "text-embedding-3-small",
-    "dimensions": 1536,
-    "api_key": "sk-..."
-  },
-  "llm": {
-    "provider": "openai",
-    "model": "gpt-4.1-mini",
-    "api_key": "sk-..."
-  }
 }
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,8 @@ bikky is designed to start with one required setting: **where Qdrant lives**. Ev
 
 ```bash
 mkdir -p ~/.bikky
-echo '{ "qdrant_url": "http://localhost:6333" }' > ~/.bikky/config.json
+echo '{ "qdrant_url": "http://localhost:6333", "qdrant_api_key": "" }' > ~/.bikky/config.json
+# qdrant_api_key is optional; leave it empty or omit it for local Qdrant.
 bikky status
 ```
 
@@ -26,9 +27,12 @@ Use this first. Qdrant runs locally and Ollama provides the default embedding + 
 
 ```json
 {
-  "qdrant_url": "http://localhost:6333"
+  "qdrant_url": "http://localhost:6333",
+  "qdrant_api_key": ""
 }
 ```
+
+`qdrant_api_key` is optional. Leave it empty or omit it for local or unauthenticated self-hosted Qdrant.
 
 ### Hosted Qdrant, local models
 
@@ -40,6 +44,8 @@ Use this when you want the memory database shared across machines, but still wan
   "qdrant_api_key": "your-key"
 }
 ```
+
+`qdrant_api_key` is optional only for unauthenticated self-hosted Qdrant. Qdrant Cloud usually requires it.
 
 ### Hosted Qdrant and hosted models
 
@@ -63,6 +69,8 @@ Use this when you want the whole stack managed. This example uses OpenAI-compati
 }
 ```
 
+`qdrant_api_key` is optional only for unauthenticated self-hosted Qdrant. Qdrant Cloud usually requires it.
+
 After changing Qdrant or provider settings, restart long-running processes:
 
 ```bash
@@ -85,7 +93,7 @@ Useful basics:
 | Env var | Config field | Notes |
 |---|---|---|
 | `QDRANT_URL` | `qdrant_url` | Required unless set in config |
-| `QDRANT_API_KEY` | `qdrant_api_key` | Needed for Qdrant Cloud |
+| `QDRANT_API_KEY` | `qdrant_api_key` | Optional for local/unauthenticated Qdrant; usually needed for Qdrant Cloud |
 | `BIKKY_HOME` | — | Moves the config/log/state directory from `~/.bikky` |
 
 ## Provider options
@@ -107,7 +115,7 @@ You can keep the defaults unless you want hosted models.
 | Setting | Env var | Default | Description |
 |---|---|---|---|
 | `qdrant_url` | `QDRANT_URL` | none | Qdrant REST URL |
-| `qdrant_api_key` | `QDRANT_API_KEY` | none | Required for Qdrant Cloud/authenticated self-hosted Qdrant |
+| `qdrant_api_key` | `QDRANT_API_KEY` | none | Optional for local/unauthenticated Qdrant; required for Qdrant Cloud/authenticated self-hosted Qdrant |
 | `collection` | `BIKKY_COLLECTION` | `bikky` | Collection name |
 
 ### Embeddings
@@ -223,9 +231,12 @@ Example:
 ```json
 {
   "qdrant_url": "http://localhost:6333",
+  "qdrant_api_key": "",
   "default_workspace": "team"
 }
 ```
+
+`qdrant_api_key` is optional. Leave it empty or omit it for local or unauthenticated self-hosted Qdrant.
 
 The literal workspace name `"default"` also reads legacy facts that do not have a `workspace_id` payload. Other named workspaces are strict.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,11 +1,26 @@
 # Configuration
 
-bikky is designed to start with one required setting: **where Qdrant lives**. Everything else has local defaults.
+bikky is designed to keep setup small. For the best first-time experience, run Qdrant locally and use hosted models for embeddings and extraction quality. For private, free, account-free testing, you can use local Ollama models instead.
 
 ```bash
 mkdir -p ~/.bikky
-echo '{ "qdrant_url": "http://localhost:6333", "qdrant_api_key": "" }' > ~/.bikky/config.json
-# qdrant_api_key is optional; leave it empty or omit it for local Qdrant.
+cat > ~/.bikky/config.json <<'JSON'
+{
+  "qdrant_url": "http://localhost:6333",
+  "qdrant_api_key": "",
+  "embedding": {
+    "provider": "openai",
+    "model": "text-embedding-3-small",
+    "dimensions": 1536,
+    "api_key": "sk-..."
+  },
+  "llm": {
+    "provider": "openai",
+    "model": "gpt-4.1-mini",
+    "api_key": "sk-..."
+  }
+}
+JSON
 bikky status
 ```
 
@@ -17,15 +32,40 @@ If you know which path you want, start with the focused guide:
 
 | Scenario | Guide |
 |---|---|
+| Recommended first-time | [Hosted models config](config/hosted-models.md) |
 | Local and free | [Local config guide](config/local.md) |
 | Hosted Qdrant + local models | [Hosted Qdrant + local models](config/hosted-qdrant-local-models.md) |
 | Fully hosted | [Fully hosted config](config/fully-hosted.md) |
 
+### Recommended first-time
+
+Use this when you want the best first impression: Qdrant runs locally, while hosted embeddings and LLM calls provide stronger extraction and recall quality than small local models.
+
+```json
+{
+  "qdrant_url": "http://localhost:6333",
+  "qdrant_api_key": "",
+  "embedding": {
+    "provider": "openai",
+    "model": "text-embedding-3-small",
+    "dimensions": 1536,
+    "api_key": "sk-..."
+  },
+  "llm": {
+    "provider": "openai",
+    "model": "gpt-4.1-mini",
+    "api_key": "sk-..."
+  }
+}
+```
+
+`qdrant_api_key` is optional. Leave it empty or omit it for local or unauthenticated self-hosted Qdrant. Prefer env vars for hosted model auth? Omit `api_key` above and set `OPENAI_API_KEY` instead.
+
 ### Local and free
 
-Use this first for private, free testing. Qdrant runs locally and Ollama provides the default embedding + LLM models.
+Use this for private, free, account-free testing. Qdrant runs locally and Ollama provides the default embedding + LLM models.
 
-Local model quality depends on the models you run. For the strongest extraction and embedding quality while evaluating bikky, use the [fully hosted config](config/fully-hosted.md).
+Local model quality depends on the models you run. For the strongest extraction and embedding quality while evaluating bikky, use the [hosted models config](config/hosted-models.md).
 
 ```json
 {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,12 +30,12 @@ Config lives at `~/.bikky/config.json`, or at `BIKKY_HOME/config.json` when `BIK
 
 If you know which path you want, start with the focused guide:
 
-| Setup | Best for | Guide |
-|---|---|---|
-| Fully hosted | Best performance and teams; managed vector storage and models | [Fully hosted config](config/fully-hosted.md) |
-| Local Qdrant + hosted models | Local vector storage with hosted extraction and embedding | [Hosted models config](config/hosted-models.md) |
-| Local and free | Private/free testing; quality depends on local models | [Local config guide](config/local.md) |
-| Hosted Qdrant + local models | Shared vector storage while keeping model calls local | [Hosted Qdrant + local models](config/hosted-qdrant-local-models.md) |
+| Setup                         | Best for                                                     | Guide                                                                    |
+| ----------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| Fully hosted                  | Best performance and teams; managed vector storage and models | [Fully hosted config](config/fully-hosted.md)                            |
+| Local Qdrant + hosted models  | Local vector storage with hosted extraction and embedding    | [Hosted models config](config/hosted-models.md)                          |
+| Local and free                | Private/free testing; quality depends on local models        | [Local config guide](config/local.md)                                    |
+| Hosted Qdrant + local models  | Shared vector storage while keeping model calls local        | [Hosted Qdrant + local models](config/hosted-qdrant-local-models.md)     |
 
 ### Fully hosted
 
@@ -132,53 +132,59 @@ export QDRANT_API_KEY="..."  # only needed for Qdrant Cloud or authenticated sel
 
 Useful basics:
 
-| Env var | Config field | Notes |
-|---|---|---|
-| `QDRANT_URL` | `qdrant_url` | Required unless set in config |
-| `QDRANT_API_KEY` | `qdrant_api_key` | Optional for local/unauthenticated Qdrant; usually needed for Qdrant Cloud |
-| `BIKKY_HOME` | — | Moves the config/log/state directory from `~/.bikky` |
+| Env var          | Config field     | Notes                                                                       |
+| ---------------- | ---------------- | --------------------------------------------------------------------------- |
+| `QDRANT_URL`     | `qdrant_url`     | Required unless set in config                                               |
+| `QDRANT_API_KEY` | `qdrant_api_key` | Optional for local/unauthenticated Qdrant; usually needed for Qdrant Cloud  |
+| `BIKKY_HOME`     | —                | Moves the config/log/state directory from `~/.bikky`                        |
 
 ## Provider options
 
 You can keep the defaults unless you want hosted models.
 
-| Provider | Best for | Auth |
-|---|---|---|
-| `ollama` | Local and free defaults | None |
-| `openai` | Simple hosted models | `OPENAI_API_KEY` or `api_key` |
-| `bedrock` | AWS-managed models | AWS credentials or IAM role |
-| `portkey` | Gateway/routing over other providers | Portkey API key |
+| Provider  | Best for                                | Auth                              |
+| --------- | --------------------------------------- | --------------------------------- |
+| `ollama`  | Local and free defaults                 | None                              |
+| `openai`  | Simple hosted models                    | `OPENAI_API_KEY` or `api_key`     |
+| `bedrock` | AWS-managed models                      | AWS credentials or IAM role       |
+| `portkey` | Gateway/routing over other providers    | Portkey API key                   |
+
+## Advanced configuration
+
+These sections are optional references for custom providers, tuning, scoping, and daemon internals.
 
 <details>
-<summary>Advanced: full setting reference</summary>
+<summary><strong>Full setting reference</strong></summary>
 
 ### Qdrant
 
-| Setting | Env var | Default | Description |
-|---|---|---|---|
-| `qdrant_url` | `QDRANT_URL` | none | Qdrant REST URL |
-| `qdrant_api_key` | `QDRANT_API_KEY` | none | Optional for local/unauthenticated Qdrant; required for Qdrant Cloud/authenticated self-hosted Qdrant |
-| `collection` | `BIKKY_COLLECTION` | `bikky` | Collection name |
+| Setting          | Env var            | Default | Notes                          |
+| ---------------- | ------------------ | ------- | ------------------------------ |
+| `qdrant_url`     | `QDRANT_URL`       | none    | Qdrant REST URL                |
+| `qdrant_api_key` | `QDRANT_API_KEY`   | none    | API key for authenticated Qdrant |
+| `collection`     | `BIKKY_COLLECTION` | `bikky` | Collection name                |
+
+`qdrant_api_key` is optional for local or unauthenticated self-hosted Qdrant. Qdrant Cloud usually requires it.
 
 ### Embeddings
 
-| Setting | Env var | Default |
-|---|---|---|
-| `embedding.provider` | `EMBEDDING_PROVIDER` | `ollama` |
-| `embedding.model` | `EMBEDDING_MODEL` | `qwen3-embedding:0.6b` |
-| `embedding.dimensions` | `EMBEDDING_DIMENSIONS` | `1024` |
-| `embedding.base_url` | `EMBEDDING_BASE_URL` | `http://localhost:11434` |
-| `embedding.api_key` | `OPENAI_API_KEY` | — |
+| Setting                | Env var                | Default                  | Notes                                           |
+| ---------------------- | ---------------------- | ------------------------ | ----------------------------------------------- |
+| `embedding.provider`   | `EMBEDDING_PROVIDER`   | `ollama`                 | Embedding provider                              |
+| `embedding.model`      | `EMBEDDING_MODEL`      | `qwen3-embedding:0.6b`   | Embedding model name                            |
+| `embedding.dimensions` | `EMBEDDING_DIMENSIONS` | `1024`                   | Must match the selected model output            |
+| `embedding.base_url`   | `EMBEDDING_BASE_URL`   | `http://localhost:11434` | Used by local or OpenAI-compatible providers    |
+| `embedding.api_key`    | `OPENAI_API_KEY`       | —                        | Provider API key; can also be set in config     |
 
 Common model dimensions:
 
-| Provider | Model | Dimensions |
-|---|---|---|
-| `ollama` | `qwen3-embedding:0.6b` | `1024` |
-| `ollama` | `nomic-embed-text` | `768` |
-| `openai` | `text-embedding-3-small` | `1536` |
-| `openai` | `text-embedding-3-large` | `3072` |
-| `bedrock` | `amazon.titan-embed-text-v2:0` | `1024` |
+| Provider  | Model                            | Dimensions |
+| --------- | -------------------------------- | ---------- |
+| `ollama`  | `qwen3-embedding:0.6b`           | `1024`     |
+| `ollama`  | `nomic-embed-text`               | `768`      |
+| `openai`  | `text-embedding-3-small`         | `1536`     |
+| `openai`  | `text-embedding-3-large`         | `3072`     |
+| `bedrock` | `amazon.titan-embed-text-v2:0`   | `1024`     |
 
 If you change the embedding model, make sure `embedding.dimensions` matches the model output.
 
@@ -186,31 +192,31 @@ If you change the embedding model, make sure `embedding.dimensions` matches the 
 
 The LLM is used by background maintenance features. Ollama is the default.
 
-| Setting | Env var | Default |
-|---|---|---|
-| `llm.provider` | `LLM_PROVIDER` | `ollama` |
-| `llm.model` | `LLM_MODEL` | `qwen2.5:7b` |
-| `llm.base_url` | `LLM_BASE_URL` | `http://localhost:11434` |
-| `llm.api_key` | `OPENAI_API_KEY` | — |
-| `llm.extra.region` | `AWS_BEDROCK_REGION` / `AWS_REGION` | `us-east-1` |
+| Setting            | Env var                              | Default                  | Notes                                        |
+| ------------------ | ------------------------------------ | ------------------------ | -------------------------------------------- |
+| `llm.provider`     | `LLM_PROVIDER`                       | `ollama`                 | LLM provider                                 |
+| `llm.model`        | `LLM_MODEL`                          | `qwen2.5:7b`             | LLM model name                               |
+| `llm.base_url`     | `LLM_BASE_URL`                       | `http://localhost:11434` | Used by local or OpenAI-compatible providers |
+| `llm.api_key`      | `OPENAI_API_KEY`                     | —                        | Provider API key; can also be set in config  |
+| `llm.extra.region` | `AWS_BEDROCK_REGION` / `AWS_REGION`  | `us-east-1`              | AWS Bedrock region                           |
 
 ### Timeouts and retries
 
-| Setting | Env var | Default |
-|---|---|---|
-| `embedding.timeout_ms` | `BIKKY_EMBEDDING_TIMEOUT_MS` | `30000` |
-| `embedding.retries` | `BIKKY_EMBEDDING_RETRIES` | `2` |
-| `embedding.retry_base_delay_ms` | `BIKKY_EMBEDDING_RETRY_BASE_DELAY_MS` | `250` |
-| `llm.timeout_ms` | `BIKKY_LLM_TIMEOUT_MS` | `30000` |
-| `llm.retries` | `BIKKY_LLM_RETRIES` | `2` |
-| `llm.retry_base_delay_ms` | `BIKKY_LLM_RETRY_BASE_DELAY_MS` | `250` |
+| Setting                         | Env var                                  | Default |
+| ------------------------------- | ---------------------------------------- | ------- |
+| `embedding.timeout_ms`          | `BIKKY_EMBEDDING_TIMEOUT_MS`             | `30000` |
+| `embedding.retries`             | `BIKKY_EMBEDDING_RETRIES`                | `2`     |
+| `embedding.retry_base_delay_ms` | `BIKKY_EMBEDDING_RETRY_BASE_DELAY_MS`    | `250`   |
+| `llm.timeout_ms`                | `BIKKY_LLM_TIMEOUT_MS`                   | `30000` |
+| `llm.retries`                   | `BIKKY_LLM_RETRIES`                      | `2`     |
+| `llm.retry_base_delay_ms`       | `BIKKY_LLM_RETRY_BASE_DELAY_MS`          | `250`   |
 
 Retries use jittered exponential backoff for transient errors, rate limits, and timeouts. Authentication and bad-request errors fail fast.
 
 </details>
 
 <details>
-<summary>Advanced: Portkey and Bedrock examples</summary>
+<summary><strong>Portkey and Bedrock examples</strong></summary>
 
 ### Portkey gateway
 
@@ -257,7 +263,7 @@ Bedrock reads `embedding.extra.region` and `llm.extra.region`. `AWS_BEDROCK_REGI
 </details>
 
 <details>
-<summary>Advanced: workspace and metadata scoping</summary>
+<summary><strong>Workspace and metadata scoping</strong></summary>
 
 Most users do not need to manage scopes manually. bikky can store optional metadata such as `workspace_id`, `repo`, `branch`, `task_key`, `workstream_key`, and `episode_id` when an agent or daemon has that context.
 
@@ -285,40 +291,40 @@ The literal workspace name `"default"` also reads legacy facts that do not have 
 </details>
 
 <details>
-<summary>Advanced: daemon, watchers, and logs</summary>
+<summary><strong>Daemon, watchers, and logs</strong></summary>
 
 You normally do not need to tune these. `bikky setup` starts the daemon and registers supported MCP clients.
 
 ### Daemon settings
 
-| Setting | Default | Description |
-|---|---|---|
-| `daemon.tick_interval_sec` | `5` | Seconds between daemon loop ticks |
-| `daemon.extract_every_sec` | `300` | Seconds between extraction runs |
-| `daemon.extract_min_events` | `10` | Minimum session events before triggering extraction |
-| `daemon.consolidation_enabled` | `true` | Consolidate session summaries into durable patterns |
-| `daemon.relation_inference_enabled` | `true` | Infer entity relationships |
-| `daemon.entity_typing_enabled` | `true` | Classify entities for UI/graph filtering |
-| `daemon.staleness_threshold_days` | `30` | Days before a fact is flagged as stale |
+| Setting                              | Default | Description                                      |
+| ------------------------------------ | ------- | ------------------------------------------------ |
+| `daemon.tick_interval_sec`           | `5`     | Seconds between daemon loop ticks                |
+| `daemon.extract_every_sec`           | `300`   | Seconds between extraction runs                  |
+| `daemon.extract_min_events`          | `10`    | Minimum events before extraction                    |
+| `daemon.consolidation_enabled`       | `true`  | Consolidate summaries into durable patterns         |
+| `daemon.relation_inference_enabled`  | `true`  | Infer entity relationships                       |
+| `daemon.entity_typing_enabled`       | `true`  | Classify entities for UI/graph filtering         |
+| `daemon.staleness_threshold_days`    | `30`    | Days before a fact is flagged as stale           |
 
 ### Watcher settings
 
-| Setting | Default | Description |
-|---|---|---|
-| `watchers.copilot.enabled` | `true` | Watch GitHub Copilot session logs |
-| `watchers.copilot.path` | `~/.copilot/session-state` | Path to Copilot session directory |
-| `watchers.claude.enabled` | `true` | Watch Claude Code project logs |
-| `watchers.claude.path` | `~/.claude/projects` | Path to Claude Code projects directory |
+| Setting                    | Default                    | Description                       |
+| -------------------------- | -------------------------- | --------------------------------- |
+| `watchers.copilot.enabled` | `true`                     | Watch GitHub Copilot session logs |
+| `watchers.copilot.path`    | `~/.copilot/session-state` | Path to Copilot session directory |
+| `watchers.claude.enabled`  | `true`                     | Watch Claude Code project logs    |
+| `watchers.claude.path`     | `~/.claude/projects`       | Path to Claude Code projects         |
 
 ### Logs
 
 bikky writes logs to `~/.bikky/logs/`:
 
-| File | Written by |
-|---|---|
-| `mcp.log` | MCP server |
+| File         | Written by        |
+| ------------ | ----------------- |
+| `mcp.log`    | MCP server        |
 | `daemon.log` | Background daemon |
-| `llm.jsonl` | LLM telemetry |
+| `llm.jsonl`  | LLM telemetry     |
 
 Pretty-print logs with:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -153,10 +153,9 @@ You can keep the defaults unless you want hosted models.
 
 These sections are optional references for custom providers, tuning, scoping, and daemon internals.
 
-<details>
-<summary><strong>Full setting reference</strong></summary>
+### Full setting reference
 
-### Qdrant
+#### Qdrant
 
 | Setting          | Env var            | Default | Notes                          |
 | ---------------- | ------------------ | ------- | ------------------------------ |
@@ -166,7 +165,7 @@ These sections are optional references for custom providers, tuning, scoping, an
 
 `qdrant_api_key` is optional for local or unauthenticated self-hosted Qdrant. Qdrant Cloud usually requires it.
 
-### Embeddings
+#### Embeddings
 
 | Setting                | Env var                | Default                  | Notes                                           |
 | ---------------------- | ---------------------- | ------------------------ | ----------------------------------------------- |
@@ -188,7 +187,7 @@ Common model dimensions:
 
 If you change the embedding model, make sure `embedding.dimensions` matches the model output.
 
-### LLM
+#### LLM
 
 The LLM is used by background maintenance features. Ollama is the default.
 
@@ -200,7 +199,7 @@ The LLM is used by background maintenance features. Ollama is the default.
 | `llm.api_key`      | `OPENAI_API_KEY`                     | —                        | Provider API key; can also be set in config  |
 | `llm.extra.region` | `AWS_BEDROCK_REGION` / `AWS_REGION`  | `us-east-1`              | AWS Bedrock region                           |
 
-### Timeouts and retries
+#### Timeouts and retries
 
 | Setting                         | Env var                                  | Default |
 | ------------------------------- | ---------------------------------------- | ------- |
@@ -213,12 +212,9 @@ The LLM is used by background maintenance features. Ollama is the default.
 
 Retries use jittered exponential backoff for transient errors, rate limits, and timeouts. Authentication and bad-request errors fail fast.
 
-</details>
+### Portkey and Bedrock examples
 
-<details>
-<summary><strong>Portkey and Bedrock examples</strong></summary>
-
-### Portkey gateway
+#### Portkey gateway
 
 ```json
 {
@@ -239,7 +235,7 @@ Retries use jittered exponential backoff for transient errors, rate limits, and 
 }
 ```
 
-### AWS Bedrock
+#### AWS Bedrock
 
 ```json
 {
@@ -260,10 +256,7 @@ Retries use jittered exponential backoff for transient errors, rate limits, and 
 
 Bedrock reads `embedding.extra.region` and `llm.extra.region`. `AWS_BEDROCK_REGION` populates both, falling back to `AWS_REGION`; `aws_profile` or `AWS_PROFILE` selects the shared AWS profile when you are not using direct env credentials.
 
-</details>
-
-<details>
-<summary><strong>Workspace and metadata scoping</strong></summary>
+### Workspace and metadata scoping
 
 Most users do not need to manage scopes manually. bikky can store optional metadata such as `workspace_id`, `repo`, `branch`, `task_key`, `workstream_key`, and `episode_id` when an agent or daemon has that context.
 
@@ -288,35 +281,32 @@ Example:
 
 The literal workspace name `"default"` also reads legacy facts that do not have a `workspace_id` payload. Other named workspaces are strict.
 
-</details>
-
-<details>
-<summary><strong>Daemon, watchers, and logs</strong></summary>
+### Daemon, watchers, and logs
 
 You normally do not need to tune these. `bikky setup` starts the daemon and registers supported MCP clients.
 
-### Daemon settings
+#### Daemon settings
 
 | Setting                              | Default | Description                                      |
 | ------------------------------------ | ------- | ------------------------------------------------ |
 | `daemon.tick_interval_sec`           | `5`     | Seconds between daemon loop ticks                |
 | `daemon.extract_every_sec`           | `300`   | Seconds between extraction runs                  |
-| `daemon.extract_min_events`          | `10`    | Minimum events before extraction                    |
-| `daemon.consolidation_enabled`       | `true`  | Consolidate summaries into durable patterns         |
+| `daemon.extract_min_events`          | `10`    | Minimum events before extraction                 |
+| `daemon.consolidation_enabled`       | `true`  | Consolidate summaries into durable patterns      |
 | `daemon.relation_inference_enabled`  | `true`  | Infer entity relationships                       |
 | `daemon.entity_typing_enabled`       | `true`  | Classify entities for UI/graph filtering         |
 | `daemon.staleness_threshold_days`    | `30`    | Days before a fact is flagged as stale           |
 
-### Watcher settings
+#### Watcher settings
 
 | Setting                    | Default                    | Description                       |
 | -------------------------- | -------------------------- | --------------------------------- |
 | `watchers.copilot.enabled` | `true`                     | Watch GitHub Copilot session logs |
 | `watchers.copilot.path`    | `~/.copilot/session-state` | Path to Copilot session directory |
 | `watchers.claude.enabled`  | `true`                     | Watch Claude Code project logs    |
-| `watchers.claude.path`     | `~/.claude/projects`       | Path to Claude Code projects         |
+| `watchers.claude.path`     | `~/.claude/projects`       | Path to Claude Code projects      |
 
-### Logs
+#### Logs
 
 bikky writes logs to `~/.bikky/logs/`:
 
@@ -331,8 +321,6 @@ Pretty-print logs with:
 ```bash
 tail -f ~/.bikky/logs/daemon.log | npx pino-pretty
 ```
-
-</details>
 
 ## Troubleshooting
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,9 @@ If you know which path you want, start with the focused guide:
 
 ### Local and free
 
-Use this first. Qdrant runs locally and Ollama provides the default embedding + LLM models.
+Use this first for private, free testing. Qdrant runs locally and Ollama provides the default embedding + LLM models.
+
+Local model quality depends on the models you run. For the strongest extraction and embedding quality while evaluating bikky, use the [fully hosted config](config/fully-hosted.md).
 
 ```json
 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bikky",
-  "version": "0.3.10",
+  "version": "0.3.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bikky",
-      "version": "0.3.10",
+      "version": "0.3.13",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bikky",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Shared memory for AI coding sessions — MCP server + background daemon",
   "type": "module",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary
- fold the separate “How it works” content into “How bikky solves it”
- remove the duplicate architecture-focused section from the README
- keep the explanation short and beginner-friendly

## Validation
- docs-only README change reviewed locally

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>