### PR TITLE
docs: remove Discussion references

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -29,5 +29,5 @@ body:
     attributes:
       label: Confirmation
       options:
-        - label: I have searched existing issues and discussions for similar requests.
+        - label: I have searched existing issues for similar requests.
           required: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -45,7 +45,7 @@ or harmful.
 ## Scope
 
 This Code of Conduct applies within all community spaces (issues, PRs,
-Discussions, Discord/Slack if any), and also applies when an individual is
+Discord/Slack if any), and also applies when an individual is
 officially representing the community in public spaces.
 
 ## Enforcement


### PR DESCRIPTION
## Summary
- remove Discussion references from the feature request template and Code of Conduct
- keep support/community references focused on issues and PRs

## Validation
- git diff --check
- git grep -i discussion