### PR TITLE
docs: point public docs to GitHub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,7 +199,7 @@ Configure a fallback chain via `llm.fallback_provider` in config (or
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the project's [AGPL-3.0-or-later](LICENSE) license.
+By contributing, you agree that your contributions will be licensed under the project's [AGPL-3.0-or-later](https://github.com/bikky-dev/bikky/blob/main/LICENSE) license.
 
 ## Code of conduct
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ bikky gives AI coding agents (GitHub Copilot, Claude Code, Cursor, and other MCP
 - 🤖 **Multi-agent engineering workflows** — Multiple Cursor / Claude Code / Copilot sessions can share codebase context, conventions, and recent decisions instead of re-learning them from scratch.
 
 <p align="center">
-  <img src="https://cdn.jsdelivr.net/npm/bikky@latest/docs/diagrams/team-memory.svg" alt="Memory — facts flow from individual sessions into a self-curating knowledge store shared across your team" width="720" />
+  <img src="https://raw.githubusercontent.com/bikky-dev/bikky/main/docs/diagrams/team-memory.svg" alt="Memory — facts flow from individual sessions into a self-curating knowledge store shared across your team" width="720" />
 </p>
 
 <p align="center"><i>Knowledge flows from every session into a store that curates itself over time — deduplicating, distilling, and decaying stale facts — so every future session starts smarter across the team.</i></p>
@@ -165,15 +165,15 @@ Most installs use one Qdrant destination. If you need clean separation later, re
 
 That is enough for explicit selection in the UI and tools. Add routing rules only when you want automatic placement by cwd, entity, content, or metadata. Search tools can also use `search_scope: "all"` or a named/listed scope when context may span stores. Existing single-Qdrant configs continue to work.
 
-> 📖 **Details:** [multi-destination configuration](docs/configuration.md#multi-destination-routing)
+> 📖 **Details:** [multi-destination configuration](https://github.com/bikky-dev/bikky/blob/main/docs/configuration.md#multi-destination-routing)
 
-[fully-hosted-config]: https://cdn.jsdelivr.net/npm/bikky@latest/docs/config/fully-hosted.md
-[hosted-models-config]: https://cdn.jsdelivr.net/npm/bikky@latest/docs/config/hosted-models.md
-[local-config]: https://cdn.jsdelivr.net/npm/bikky@latest/docs/config/local.md
-[hosted-qdrant-local-models-config]: https://cdn.jsdelivr.net/npm/bikky@latest/docs/config/hosted-qdrant-local-models.md
-[configuration-guide]: https://cdn.jsdelivr.net/npm/bikky@latest/docs/configuration.md
-[privacy-quickstart]: https://cdn.jsdelivr.net/npm/bikky@latest/docs/privacy-first.md
-[contributing]: https://cdn.jsdelivr.net/npm/bikky@latest/CONTRIBUTING.md
+[fully-hosted-config]: https://github.com/bikky-dev/bikky/blob/main/docs/config/fully-hosted.md
+[hosted-models-config]: https://github.com/bikky-dev/bikky/blob/main/docs/config/hosted-models.md
+[local-config]: https://github.com/bikky-dev/bikky/blob/main/docs/config/local.md
+[hosted-qdrant-local-models-config]: https://github.com/bikky-dev/bikky/blob/main/docs/config/hosted-qdrant-local-models.md
+[configuration-guide]: https://github.com/bikky-dev/bikky/blob/main/docs/configuration.md
+[privacy-quickstart]: https://github.com/bikky-dev/bikky/blob/main/docs/privacy-first.md
+[contributing]: https://github.com/bikky-dev/bikky/blob/main/CONTRIBUTING.md
 
 ---
 
@@ -189,17 +189,17 @@ bikky-ui              # opens http://localhost:1422
 ```
 
 <p align="center">
-  <img src="docs/screenshots/dashboard.png" alt="Dashboard — overview stats, category breakdown, recent facts" width="720" />
+  <img src="https://raw.githubusercontent.com/bikky-dev/bikky/main/docs/screenshots/dashboard.png" alt="Dashboard — overview stats, category breakdown, recent facts" width="720" />
 </p>
 <p align="center"><i>Dashboard — memory stats, category breakdown, and recent facts at a glance</i></p>
 
 <p align="center">
-  <img src="docs/screenshots/memory.png" alt="Memory browser — search, filter, and browse all stored facts" width="720" />
+  <img src="https://raw.githubusercontent.com/bikky-dev/bikky/main/docs/screenshots/memory.png" alt="Memory browser — search, filter, and browse all stored facts" width="720" />
 </p>
 <p align="center"><i>Memory browser — search, filter by category/kind/source, and browse all stored facts</i></p>
 
 <p align="center">
-  <img src="docs/screenshots/graph.png" alt="Entity graph — interactive visualization of entity relationships" width="720" />
+  <img src="https://raw.githubusercontent.com/bikky-dev/bikky/main/docs/screenshots/graph.png" alt="Entity graph — interactive visualization of entity relationships" width="720" />
 </p>
 <p align="center"><i>Entity graph — interactive visualization of how concepts, people, and services relate</i></p>
 
@@ -248,4 +248,4 @@ For questions, bugs, and feature requests, please use [GitHub issues](https://gi
 
 ## License
 
-AGPL-3.0 — see [LICENSE](LICENSE).
+AGPL-3.0 — see [LICENSE](https://github.com/bikky-dev/bikky/blob/main/LICENSE).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -20,4 +20,4 @@ Use the bug report template and include a minimal reproduction when possible. If
 
 ## Security reports
 
-Do not open a public issue for vulnerabilities. Follow [SECURITY.md](SECURITY.md) and use GitHub private vulnerability reporting.
+Do not open a public issue for vulnerabilities. Follow [SECURITY.md](https://github.com/bikky-dev/bikky/blob/main/SECURITY.md) and use GitHub private vulnerability reporting.

--- a/docs/config/fully-hosted.md
+++ b/docs/config/fully-hosted.md
@@ -54,4 +54,4 @@ bikky stop && bikky start
 
 Then restart your editor so its MCP process reloads.
 
-For Bedrock, Portkey, custom base URLs, or model-specific dimensions, see the [full configuration guide](../configuration.md).
+For Bedrock, Portkey, custom base URLs, or model-specific dimensions, see the [full configuration guide](https://github.com/bikky-dev/bikky/blob/main/docs/configuration.md).

--- a/docs/config/hosted-models.md
+++ b/docs/config/hosted-models.md
@@ -47,4 +47,4 @@ bikky status
 
 If you started from a fresh install, run `bikky setup` after writing the config, then restart your editor so its MCP process reloads.
 
-For Bedrock, Portkey, custom base URLs, or model-specific dimensions, see the [full configuration guide](../configuration.md).
+For Bedrock, Portkey, custom base URLs, or model-specific dimensions, see the [full configuration guide](https://github.com/bikky-dev/bikky/blob/main/docs/configuration.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,12 +32,12 @@ If you know which path you want, start with the focused guide:
 
 | Setup                         | Best for                                                     | Guide                                                                    |
 | ----------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------ |
-| Fully hosted                  | Best performance and teams; managed vector storage and models | [Fully hosted config](config/fully-hosted.md)                            |
-| Local Qdrant + hosted models  | Local vector storage with hosted extraction and embedding    | [Hosted models config](config/hosted-models.md)                          |
-| Local and free                | Local evaluation; quality depends on local models            | [Local config guide](config/local.md)                                    |
-| Hosted Qdrant + local models  | Shared vector storage while keeping model calls local        | [Hosted Qdrant + local models](config/hosted-qdrant-local-models.md)     |
+| Fully hosted                  | Best performance and teams; managed vector storage and models | [Fully hosted config](https://github.com/bikky-dev/bikky/blob/main/docs/config/fully-hosted.md)                            |
+| Local Qdrant + hosted models  | Local vector storage with hosted extraction and embedding    | [Hosted models config](https://github.com/bikky-dev/bikky/blob/main/docs/config/hosted-models.md)                          |
+| Local and free                | Local evaluation; quality depends on local models            | [Local config guide](https://github.com/bikky-dev/bikky/blob/main/docs/config/local.md)                                    |
+| Hosted Qdrant + local models  | Shared vector storage while keeping model calls local        | [Hosted Qdrant + local models](https://github.com/bikky-dev/bikky/blob/main/docs/config/hosted-qdrant-local-models.md)     |
 
-Privacy-conscious users should also read the [privacy-first quickstart](privacy-first.md), which combines local Qdrant, local Ollama models, and transcript-capture disable controls.
+Privacy-conscious users should also read the [privacy-first quickstart](https://github.com/bikky-dev/bikky/blob/main/docs/privacy-first.md), which combines local Qdrant, local Ollama models, and transcript-capture disable controls.
 
 ### Fully hosted
 


### PR DESCRIPTION
## Summary
- replace jsDelivr bikky documentation links with GitHub repository URLs
- replace relative public doc and image links with GitHub blob/raw URLs
- keep README assets rendering outside GitHub by using raw.githubusercontent.com for images

## Validation
- git diff --check
- verified no remaining jsDelivr bikky docs links
- verified no remaining relative markdown/image links in public docs
- smoke-tested representative GitHub doc/raw URLs with curl