### PR TITLE
Ingest Claude Code transcripts

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -370,6 +370,8 @@ You normally do not need to tune these. `bikky setup` starts the daemon and regi
 | `watchers.claude.enabled`  | `true`                     | Watch Claude Code project logs    |
 | `watchers.claude.path`     | `~/.claude/projects`       | Path to Claude Code projects      |
 
+Claude Code ingestion reads top-level `*.jsonl` transcripts inside each project directory under `watchers.claude.path`. It captures user/assistant text and skips tool calls, tool results, attachments, file snapshots, permission records, and thinking blocks.
+
 #### Logs
 
 bikky writes logs to `~/.bikky/logs/`:

--- a/src/daemon/extraction.ts
+++ b/src/daemon/extraction.ts
@@ -1,17 +1,17 @@
 /**
- * Events-based memory extraction — reads Copilot CLI events.jsonl transcripts,
+ * Events-based memory extraction — reads supported coding-agent transcripts,
  * extracts facts via LLM, and stores them in Qdrant with source: "system".
  *
  * Uses a JSON file for extraction state (high-water byte offsets) instead of SQLite.
- * Active session detection scans ~/.copilot/session-state/ for lock files.
+ * Copilot session detection uses lock files. Claude Code detection uses
+ * top-level JSONL transcripts under ~/.claude/projects.
  */
 
-import { readFile, readdir, stat } from "node:fs/promises";
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { join } from "node:path";
 
-import { loadConfig, STATE_DIR, EXTRACTION_HEALTH_PATH } from "../config.js";
+import { STATE_DIR, EXTRACTION_HEALTH_PATH } from "../config.js";
 import type { BikkyConfig } from "../config.js";
 import * as qdrant from "./qdrant.js";
 import { chatCompletion } from "../llm/index.js";
@@ -41,6 +41,16 @@ import { shouldSummarizeEvents, updateSessionSummary } from "./session-summary.j
 import { redactStorageText } from "../privacy/redaction.js";
 import { compareSubtype, hasTypedToken, verifyGrounding, verifyVolatilityCoherence } from "./extraction-rules.js";
 import { resolveActorIdentity } from "../provenance/actor.js";
+import {
+  discoverClaudeTranscriptMappings,
+  discoverCopilotTranscriptMappings,
+  extractionStateKey,
+  readNewTranscriptEvents,
+  transcriptLabel,
+  type ParsedEvent,
+  type TranscriptMapping,
+  type TranscriptSource,
+} from "./transcript-sources.js";
 
 // ── Module state ─────────────────────────────────────────────────────────────
 
@@ -52,12 +62,6 @@ export const setLogger = (fn: LogFn): void => {
 };
 
 // ── Constants ────────────────────────────────────────────────────────────────
-
-const EXTRACTABLE_TYPES = new Set([
-  "user.message",
-  "assistant.message",
-  "session.compaction_complete",
-]);
 
 export const DEFAULT_EXTRACTION_PROMPT = `You are Bikky's memory extraction agent for open-source coding agents. Extract durable, reusable facts that help a future agent continue work without rereading the whole transcript.
 
@@ -131,7 +135,9 @@ const EXTRACTION_STATE_PATH = join(STATE_DIR, "extraction-state.json");
 
 interface ExtractionState {
   session_id: string;
-  copilot_uuid: string;
+  source?: TranscriptSource;
+  copilot_uuid?: string;
+  claude_session_id?: string;
   events_path: string;
   byte_offset: number;
   last_extracted_at: string | null;
@@ -167,135 +173,8 @@ const upsertExtractionState = (state: ExtractionState): void => {
   saveExtractionStates(states);
 };
 
-// ── PID → Copilot UUID resolution ───────────────────────────────────────────
-
-interface LockMapping {
-  pid: number;
-  uuid: string;
-  eventsPath: string;
-}
-
-/**
- * Scan lock files to build PID → Copilot UUID mapping.
- * Copilot CLI writes `inuse.<pid>.lock` in each session directory.
- */
-const resolveLockFiles = async (): Promise<LockMapping[]> => {
-  const cfg = loadConfig();
-  const copilotStateDir = cfg.watchers.copilot.path;
-  const mappings: LockMapping[] = [];
-
-  try {
-    const sessionDirs = await readdir(copilotStateDir, { withFileTypes: true });
-    for (const sessionDir of sessionDirs) {
-      if (!sessionDir.isDirectory()) continue;
-
-      const uuid = sessionDir.name;
-      const sessionPath = join(copilotStateDir, uuid);
-      const entries = await readdir(sessionPath, { withFileTypes: true });
-
-      for (const entry of entries) {
-        if (!entry.isFile()) continue;
-
-        const lockFile = entry.name; // inuse.12345.lock
-
-        const pidMatch = lockFile.match(/^inuse\.(\d+)\.lock$/);
-        if (!pidMatch || !uuid) continue;
-
-        const pid = parseInt(pidMatch[1]!, 10);
-        const eventsPath = join(copilotStateDir, uuid, "events.jsonl");
-
-        // Verify events.jsonl exists
-        try {
-          await stat(eventsPath);
-          mappings.push({ pid, uuid, eventsPath });
-        } catch {
-          // No events.jsonl — skip
-        }
-      }
-    }
-  } catch (e) {
-    logFn("WARN", `Lock file scan failed: ${(e as Error).message}`);
-  }
-
-  return mappings;
-};
-
-/**
- * Check if a process is still running.
- */
 const isProcessAlive = (pid: number): boolean => {
   try { process.kill(pid, 0); return true; } catch { return false; }
-};
-
-// ── Event reading ────────────────────────────────────────────────────────────
-
-interface ParsedEvent {
-  type: string;
-  content: string;
-  timestamp: string;
-}
-
-/**
- * Read new events from events.jsonl starting at the given byte offset.
- * Returns parsed extractable events and the new byte offset.
- */
-const readNewEvents = async (
-  eventsPath: string,
-  byteOffset: number,
-): Promise<{ events: ParsedEvent[]; newOffset: number; totalLines: number }> => {
-  const fileStat = await stat(eventsPath);
-  if (fileStat.size <= byteOffset) {
-    return { events: [], newOffset: byteOffset, totalLines: 0 };
-  }
-
-  // Read from byte offset to end of file
-  const buf = await readFile(eventsPath);
-  const newContent = buf.subarray(byteOffset).toString("utf-8");
-
-  const events: ParsedEvent[] = [];
-  let totalLines = 0;
-
-  for (const line of newContent.split("\n")) {
-    if (!line.trim()) continue;
-    totalLines++;
-
-    try {
-      const obj = JSON.parse(line) as {
-        type: string;
-        timestamp?: string;
-        data?: Record<string, unknown>;
-      };
-
-      if (!EXTRACTABLE_TYPES.has(obj.type)) continue;
-
-      const data = obj.data || {};
-      let content = "";
-
-      if (obj.type === "user.message") {
-        content = (data.content as string) || "";
-      } else if (obj.type === "assistant.message") {
-        const parts: string[] = [];
-        if (data.content) parts.push(data.content as string);
-        if (data.reasoningText) parts.push(data.reasoningText as string);
-        // Skip reasoningOpaque — encrypted noise
-        content = parts.join("\n");
-      } else if (obj.type === "session.compaction_complete") {
-        content = (data.summaryContent as string) || "";
-      }
-
-      if (content.length > 0) {
-        events.push({
-          type: obj.type,
-          content,
-          timestamp: obj.timestamp || new Date().toISOString(),
-        });
-      }
-    } catch {
-      // Malformed line — skip
-    }
-  }
-
-  return { events, newOffset: fileStat.size, totalLines };
 };
 
 /**
@@ -629,6 +508,7 @@ const storeFacts = async (
   facts: ExtractedFact[],
   sessionId: string,
   config?: BikkyConfig,
+  source?: TranscriptSource,
 ): Promise<number> => {
   if (!qdrant.isReady()) {
     logFn("WARN", "Extraction: Qdrant not ready, skipping store");
@@ -640,6 +520,7 @@ const storeFacts = async (
     capture_policy_version: CAPTURE_POLICY_VERSION,
     extracted_by_prompt: `${EXTRACTION_PROMPT_DESCRIPTOR.id}@${EXTRACTION_PROMPT_DESCRIPTOR.version}`,
   };
+  if (source) baseMeta.extraction_source = source;
   const actor = resolveActorIdentity({ config });
   if (actor.actor_label) baseMeta.actor_label = actor.actor_label;
   if (actor.source) baseMeta.actor_source = actor.source;
@@ -871,18 +752,40 @@ export const tick = async (config: BikkyConfig): Promise<void> => {
   const minEvents = config.daemon.extract_min_events || CAPTURE_TRIGGERS.factExtraction.minEvents;
 
   try {
-    // Extract from ALL active Copilot sessions with events.jsonl
-    const lockMappings = await resolveLockFiles();
-    const aliveMappings = lockMappings.filter(m => isProcessAlive(m.pid));
-    logFn("INFO", `Extraction tick: ${aliveMappings.length} active copilot session(s) with events.jsonl`);
+    const copilotMappings = await discoverCopilotMappings(config);
+    const claudeMappings = await discoverClaudeMappings(config);
+    const mappings = [...copilotMappings, ...claudeMappings];
 
-    writeExtractionHealth(aliveMappings.length, config);
+    logFn(
+      "INFO",
+      `Extraction tick: ${copilotMappings.length} active copilot session(s), ${claudeMappings.length} claude transcript(s)`,
+    );
 
-    for (const mapping of aliveMappings) {
-      await extractForUuid(mapping, minEvents, config);
+    writeExtractionHealth({ copilot: copilotMappings.length, claude: claudeMappings.length }, config);
+
+    for (const mapping of mappings) {
+      await extractForMapping(mapping, minEvents, config);
     }
   } catch (e) {
     logFn("ERROR", `Extraction tick failed: ${(e as Error).message}`);
+  }
+};
+
+const discoverCopilotMappings = async (config: BikkyConfig): Promise<TranscriptMapping[]> => {
+  try {
+    return await discoverCopilotTranscriptMappings(config, isProcessAlive);
+  } catch (e) {
+    logFn("WARN", `Copilot transcript scan failed: ${(e as Error).message}`);
+    return [];
+  }
+};
+
+const discoverClaudeMappings = async (config: BikkyConfig): Promise<TranscriptMapping[]> => {
+  try {
+    return await discoverClaudeTranscriptMappings(config);
+  } catch (e) {
+    logFn("WARN", `Claude transcript scan failed: ${(e as Error).message}`);
+    return [];
   }
 };
 
@@ -897,20 +800,51 @@ export interface ExtractionHealth {
   active_session_count: number;
   /** Configured copilot watcher path at the time of the tick. */
   watcher_path: string;
+  /** Per-source health, including non-Copilot watchers. */
+  sources?: Record<TranscriptSource, ExtractionSourceHealth>;
 }
 
-function writeExtractionHealth(activeCount: number, config: BikkyConfig): void {
+export interface ExtractionSourceHealth {
+  enabled: boolean;
+  watcher_path: string;
+  active_session_count: number;
+  last_active_session_at: string | null;
+}
+
+function writeExtractionHealth(activeCounts: Record<TranscriptSource, number>, config: BikkyConfig): void {
   try {
     let existing: Partial<ExtractionHealth> = {};
     if (existsSync(EXTRACTION_HEALTH_PATH)) {
       try { existing = JSON.parse(readFileSync(EXTRACTION_HEALTH_PATH, "utf-8")); } catch { /* ignore */ }
     }
     const now = new Date().toISOString();
+    const activeCount = activeCounts.copilot + activeCounts.claude;
+    const existingSources: Partial<Record<TranscriptSource, ExtractionSourceHealth>> = existing.sources ?? {};
+    const copilotLastActive = activeCounts.copilot > 0
+      ? now
+      : (existingSources.copilot?.last_active_session_at ?? existing.last_active_session_at ?? null);
+    const claudeLastActive = activeCounts.claude > 0
+      ? now
+      : (existingSources.claude?.last_active_session_at ?? null);
     const health: ExtractionHealth = {
       last_tick_at: now,
       last_active_session_at: activeCount > 0 ? now : (existing.last_active_session_at ?? null),
       active_session_count: activeCount,
       watcher_path: config.watchers.copilot.path,
+      sources: {
+        copilot: {
+          enabled: config.watchers.copilot.enabled,
+          watcher_path: config.watchers.copilot.path,
+          active_session_count: activeCounts.copilot,
+          last_active_session_at: copilotLastActive,
+        },
+        claude: {
+          enabled: config.watchers.claude.enabled,
+          watcher_path: config.watchers.claude.path,
+          active_session_count: activeCounts.claude,
+          last_active_session_at: claudeLastActive,
+        },
+      },
     };
     mkdirSync(STATE_DIR, { recursive: true });
     writeFileSync(EXTRACTION_HEALTH_PATH, JSON.stringify(health, null, 2) + "\n");
@@ -919,41 +853,44 @@ function writeExtractionHealth(activeCount: number, config: BikkyConfig): void {
   }
 }
 
-/**
- * Extract facts for a single Copilot session identified by UUID.
- * Uses UUID as the extraction_state key.
- * Automatically chunks large transcripts into multiple LLM calls.
- */
-const extractForUuid = async (
-  mapping: LockMapping,
+const extractForMapping = async (
+  mapping: TranscriptMapping,
   minEvents: number,
   config?: BikkyConfig,
 ): Promise<number> => {
-  const { uuid, eventsPath } = mapping;
-
-  // Use UUID as session_id in extraction_state (prefix with "uuid:" to avoid collisions)
-  const stateKey = `uuid:${uuid}`;
+  const { uuid, eventsPath, source } = mapping;
+  const stateKey = extractionStateKey(mapping);
+  const label = transcriptLabel(mapping);
 
   let state = getExtractionState(stateKey);
   if (!state) {
     state = {
       session_id: stateKey,
-      copilot_uuid: uuid,
+      source,
+      ...(source === "copilot" ? { copilot_uuid: uuid } : { claude_session_id: uuid }),
       events_path: eventsPath,
       byte_offset: 0,
       last_extracted_at: null,
       event_count: 0,
     };
   }
+  state.source = source;
+  if (source === "copilot") {
+    state.copilot_uuid = uuid;
+  } else {
+    state.claude_session_id = uuid;
+  }
+  state.events_path = eventsPath;
 
   // Read new events
-  const { events, newOffset, totalLines } = await readNewEvents(eventsPath, state.byte_offset);
+  const { events, newOffset, totalLines } = await readNewTranscriptEvents(eventsPath, state.byte_offset, source);
 
   const shouldSummarize = shouldSummarizeEvents(events, minEvents);
 
   if (events.length < minEvents && !shouldSummarize) {
-    // Still update offset to avoid re-scanning non-extractable events
-    if (newOffset > state.byte_offset) {
+    // Still advance past pure noise, but keep below-threshold conversation
+    // events buffered until enough context accumulates for extraction.
+    if (events.length === 0 && newOffset > state.byte_offset) {
       state.byte_offset = newOffset;
       state.event_count += totalLines;
       upsertExtractionState(state);
@@ -967,13 +904,13 @@ const extractForUuid = async (
 
   for (let i = 0; i < chunks.length; i++) {
     const transcript = buildTranscript(chunks[i]!);
-    logFn("DEBUG", `Extraction: UUID ${uuid.slice(0, 8)} — chunk ${i + 1}/${chunks.length}, ${chunks[i]!.length} events, ${transcript.length} chars`);
+    logFn("DEBUG", `Extraction: ${label} — chunk ${i + 1}/${chunks.length}, ${chunks[i]!.length} events, ${transcript.length} chars`);
 
     if (events.length >= minEvents) {
       const facts = await extractFacts(transcript, stateKey, config);
 
       if (facts.length > 0) {
-        const stored = await storeFacts(facts, stateKey, config);
+        const stored = await storeFacts(facts, stateKey, config, source);
         totalFacts += stored;
       }
     }
@@ -982,16 +919,21 @@ const extractForUuid = async (
   }
 
   if (totalFacts > 0) {
-    logFn("INFO", `Extraction: UUID ${uuid.slice(0, 8)} — ${totalFacts} facts stored (${events.length} events, ${chunks.length} chunk(s))`);
+    logFn("INFO", `Extraction: ${label} — ${totalFacts} facts stored (${events.length} events, ${chunks.length} chunk(s))`);
   } else {
-    logFn("DEBUG", `Extraction: UUID ${uuid.slice(0, 8)} — ${events.length} events but 0 facts extracted`);
+    logFn("DEBUG", `Extraction: ${label} — ${events.length} events but 0 facts extracted`);
   }
 
   // Update high-water mark
   state.byte_offset = newOffset;
   state.event_count += totalLines;
   state.last_extracted_at = new Date().toISOString();
-  state.copilot_uuid = uuid;
+  state.source = source;
+  if (source === "copilot") {
+    state.copilot_uuid = uuid;
+  } else {
+    state.claude_session_id = uuid;
+  }
   state.events_path = eventsPath;
   upsertExtractionState(state);
 

--- a/src/daemon/transcript-sources.test.ts
+++ b/src/daemon/transcript-sources.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, beforeEach, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { CONFIG_DEFAULTS, type BikkyConfig } from "../config.js";
+import {
+  discoverClaudeTranscriptMappings,
+  discoverCopilotTranscriptMappings,
+  extractionStateKey,
+  parseClaudeTranscriptLine,
+  parseCopilotTranscriptLine,
+  readNewTranscriptEvents,
+} from "./transcript-sources.js";
+
+const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-transcript-sources-"));
+
+const testConfig = (watchers: Partial<BikkyConfig["watchers"]>): BikkyConfig => ({
+  ...CONFIG_DEFAULTS,
+  watchers: {
+    ...CONFIG_DEFAULTS.watchers,
+    ...watchers,
+  },
+});
+
+beforeEach(() => {
+  fs.rmSync(testDir, { recursive: true, force: true });
+  fs.mkdirSync(testDir, { recursive: true });
+});
+
+after(() => {
+  fs.rmSync(testDir, { recursive: true, force: true });
+});
+
+describe("transcript source discovery", () => {
+  it("discovers live Copilot sessions with events.jsonl", async () => {
+    const sessionDir = path.join(testDir, "copilot-session");
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(path.join(sessionDir, "events.jsonl"), "");
+    fs.writeFileSync(path.join(sessionDir, "inuse.123.lock"), "");
+    fs.writeFileSync(path.join(sessionDir, "inuse.456.lock"), "");
+
+    const mappings = await discoverCopilotTranscriptMappings(
+      testConfig({ copilot: { enabled: true, path: testDir } }),
+      (pid) => pid === 123,
+    );
+
+    assert.strictEqual(mappings.length, 1);
+    assert.deepStrictEqual(mappings[0], {
+      source: "copilot",
+      pid: 123,
+      uuid: "copilot-session",
+      eventsPath: path.join(sessionDir, "events.jsonl"),
+      active: true,
+    });
+  });
+
+  it("discovers Claude project transcripts and skips nested artifacts", async () => {
+    const projectDir = path.join(testDir, "-Users-test-code-project");
+    const nestedDir = path.join(projectDir, "subagents");
+    fs.mkdirSync(nestedDir, { recursive: true });
+    fs.writeFileSync(path.join(projectDir, "claude-session.jsonl"), "");
+    fs.writeFileSync(path.join(nestedDir, "nested-session.jsonl"), "");
+
+    const mappings = await discoverClaudeTranscriptMappings(
+      testConfig({ claude: { enabled: true, path: testDir } }),
+    );
+
+    assert.strictEqual(mappings.length, 1);
+    assert.strictEqual(mappings[0].source, "claude");
+    assert.strictEqual(mappings[0].uuid, "claude-session");
+    assert.strictEqual(mappings[0].eventsPath, path.join(projectDir, "claude-session.jsonl"));
+    assert.strictEqual(extractionStateKey(mappings[0]), "claude:claude-session");
+  });
+
+  it("returns no Claude transcripts when the watcher is disabled", async () => {
+    fs.writeFileSync(path.join(testDir, "claude-session.jsonl"), "");
+
+    const mappings = await discoverClaudeTranscriptMappings(
+      testConfig({ claude: { enabled: false, path: testDir } }),
+    );
+
+    assert.deepStrictEqual(mappings, []);
+  });
+
+  it("returns no transcripts for missing watcher directories", async () => {
+    const missingDir = path.join(testDir, "missing");
+
+    assert.deepStrictEqual(
+      await discoverCopilotTranscriptMappings(
+        testConfig({ copilot: { enabled: true, path: missingDir } }),
+        () => true,
+      ),
+      [],
+    );
+    assert.deepStrictEqual(
+      await discoverClaudeTranscriptMappings(
+        testConfig({ claude: { enabled: true, path: missingDir } }),
+      ),
+      [],
+    );
+  });
+});
+
+describe("transcript source parsing", () => {
+  it("parses Copilot user, assistant, and summary events", () => {
+    assert.deepStrictEqual(
+      parseCopilotTranscriptLine(JSON.stringify({
+        type: "assistant.message",
+        timestamp: "2026-05-04T00:00:00.000Z",
+        data: { content: "Done.", reasoningText: "Reasoned summary." },
+      })),
+      {
+        type: "assistant.message",
+        content: "Done.\nReasoned summary.",
+        timestamp: "2026-05-04T00:00:00.000Z",
+      },
+    );
+
+    assert.deepStrictEqual(
+      parseCopilotTranscriptLine(JSON.stringify({
+        type: "session.compaction_complete",
+        data: { summaryContent: "Prior session summary." },
+      }))?.content,
+      "Prior session summary.",
+    );
+  });
+
+  it("parses Claude text and skips tool/thinking blocks", () => {
+    const event = parseClaudeTranscriptLine(JSON.stringify({
+      type: "assistant",
+      timestamp: "2026-05-04T00:00:00.000Z",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "internal reasoning" },
+          { type: "text", text: "Visible answer." },
+          { type: "tool_use", name: "Read", input: { file_path: "src/index.ts" } },
+        ],
+      },
+    }));
+
+    assert.deepStrictEqual(event, {
+      type: "assistant.message",
+      content: "Visible answer.",
+      timestamp: "2026-05-04T00:00:00.000Z",
+    });
+  });
+
+  it("parses Claude user string content and ignores non-conversation records", () => {
+    assert.deepStrictEqual(
+      parseClaudeTranscriptLine(JSON.stringify({
+        type: "user",
+        message: { role: "user", content: "Please remember this preference." },
+      }))?.content,
+      "Please remember this preference.",
+    );
+
+    assert.strictEqual(
+      parseClaudeTranscriptLine(JSON.stringify({
+        type: "system",
+        content: "startup metadata",
+      })),
+      null,
+    );
+  });
+
+  it("reads new transcript events from a byte offset", async () => {
+    const firstLine = `${JSON.stringify({
+      type: "user",
+      message: { role: "user", content: "First message." },
+    })}\n`;
+    const secondLine = `${JSON.stringify({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "Second message." }] },
+    })}\n`;
+    const transcriptPath = path.join(testDir, "offset-session.jsonl");
+    fs.writeFileSync(transcriptPath, firstLine + secondLine);
+
+    const result = await readNewTranscriptEvents(transcriptPath, Buffer.byteLength(firstLine), "claude");
+
+    assert.strictEqual(result.events.length, 1);
+    assert.strictEqual(result.events[0].content, "Second message.");
+    assert.strictEqual(result.totalLines, 1);
+  });
+});

--- a/src/daemon/transcript-sources.ts
+++ b/src/daemon/transcript-sources.ts
@@ -1,0 +1,237 @@
+import { readFile, readdir, stat } from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import { basename, join } from "node:path";
+
+import type { BikkyConfig } from "../config.js";
+
+export type TranscriptSource = "copilot" | "claude";
+
+export interface TranscriptMapping {
+  source: TranscriptSource;
+  uuid: string;
+  eventsPath: string;
+  active: boolean;
+  pid?: number;
+}
+
+export interface ParsedEvent {
+  type: string;
+  content: string;
+  timestamp: string;
+}
+
+const COPILOT_EXTRACTABLE_TYPES = new Set([
+  "user.message",
+  "assistant.message",
+  "session.compaction_complete",
+]);
+
+const isNotFoundError = (error: unknown): boolean =>
+  typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+
+const readDirIfExists = async (dir: string): Promise<Dirent[]> => {
+  try {
+    return await readdir(dir, { withFileTypes: true });
+  } catch (e) {
+    if (isNotFoundError(e)) return [];
+    throw e;
+  }
+};
+
+export const extractionStateKey = (mapping: Pick<TranscriptMapping, "source" | "uuid">): string =>
+  mapping.source === "copilot" ? `uuid:${mapping.uuid}` : `claude:${mapping.uuid}`;
+
+export const transcriptLabel = (mapping: Pick<TranscriptMapping, "source" | "uuid">): string =>
+  `${mapping.source}:${mapping.uuid.slice(0, 8)}`;
+
+export const discoverCopilotTranscriptMappings = async (
+  config: BikkyConfig,
+  isProcessAlive: (pid: number) => boolean,
+): Promise<TranscriptMapping[]> => {
+  if (!config.watchers.copilot.enabled) return [];
+
+  const copilotStateDir = config.watchers.copilot.path;
+  const mappings: TranscriptMapping[] = [];
+
+  const sessionDirs = await readDirIfExists(copilotStateDir);
+  for (const sessionDir of sessionDirs) {
+    if (!sessionDir.isDirectory()) continue;
+
+    const uuid = sessionDir.name;
+    const sessionPath = join(copilotStateDir, uuid);
+    const entries = await readDirIfExists(sessionPath);
+
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+
+      const pidMatch = entry.name.match(/^inuse\.(\d+)\.lock$/);
+      if (!pidMatch || !uuid) continue;
+
+      const pid = parseInt(pidMatch[1]!, 10);
+      if (!isProcessAlive(pid)) continue;
+
+      const eventsPath = join(copilotStateDir, uuid, "events.jsonl");
+      try {
+        await stat(eventsPath);
+      } catch (e) {
+        if (isNotFoundError(e)) continue;
+        throw e;
+      }
+      mappings.push({ source: "copilot", pid, uuid, eventsPath, active: true });
+    }
+  }
+
+  return mappings;
+};
+
+export const discoverClaudeTranscriptMappings = async (config: BikkyConfig): Promise<TranscriptMapping[]> => {
+  if (!config.watchers.claude.enabled) return [];
+
+  const baseDir = config.watchers.claude.path;
+  const mappings: Array<TranscriptMapping & { mtimeMs: number }> = [];
+  const entries = await readDirIfExists(baseDir);
+
+  for (const entry of entries) {
+    const entryPath = join(baseDir, entry.name);
+    if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+      const fileStat = await stat(entryPath);
+      mappings.push({
+        source: "claude",
+        uuid: basename(entry.name, ".jsonl"),
+        eventsPath: entryPath,
+        active: true,
+        mtimeMs: fileStat.mtimeMs,
+      });
+      continue;
+    }
+
+    if (!entry.isDirectory()) continue;
+
+    const projectEntries = await readDirIfExists(entryPath);
+    for (const projectEntry of projectEntries) {
+      if (!projectEntry.isFile() || !projectEntry.name.endsWith(".jsonl")) continue;
+      const eventsPath = join(entryPath, projectEntry.name);
+      const fileStat = await stat(eventsPath);
+      mappings.push({
+        source: "claude",
+        uuid: basename(projectEntry.name, ".jsonl"),
+        eventsPath,
+        active: true,
+        mtimeMs: fileStat.mtimeMs,
+      });
+    }
+  }
+
+  return mappings
+    .sort((a, b) => b.mtimeMs - a.mtimeMs)
+    .map(({ mtimeMs: _mtimeMs, ...mapping }) => mapping);
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const stringField = (value: unknown): string =>
+  typeof value === "string" ? value : "";
+
+const claudeTextContent = (content: unknown): string => {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+
+  const parts: string[] = [];
+  for (const block of content) {
+    if (typeof block === "string") {
+      parts.push(block);
+      continue;
+    }
+    if (!isRecord(block) || block.type !== "text") continue;
+    const text = stringField(block.text);
+    if (text) parts.push(text);
+  }
+  return parts.join("\n");
+};
+
+export const parseCopilotTranscriptLine = (line: string): ParsedEvent | null => {
+  const obj = JSON.parse(line) as {
+    type?: string;
+    timestamp?: string;
+    data?: Record<string, unknown>;
+  };
+
+  if (!obj.type || !COPILOT_EXTRACTABLE_TYPES.has(obj.type)) return null;
+
+  const data = obj.data || {};
+  let content = "";
+
+  if (obj.type === "user.message") {
+    content = stringField(data.content);
+  } else if (obj.type === "assistant.message") {
+    const parts: string[] = [];
+    const contentText = stringField(data.content);
+    const reasoningText = stringField(data.reasoningText);
+    if (contentText) parts.push(contentText);
+    if (reasoningText) parts.push(reasoningText);
+    content = parts.join("\n");
+  } else if (obj.type === "session.compaction_complete") {
+    content = stringField(data.summaryContent);
+  }
+
+  if (!content) return null;
+  return {
+    type: obj.type,
+    content,
+    timestamp: obj.timestamp || new Date().toISOString(),
+  };
+};
+
+export const parseClaudeTranscriptLine = (line: string): ParsedEvent | null => {
+  const obj = JSON.parse(line) as Record<string, unknown>;
+  const recordType = obj.type;
+  if (recordType !== "user" && recordType !== "assistant") return null;
+
+  const message = isRecord(obj.message) ? obj.message : null;
+  if (!message) return null;
+
+  const role = message.role === "user" || message.role === "assistant" ? message.role : recordType;
+  if (role !== "user" && role !== "assistant") return null;
+
+  const content = claudeTextContent(message.content).trim();
+  if (!content) return null;
+
+  return {
+    type: role === "user" ? "user.message" : "assistant.message",
+    content,
+    timestamp: stringField(obj.timestamp) || new Date().toISOString(),
+  };
+};
+
+export const readNewTranscriptEvents = async (
+  eventsPath: string,
+  byteOffset: number,
+  source: TranscriptSource,
+): Promise<{ events: ParsedEvent[]; newOffset: number; totalLines: number }> => {
+  const fileStat = await stat(eventsPath);
+  if (fileStat.size <= byteOffset) {
+    return { events: [], newOffset: byteOffset, totalLines: 0 };
+  }
+
+  const buf = await readFile(eventsPath);
+  const newContent = buf.subarray(byteOffset).toString("utf-8");
+  const events: ParsedEvent[] = [];
+  let totalLines = 0;
+
+  for (const line of newContent.split("\n")) {
+    if (!line.trim()) continue;
+    totalLines++;
+
+    try {
+      const event = source === "claude"
+        ? parseClaudeTranscriptLine(line)
+        : parseCopilotTranscriptLine(line);
+      if (event) events.push(event);
+    } catch {
+      // Malformed line — skip it.
+    }
+  }
+
+  return { events, newOffset: fileStat.size, totalLines };
+};

--- a/src/daemon/watcher.test.ts
+++ b/src/daemon/watcher.test.ts
@@ -17,7 +17,7 @@ const TEST_BIKKY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-home-watche
 process.env.BIKKY_HOME = TEST_BIKKY_HOME;
 
 const { resetConfig, saveConfig, CONFIG_DEFAULTS } = await import("../config.js");
-const { discoverSessions } = await import("./watcher.js");
+const { discoverClaudeSessions, discoverSessions } = await import("./watcher.js");
 
 // ---------------------------------------------------------------------------
 // Test directory setup
@@ -29,17 +29,17 @@ function createTestDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "bikky-test-sessions-"));
 }
 
+before(() => {
+  testDir = createTestDir();
+});
+
+after(() => {
+  fs.rmSync(testDir, { recursive: true, force: true });
+  fs.rmSync(TEST_BIKKY_HOME, { recursive: true, force: true });
+  resetConfig();
+});
+
 describe("discoverSessions", () => {
-  before(() => {
-    testDir = createTestDir();
-  });
-
-  after(() => {
-    fs.rmSync(testDir, { recursive: true, force: true });
-    fs.rmSync(TEST_BIKKY_HOME, { recursive: true, force: true });
-    resetConfig();
-  });
-
   beforeEach(() => {
     resetConfig();
   });
@@ -242,5 +242,51 @@ describe("discoverSessions", () => {
     assert.strictEqual(typeof session.active, "boolean");
     assert.strictEqual(session.uuid, sessionUuid);
     assert.strictEqual(session.eventsPath, path.join(sessionDir, "events.jsonl"));
+  });
+});
+
+describe("discoverClaudeSessions", () => {
+  beforeEach(() => {
+    resetConfig();
+  });
+
+  it("discovers top-level Claude project transcripts", () => {
+    const claudeDir = path.join(testDir, "claude-projects");
+    const projectDir = path.join(claudeDir, "-Users-test-code-project");
+    const nestedDir = path.join(projectDir, "subagents");
+    fs.mkdirSync(nestedDir, { recursive: true });
+    fs.writeFileSync(path.join(projectDir, "claude-session-1.jsonl"), '{"type":"user"}\n');
+    fs.writeFileSync(path.join(nestedDir, "nested-session.jsonl"), '{"type":"assistant"}\n');
+
+    saveConfig({
+      ...CONFIG_DEFAULTS,
+      watchers: {
+        ...CONFIG_DEFAULTS.watchers,
+        claude: { enabled: true, path: claudeDir },
+      },
+    });
+
+    const sessions = discoverClaudeSessions();
+    assert.strictEqual(sessions.length, 1);
+    assert.strictEqual(sessions[0].source, "claude");
+    assert.strictEqual(sessions[0].uuid, "claude-session-1");
+    assert.strictEqual(sessions[0].active, true);
+    assert.strictEqual(sessions[0].eventsPath, path.join(projectDir, "claude-session-1.jsonl"));
+  });
+
+  it("returns empty array when the Claude watcher is disabled", () => {
+    const claudeDir = path.join(testDir, "claude-disabled");
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.writeFileSync(path.join(claudeDir, "session.jsonl"), '{"type":"user"}\n');
+
+    saveConfig({
+      ...CONFIG_DEFAULTS,
+      watchers: {
+        ...CONFIG_DEFAULTS.watchers,
+        claude: { enabled: false, path: claudeDir },
+      },
+    });
+
+    assert.deepStrictEqual(discoverClaudeSessions(), []);
   });
 });

--- a/src/daemon/watcher.ts
+++ b/src/daemon/watcher.ts
@@ -1,6 +1,5 @@
 /**
- * Copilot session watcher — detects active sessions by scanning
- * ~/.copilot/session-state/ for directories with events.jsonl files.
+ * Session watcher helpers for supported coding-agent transcript directories.
  */
 
 import fs from "node:fs";
@@ -10,7 +9,8 @@ import { loadConfig } from "../config.js";
 export interface WatchedSession {
   uuid: string;
   eventsPath: string;
-  active: boolean;  // has inuse.*.lock file
+  active: boolean;
+  source?: "copilot" | "claude";
 }
 
 export function discoverSessions(): WatchedSession[] {
@@ -40,7 +40,60 @@ export function discoverSessions(): WatchedSession[] {
       uuid: entry,
       eventsPath,
       active: lockFiles.length > 0,
+      source: "copilot",
     });
   }
+  return sessions;
+}
+
+export function discoverClaudeSessions(): WatchedSession[] {
+  const cfg = loadConfig();
+  if (!cfg.watchers.claude.enabled) return [];
+
+  const baseDir = cfg.watchers.claude.path;
+  if (!fs.existsSync(baseDir)) return [];
+
+  const sessions: WatchedSession[] = [];
+  for (const entry of fs.readdirSync(baseDir)) {
+    const projectPath = path.join(baseDir, entry);
+
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(projectPath);
+    } catch {
+      continue;
+    }
+
+    if (stat.isFile() && entry.endsWith(".jsonl")) {
+      sessions.push({
+        uuid: path.basename(entry, ".jsonl"),
+        eventsPath: projectPath,
+        active: true,
+        source: "claude",
+      });
+      continue;
+    }
+
+    if (!stat.isDirectory()) continue;
+
+    for (const file of fs.readdirSync(projectPath)) {
+      const transcriptPath = path.join(projectPath, file);
+      let transcriptStat: fs.Stats;
+      try {
+        transcriptStat = fs.statSync(transcriptPath);
+      } catch {
+        continue;
+      }
+      if (!transcriptStat.isFile() || !file.endsWith(".jsonl")) continue;
+
+      sessions.push({
+        uuid: path.basename(file, ".jsonl"),
+        eventsPath: transcriptPath,
+        active: true,
+        source: "claude",
+      });
+    }
+  }
+
   return sessions;
 }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -441,6 +441,10 @@ export function registerTools(mcp: McpServer): void {
       const warnings: string[] = [];
       try {
         status["watcher_path"] = cfg.watchers.copilot.path;
+        status["watcher_paths"] = {
+          copilot: cfg.watchers.copilot.path,
+          claude: cfg.watchers.claude.path,
+        };
         for (const issue of inspectWatcherPaths(cfg)) {
           warnings.push(formatIssue(issue));
         }
@@ -453,22 +457,29 @@ export function registerTools(mcp: McpServer): void {
             last_active_session_at?: string | null;
             active_session_count?: number;
             watcher_path?: string;
+            sources?: Record<string, {
+              enabled?: boolean;
+              watcher_path?: string;
+              active_session_count?: number;
+              last_active_session_at?: string | null;
+            }>;
           };
           status["extraction_last_tick_at"] = health.last_tick_at ?? null;
           status["extraction_last_active_session_at"] = health.last_active_session_at ?? null;
           status["extraction_active_session_count"] = health.active_session_count ?? 0;
+          if (health.sources) status["extraction_sources"] = health.sources;
           if (health.last_active_session_at) {
             const hours = (Date.now() - Date.parse(health.last_active_session_at)) / 3_600_000;
             status["extraction_hours_since_active_session"] = Math.round(hours * 10) / 10;
             if (hours > 6) {
               warnings.push(
-                `Watcher has not seen any active Copilot sessions for ${Math.round(hours)}h — ` +
+                `Watcher has not seen any active transcript sources for ${Math.round(hours)}h — ` +
                 `check watcher_path (${health.watcher_path ?? "unknown"}) and that the daemon is running.`,
               );
             }
           } else {
             status["extraction_hours_since_active_session"] = null;
-            warnings.push("Daemon has never observed an active Copilot session — extraction may be stalled.");
+            warnings.push("Daemon has never observed an active transcript source — extraction may be stalled.");
           }
         } else {
           status["extraction_last_tick_at"] = null;


### PR DESCRIPTION
## Summary\n\nCloses #113.\n\n- Add source-aware transcript discovery/parsing for Copilot and Claude Code.\n- Ingest top-level Claude Code project JSONL files from watchers.claude.path when enabled.\n- Parse visible user/assistant text while skipping tool calls/results, attachments, file snapshots, permission records, and thinking blocks.\n- Preserve existing Copilot extraction state keys and extend health/status with per-source watcher counts and paths.\n- Document Claude transcript ingestion behavior.\n\n## Validation\n\n- npm run check\n- npm run build && node --test --test-concurrency=1 dist/daemon/transcript-sources.test.js dist/daemon/watcher.test.js\n- npm test\n- live metadata smoke: Claude watcher enabled, 2 top-level transcripts discovered, sample parsed 4 conversation events without printing transcript text