### PR TITLE
Prepare repo for public OSS launch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Default owners for everything in the repo.
 # Pull requests automatically request a review from these owners.
-* @saber-zrelli-private
+* @zrelli-s
 
 # Workflows / CI changes — extra eyes on anything that touches release or security tooling.
-/.github/        @saber-zrelli-private
+/.github/        @zrelli-s

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,8 +11,8 @@ body:
     id: package
     attributes:
       label: Package and version
-      description: e.g. `bikky@0.3.8` or `bikky-ui@0.1.10`
-      placeholder: bikky@0.3.8
+      description: e.g. `bikky@0.4.0` or `bikky-ui@0.1.14`
+      placeholder: bikky@0.4.0
     validations:
       required: true
 
@@ -31,7 +31,7 @@ body:
       description: Minimal steps that trigger the bug. A small code snippet or command sequence is ideal.
       placeholder: |
         1. Run `npx bikky-ui`
-        2. Open http://localhost:3001
+        2. Open http://localhost:1422
         3. ...
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Security vulnerability
     url: https://github.com/bikky-dev/bikky/security/advisories/new
     about: Please report security issues privately via GitHub Security Advisories — do NOT open a public issue.
-  - name: Question or discussion
-    url: https://github.com/bikky-dev/bikky/discussions
-    about: Have a usage question or want to discuss an idea? Start a Discussion instead of an issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,8 +17,8 @@
 
 ## Checklist
 
-- [ ] `npm run lint` passes
-- [ ] `npm run typecheck` passes
+- [ ] `npm run check` passes
 - [ ] `npm test` passes
+- [ ] `cd packages/ui && npm test` passes if UI code changed
 - [ ] Docs updated (README, CONTRIBUTING, or inline JSDoc) if behaviour changed
 - [ ] No secrets, tokens, or PII in the diff

--- a/.mailmap
+++ b/.mailmap
@@ -1,1 +1,0 @@
-zrelli-s <saber.zrelli@outlook.com> Saber Zrelli <saber@apate.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to bikky are documented here.
+
+This project uses npm package versions for release tracking:
+
+- `bikky` — core CLI, MCP server, and daemon.
+- `bikky-ui` — local web dashboard.
+
+## Unreleased
+
+- Public OSS readiness cleanup: package metadata, support docs, public maintainer ownership, package tarball hygiene, and privacy/transcript-capture documentation.
+
+## 0.4.0
+
+- Added multi-destination Qdrant routing and configurable read/search scopes.
+- Added Claude Code user-scoped MCP setup support.
+- Added Claude Code transcript ingestion for daemon memory extraction.
+- Refreshed README screenshots, setup guidance, and configuration docs.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ We aim for **focused, fast unit tests** that lock in behaviour without being a m
 
 We deliberately **do not** test:
 
-- LLM prompt quality or extraction accuracy. Those live in the separate [`bikky-evals`](https://github.com/bikky-dev/bikky-evals) repo, which uses DeepEval for prompt-level scoring.
+- LLM prompt quality or extraction accuracy. Prompt-level evals live outside the default unit-test suite so day-to-day contributor tests stay fast and deterministic.
 - Implementation details (private function internals, exact log strings) — these change often and tests that pin them slow contributors down.
 - The React frontend — the testable surface there is small; we rely on type-checking and manual smoke tests.
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ JSON
 bikky setup            # writes MCP config for Copilot + Claude Code, then starts the daemon
 ```
 
+`npm install -g bikky` runs a best-effort postinstall setup hook for convenience. It never fails the install, and you should still run `bikky setup` after writing your config to make setup explicit and repeatable.
+
 Restart your editor. The memory tools appear automatically in supported MCP clients.
 
 ```bash
@@ -214,6 +216,26 @@ bikky render    # render a prompt to JSON (for eval harnesses & debugging)
 ```
 
 `bikky status` is the first thing to run when setup feels wrong. It checks the config, Qdrant, embeddings, background daemon, and local UI health, then tells you what needs attention. Use `bikky status --json` for automation.
+
+## Privacy and transcript capture
+
+bikky stores memory in the Qdrant destination you configure. The daemon runs locally and reads supported coding-agent transcript locations so it can extract durable facts for future sessions:
+
+- GitHub Copilot session state: `~/.copilot/session-state`
+- Claude Code project transcripts: `~/.claude/projects`
+
+Only the configured daemon process reads these files. Extracted facts are redacted before storage, but they are still sent to your configured LLM provider for extraction unless you use a local provider such as Ollama. To disable transcript capture, set the relevant watcher to `false` in `~/.bikky/config.json`:
+
+```json
+{
+  "watchers": {
+    "copilot": { "enabled": false },
+    "claude": { "enabled": false }
+  }
+}
+```
+
+You can also set `daemon.extract_every_sec` to `0` to disable background extraction while keeping MCP recall tools available.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ Security fixes land on the latest minor release of each package:
 
 | Package    | Supported versions       |
 | ---------- | ------------------------ |
-| `bikky`    | latest minor (`0.3.x`)   |
+| `bikky`    | latest minor (`0.4.x`)   |
 | `bikky-ui` | latest minor (`0.1.x`)   |
 
 Older versions are not patched. If you're on an old version, please upgrade before reporting a vulnerability that may already be fixed.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,22 @@
+# Support
+
+Thanks for using bikky.
+
+## Questions and usage help
+
+Open a GitHub issue using the most relevant template. Include your OS, Node.js version, package version, MCP client, and the output of:
+
+```bash
+bikky status
+```
+
+Please redact API keys, access tokens, local file contents, and any private transcript data before posting.
+
+## Bugs
+
+Use the bug report template and include a minimal reproduction when possible. If the issue involves setup, include whether you installed with `npm install -g bikky`, `npx bikky`, or a local checkout.
+
+## Security reports
+
+Do not open a public issue for vulnerabilities. Follow [SECURITY.md](SECURITY.md) and use GitHub private vulnerability reporting.
+

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -372,6 +372,8 @@ You normally do not need to tune these. `bikky setup` starts the daemon and regi
 
 Claude Code ingestion reads top-level `*.jsonl` transcripts inside each project directory under `watchers.claude.path`. It captures user/assistant text and skips tool calls, tool results, attachments, file snapshots, permission records, and thinking blocks.
 
+Set either watcher `enabled` field to `false` to disable that transcript source. Set `daemon.extract_every_sec` to `0` to disable background extraction entirely while keeping MCP recall/search tools available.
+
 #### Logs
 
 bikky writes logs to `~/.bikky/logs/`:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "type": "git",
     "url": "git+https://github.com/bikky-dev/bikky.git"
   },
+  "bugs": {
+    "url": "https://github.com/bikky-dev/bikky/issues"
+  },
+  "homepage": "https://github.com/bikky-dev/bikky#readme",
   "bin": {
     "bikky": "bin/bikky.js"
   },
@@ -16,7 +20,16 @@
   },
   "files": [
     "CONTRIBUTING.md",
-    "dist/",
+    "SECURITY.md",
+    "CODE_OF_CONDUCT.md",
+    "SUPPORT.md",
+    "CHANGELOG.md",
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
+    "!dist/**/*.test.js",
+    "!dist/**/*.test.d.ts",
+    "!dist/**/*.itest.js",
+    "!dist/**/*.itest.d.ts",
     "bin/",
     "docs/configuration.md",
     "docs/config/",
@@ -54,6 +67,9 @@
   },
   "engines": {
     "node": ">=20.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "keywords": [
     "mcp",

--- a/packages/ui/LICENSE
+++ b/packages/ui/LICENSE
@@ -1,0 +1,4 @@
+bikky-ui is licensed under AGPL-3.0-or-later.
+
+See the root bikky repository license for the full GNU Affero General Public License v3.0 text:
+https://github.com/bikky-dev/bikky/blob/main/LICENSE

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,16 @@
+# bikky-ui
+
+Local web UI for browsing and managing [bikky](https://github.com/bikky-dev/bikky) memory.
+
+```bash
+npx bikky-ui
+```
+
+The UI reads the same `~/.bikky/config.json` as the `bikky` CLI and opens a local dashboard at <http://localhost:1422>.
+
+For setup, configuration, and security details, see the main bikky repository:
+
+- [README](https://github.com/bikky-dev/bikky#readme)
+- [Configuration guide](https://github.com/bikky-dev/bikky/blob/main/docs/configuration.md)
+- [Security policy](https://github.com/bikky-dev/bikky/blob/main/SECURITY.md)
+

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,11 +9,21 @@
     "url": "git+https://github.com/bikky-dev/bikky.git",
     "directory": "packages/ui"
   },
+  "bugs": {
+    "url": "https://github.com/bikky-dev/bikky/issues"
+  },
+  "homepage": "https://github.com/bikky-dev/bikky/tree/main/packages/ui#readme",
   "bin": {
     "bikky-ui": "bin/bikky-ui.js"
   },
   "files": [
-    "dist/",
+    "README.md",
+    "LICENSE",
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
+    "dist/public/",
+    "!dist/**/*.test.js",
+    "!dist/**/*.test.d.ts",
     "bin/"
   ],
   "scripts": {
@@ -48,5 +58,8 @@
   },
   "engines": {
     "node": ">=20.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
Closes #115.

Summary:
- Replace private CODEOWNERS identity with public maintainer @zrelli-s.
- Remove .mailmap so the public repo no longer exposes the old Apate identity.
- Add SUPPORT and CHANGELOG docs.
- Refresh SECURITY and issue/PR templates for current versions and UI port.
- Add README/config privacy guidance for transcript capture and disable controls.
- Keep postinstall auto-setup behavior unchanged, but document the setup hook in README.
- Tighten package files lists so npm tarballs exclude compiled test artifacts.
- Add bikky-ui package README/LICENSE and npm metadata.

Validation:
- npm run check
- npm test
- npm audit --omit=dev --audit-level=high
- cd packages/ui && npm test
- cd packages/ui && npm audit --omit=dev --audit-level=high
- npm pack dry run for bikky produced 0 compiled test artifacts
- npm pack dry run for bikky-ui produced 0 compiled test artifacts and includes README/LICENSE
- high-confidence secret scan found no real secrets; only redaction unit-test dummy strings matched
- Apate/private identity scan found no matches after deleting .mailmap and replacing CODEOWNERS

Remaining launch settings after merge:
- Set repo visibility to public when ready.
- Add repository topics and homepage.
- Optionally enable Discussions, or keep them disabled now that the issue template no longer links there.
- Enable delete-branch-on-merge if desired.