### PR TITLE
Map legacy contributor identity

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+zrelli-s <saber.zrelli@outlook.com> Saber Zrelli <saber@apate.com>


### PR DESCRIPTION
## Summary
- Add a root .mailmap entry that maps the legacy Saber Zrelli <saber@apate.com> author identity to zrelli-s <saber.zrelli@outlook.com>
- Keeps GitHub contributor attribution consolidated once this lands on the default branch

## Verification
- Ran `git check-mailmap 'Saber Zrelli <saber@apate.com>'`
- Confirmed `git shortlog -sne HEAD` folds the legacy identity into zrelli-s