### PR TITLE
Add package verification CI and privacy quickstart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,32 @@ jobs:
 
       - name: Audit (production deps, fail on high+)
         run: npm audit --omit=dev --audit-level=high
+
+  package-verification:
+    name: package verification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            packages/ui/package-lock.json
+
+      - name: Install core dependencies
+        run: npm ci
+
+      - name: Build core package
+        run: npm run build
+
+      - name: Install and build UI package
+        working-directory: packages/ui
+        run: |
+          npm ci
+          npm run build
+
+      - name: Verify package contents and smoke installs
+        run: npm run verify:package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project uses npm package versions for release tracking:
 ## Unreleased
 
 - Public OSS readiness cleanup: package metadata, support docs, public maintainer ownership, package tarball hygiene, and privacy/transcript-capture documentation.
+- Added package verification CI and a privacy-first quickstart for local storage/local model setups.
 
 ## 0.4.0
 
@@ -17,4 +18,3 @@ This project uses npm package versions for release tracking:
 - Added Claude Code user-scoped MCP setup support.
 - Added Claude Code transcript ingestion for daemon memory extraction.
 - Refreshed README screenshots, setup guidance, and configuration docs.
-

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ For hosted models, custom providers, multiple profiles, or advanced tuning, use 
 
 > 📖 **Full configuration guide:** [docs/configuration.md][configuration-guide]
 >
+> 🔒 **Privacy-first setup:** [local storage, local models, and transcript-capture controls][privacy-quickstart]
+>
 > 🛠 Want to add a new embedding or LLM provider (Vertex, OpenRouter, etc.)? See **[CONTRIBUTING.md][contributing]** — it's a single-file change.
 
 #### Optional: separate memory stores
@@ -170,6 +172,7 @@ That is enough for explicit selection in the UI and tools. Add routing rules onl
 [local-config]: https://cdn.jsdelivr.net/npm/bikky@latest/docs/config/local.md
 [hosted-qdrant-local-models-config]: https://cdn.jsdelivr.net/npm/bikky@latest/docs/config/hosted-qdrant-local-models.md
 [configuration-guide]: https://cdn.jsdelivr.net/npm/bikky@latest/docs/configuration.md
+[privacy-quickstart]: https://cdn.jsdelivr.net/npm/bikky@latest/docs/privacy-first.md
 [contributing]: https://cdn.jsdelivr.net/npm/bikky@latest/CONTRIBUTING.md
 
 ---
@@ -236,6 +239,8 @@ Only the configured daemon process reads these files. Extracted facts are redact
 ```
 
 You can also set `daemon.extract_every_sec` to `0` to disable background extraction while keeping MCP recall tools available.
+
+For a local-storage, local-model setup that minimizes what leaves your machine, see the [privacy-first quickstart][privacy-quickstart].
 
 ## License
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,8 @@ If you know which path you want, start with the focused guide:
 | Local and free                | Local evaluation; quality depends on local models            | [Local config guide](config/local.md)                                    |
 | Hosted Qdrant + local models  | Shared vector storage while keeping model calls local        | [Hosted Qdrant + local models](config/hosted-qdrant-local-models.md)     |
 
+Privacy-conscious users should also read the [privacy-first quickstart](privacy-first.md), which combines local Qdrant, local Ollama models, and transcript-capture disable controls.
+
 ### Fully hosted
 
 Best for performance and teams. Qdrant Cloud stores vectors, and hosted embeddings + LLM calls handle extraction, curation, and recall.

--- a/docs/privacy-first.md
+++ b/docs/privacy-first.md
@@ -1,0 +1,140 @@
+# Privacy-first quickstart
+
+Use this setup when you want to evaluate bikky with local storage and local model calls before opting into any hosted provider.
+
+## What this protects
+
+This guide keeps memory vectors, extracted facts, and transcript extraction model calls on your machine:
+
+- Qdrant runs locally in Docker.
+- Embeddings and LLM extraction use local Ollama models.
+- Automatic transcript capture can be disabled entirely.
+
+Package installation still talks to npm, Docker pulls images from its registry, and Ollama pulls models from its registry. After those dependencies are installed, bikky does not send memory data to a hosted vector store or hosted model provider unless you configure one.
+
+## 1. Start local dependencies
+
+```bash
+docker run -d --name qdrant -p 6333:6333 -v qdrant_storage:/qdrant/storage qdrant/qdrant
+
+ollama pull qwen3-embedding:0.6b
+ollama pull qwen2.5:7b
+```
+
+## 2. Install bikky
+
+```bash
+npm install -g bikky
+```
+
+The package has a best-effort postinstall setup hook for convenience. For the most explicit first run, write your config first and then run `bikky setup` yourself.
+
+## 3. Choose your capture mode
+
+### Recall-only mode
+
+Use this mode when you want MCP memory tools available but do not want bikky to read coding-agent transcripts in the background.
+
+```bash
+mkdir -p ~/.bikky
+cat > ~/.bikky/config.json <<'JSON'
+{
+  "qdrant_url": "http://localhost:6333",
+  "qdrant_api_key": "",
+  "embedding": {
+    "provider": "ollama",
+    "model": "qwen3-embedding:0.6b",
+    "dimensions": 1024,
+    "base_url": "http://localhost:11434"
+  },
+  "llm": {
+    "provider": "ollama",
+    "model": "qwen2.5:7b",
+    "base_url": "http://localhost:11434"
+  },
+  "daemon": {
+    "extract_every_sec": 0
+  },
+  "watchers": {
+    "copilot": { "enabled": false },
+    "claude": { "enabled": false }
+  }
+}
+JSON
+```
+
+### Local-only capture mode
+
+Use this mode when you want automatic memory extraction from supported local coding-agent transcripts, but still want extraction model calls to stay local.
+
+```json
+{
+  "qdrant_url": "http://localhost:6333",
+  "qdrant_api_key": "",
+  "embedding": {
+    "provider": "ollama",
+    "model": "qwen3-embedding:0.6b",
+    "dimensions": 1024,
+    "base_url": "http://localhost:11434"
+  },
+  "llm": {
+    "provider": "ollama",
+    "model": "qwen2.5:7b",
+    "base_url": "http://localhost:11434"
+  }
+}
+```
+
+In this mode, the daemon reads supported transcript locations on your machine:
+
+- GitHub Copilot session state: `~/.copilot/session-state`
+- Claude Code project transcripts: `~/.claude/projects`
+
+It sends extracted transcript snippets only to the configured local Ollama endpoint. If you switch `embedding.provider`, `llm.provider`, or Qdrant to hosted services later, the relevant facts, vectors, or model inputs will leave your machine for those configured providers.
+
+## 4. Start and verify
+
+```bash
+bikky setup
+bikky status
+```
+
+If you change providers, watcher settings, or `daemon.extract_every_sec`, restart long-running processes:
+
+```bash
+bikky stop && bikky start
+```
+
+Restart your editor after setup so its MCP server process reloads the config.
+
+## What can leave your machine
+
+| Configuration choice | What leaves your machine |
+| -------------------- | ------------------------ |
+| Local Qdrant + Ollama | No memory payloads, vectors, or extraction model inputs leave through bikky. |
+| Qdrant Cloud or hosted Qdrant | Stored facts, metadata, and vectors are sent to that Qdrant endpoint. |
+| Hosted embedding provider | Text sent for embedding and resulting vectors are handled by that provider. |
+| Hosted LLM provider | Transcript snippets selected for extraction, curation, or distillation are sent to that provider. |
+| MCP client integration | Tool calls and tool results are visible to the MCP client that invoked them. |
+
+## Turning capture off later
+
+To stop background transcript extraction while keeping search/recall tools available:
+
+```json
+{
+  "daemon": {
+    "extract_every_sec": 0
+  },
+  "watchers": {
+    "copilot": { "enabled": false },
+    "claude": { "enabled": false }
+  }
+}
+```
+
+Then restart bikky:
+
+```bash
+bikky stop && bikky start
+```

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "!dist/**/*.itest.d.ts",
     "bin/",
     "docs/configuration.md",
+    "docs/privacy-first.md",
     "docs/config/",
     "docs/diagrams/",
     "docs/screenshots/"
@@ -47,6 +48,7 @@
     "check": "tsc --noEmit && eslint src/",
     "test": "tsc && node --test --test-concurrency=1 $(find dist -name '*.test.js')",
     "test:integration": "tsc && BIKKY_INTEGRATION=${BIKKY_INTEGRATION:-1} node --test $(find dist -name '*.itest.js')",
+    "verify:package": "node scripts/verify-package.mjs",
     "build:diagrams": "node scripts/build-diagrams.mjs",
     "prepublishOnly": "npm run build"
   },

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-package-verify-"));
+
+const textExtensions = new Set([
+  ".css",
+  ".d.ts",
+  ".html",
+  ".js",
+  ".json",
+  ".md",
+  ".svg",
+  ".txt",
+]);
+
+const packages = [
+  {
+    name: "bikky",
+    dir: repoRoot,
+    bin: "bikky",
+    requiredPaths: [
+      "bin/bikky.js",
+      "dist/cli.js",
+      "dist/mcp/index.js",
+      "docs/privacy-first.md",
+      "README.md",
+      "LICENSE",
+      "SECURITY.md",
+      "SUPPORT.md",
+      "CHANGELOG.md",
+    ],
+    smoke: async (binPath, env) => {
+      const version = run(binPath, ["--version"], { env });
+      assertIncludes(version.stdout, "bikky v", "bikky --version should print a version");
+
+      const status = run(binPath, ["status", "--json", "--no-live", "--no-ui"], {
+        env,
+        allowedExitCodes: [0, 1],
+      });
+      parseJson(status.stdout, "bikky status --json should print JSON");
+
+      await assertLongRunning(binPath, ["mcp"], env, "bikky mcp");
+    },
+  },
+  {
+    name: "bikky-ui",
+    dir: path.join(repoRoot, "packages", "ui"),
+    bin: "bikky-ui",
+    requiredPaths: [
+      "bin/bikky-ui.js",
+      "dist/cli.js",
+      "dist/public/index.html",
+      "README.md",
+      "LICENSE",
+    ],
+    smoke: async (binPath, env) => {
+      await assertLongRunning(binPath, [], { ...env, BIKKY_UI_PORT: "0" }, "bikky-ui", "bikky ui running");
+    },
+  },
+];
+
+const forbiddenPathPatterns = [
+  { re: /(^|\/)(tasks|node_modules|\.git)(\/|$)/, reason: "task, node_modules, or git metadata" },
+  { re: /(^|\/)\.env($|\.)/, reason: "environment files" },
+  { re: /(\.test|\.itest)\.(js|d\.ts)$/i, reason: "compiled test artifacts" },
+  { re: /(^|\/)(id_rsa|id_ed25519|.*\.pem|.*\.key)$/i, reason: "private key material" },
+  { re: /(^|\/)Users\/|\/Users\//i, reason: "absolute local user paths" },
+  { re: /saber-zrelli-private|saber-apate|apate/i, reason: "private identity references" },
+];
+
+const forbiddenContentPatterns = [
+  { re: /gh[pousr]_[A-Za-z0-9_]{20,}/, reason: "GitHub token" },
+  { re: /github_pat_[A-Za-z0-9_]{20,}/, reason: "GitHub fine-grained token" },
+  { re: /sk-[A-Za-z0-9]{20,}/, reason: "OpenAI-style API key" },
+  { re: /AKIA[0-9A-Z]{16}/, reason: "AWS access key id" },
+  { re: /AIza[0-9A-Za-z_-]{35}/, reason: "Google API key" },
+  { re: /xox[baprs]-[0-9A-Za-z-]{20,}/, reason: "Slack token" },
+  { re: /-----BEGIN [A-Z ]*PRIVATE KEY-----/, reason: "private key block" },
+  { re: /\/Users\/saber\b/i, reason: "local user path" },
+  { re: /saber-zrelli-private|saber-apate|apate-ai|apate\.com/i, reason: "private identity reference" },
+];
+
+try {
+  for (const pkg of packages) {
+    console.log(`\nVerifying ${pkg.name} package...`);
+    const dryRun = pack(pkg, true);
+    assertPackageContents(pkg, dryRun.files.map((file) => normalizePackPath(file.path)));
+
+    const packed = pack(pkg, false);
+    assertPackageContents(pkg, packed.files.map((file) => normalizePackPath(file.path)));
+    scanTarballContents(pkg, packed.tarball);
+
+    const installDir = fs.mkdtempSync(path.join(workDir, `${pkg.name}-install-`));
+    npm(["install", "--ignore-scripts", "--no-audit", "--fund=false", "--prefix", installDir, packed.tarball], {
+      cwd: repoRoot,
+    });
+
+    const binPath = path.join(installDir, "node_modules", ".bin", pkg.bin);
+    if (!fs.existsSync(binPath)) {
+      throw new Error(`${pkg.name} did not install expected bin at ${binPath}`);
+    }
+
+    const home = fs.mkdtempSync(path.join(workDir, `${pkg.name}-home-`));
+    await pkg.smoke(binPath, {
+      ...process.env,
+      BIKKY_HOME: home,
+      NO_COLOR: "1",
+      CI: "1",
+    });
+    console.log(`✓ ${pkg.name} package verified`);
+  }
+} finally {
+  fs.rmSync(workDir, { recursive: true, force: true });
+}
+
+function pack(pkg, dryRun) {
+  const args = ["pack", "--json", "--ignore-scripts"];
+  if (dryRun) {
+    args.push("--dry-run");
+  } else {
+    args.push("--pack-destination", workDir);
+  }
+
+  const result = npm(args, { cwd: pkg.dir });
+  const parsed = parseJson(result.stdout, `npm ${args.join(" ")} output for ${pkg.name}`);
+  const entry = parsed[0];
+  if (!entry || !Array.isArray(entry.files)) {
+    throw new Error(`Unexpected npm pack output for ${pkg.name}`);
+  }
+
+  return {
+    ...entry,
+    tarball: dryRun ? null : path.resolve(workDir, entry.filename),
+  };
+}
+
+function assertPackageContents(pkg, files) {
+  const fileSet = new Set(files);
+  for (const requiredPath of pkg.requiredPaths) {
+    if (!fileSet.has(requiredPath)) {
+      throw new Error(`${pkg.name} package is missing required file: ${requiredPath}`);
+    }
+  }
+
+  for (const file of files) {
+    for (const { re, reason } of forbiddenPathPatterns) {
+      if (re.test(file)) {
+        throw new Error(`${pkg.name} package includes forbidden path (${reason}): ${file}`);
+      }
+    }
+  }
+}
+
+function scanTarballContents(pkg, tarball) {
+  const extractDir = fs.mkdtempSync(path.join(workDir, `${pkg.name}-extract-`));
+  runCommand("tar", ["-xzf", tarball, "-C", extractDir], { cwd: repoRoot });
+  const packageDir = path.join(extractDir, "package");
+
+  for (const file of walk(packageDir)) {
+    const rel = path.relative(packageDir, file);
+    if (!shouldScanText(file)) continue;
+    const content = fs.readFileSync(file, "utf8");
+    for (const { re, reason } of forbiddenContentPatterns) {
+      if (re.test(content)) {
+        throw new Error(`${pkg.name} package includes forbidden content (${reason}) in ${rel}`);
+      }
+    }
+  }
+}
+
+function* walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(fullPath);
+    } else if (entry.isFile()) {
+      yield fullPath;
+    }
+  }
+}
+
+function shouldScanText(file) {
+  const stat = fs.statSync(file);
+  if (stat.size > 2_000_000) return false;
+  const lower = file.toLowerCase();
+  if (lower.endsWith(".d.ts")) return true;
+  return textExtensions.has(path.extname(lower));
+}
+
+function normalizePackPath(file) {
+  return file.replace(/^package\//, "");
+}
+
+function assertIncludes(value, expected, message) {
+  if (!value.includes(expected)) {
+    throw new Error(`${message}. Output was: ${value.slice(0, 300)}`);
+  }
+}
+
+function parseJson(value, label) {
+  try {
+    return JSON.parse(value);
+  } catch (err) {
+    throw new Error(`${label} was not valid JSON: ${err instanceof Error ? err.message : String(err)}\n${value.slice(0, 500)}`);
+  }
+}
+
+function npm(args, options) {
+  return runCommand("npm", args, options);
+}
+
+function run(command, args, { env, allowedExitCodes = [0] } = {}) {
+  return runCommand(command, args, {
+    cwd: repoRoot,
+    env,
+    allowedExitCodes,
+  });
+}
+
+function runCommand(command, args, { cwd, env = process.env, allowedExitCodes = [0] } = {}) {
+  const result = spawnSync(command, args, {
+    cwd,
+    env,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (!allowedExitCodes.includes(result.status ?? 1)) {
+    throw new Error(
+      `${command} ${args.join(" ")} failed with exit ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  }
+
+  return result;
+}
+
+async function assertLongRunning(command, args, env, label, expectedOutput) {
+  const minRuntimeMs = expectedOutput ? 0 : 750;
+  const startedAt = Date.now();
+  const child = spawn(command, args, {
+    cwd: repoRoot,
+    env,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk.toString();
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk.toString();
+  });
+
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`${label} exited during smoke test with code ${child.exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+    }
+    if ((!expectedOutput && Date.now() - startedAt >= minRuntimeMs) || (expectedOutput && stdout.includes(expectedOutput))) {
+      await stopChild(child);
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  await stopChild(child);
+  throw new Error(`${label} did not become ready during smoke test\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+}
+
+async function stopChild(child) {
+  if (child.exitCode !== null) return;
+  child.kill("SIGTERM");
+  const force = setTimeout(() => {
+    if (child.exitCode === null) child.kill("SIGKILL");
+  }, 2_000);
+  await waitForClose(child);
+  clearTimeout(force);
+}
+
+function waitForClose(child) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    child.once("close", resolve);
+  });
+}


### PR DESCRIPTION
Closes #117.

Summary:
- Add a package verification CI job for Node 22.
- Add scripts/verify-package.mjs to pack bikky and bikky-ui, reject compiled tests and private or secret-looking paths/content, install packed tarballs, and smoke-test the installed CLIs.
- Add docs/privacy-first.md for local Qdrant, local Ollama models, recall-only mode, local-only capture mode, and what can leave the machine.
- Link the privacy-first quickstart from README and docs/configuration.md.
- Include docs/privacy-first.md in the bikky npm package.

Validation:
- npm run build
- cd packages/ui && npm run build
- npm run verify:package
- npm run check
- npm test
- npm audit --omit=dev --audit-level=high
- cd packages/ui && npm test
- cd packages/ui && npm audit --omit=dev --audit-level=high