### PR TITLE
chore: prepare bikky 0.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project uses npm package versions for release tracking:
 
 ## Unreleased
 
+## 0.4.2
+
+- Republished the core package from current `main` so the npm package README uses GitHub documentation links instead of stale jsDelivr links.
+
+## 0.4.1
+
 - Public OSS readiness cleanup: package metadata, support docs, public maintainer ownership, package tarball hygiene, and privacy/transcript-capture documentation.
 - Added package verification CI and a privacy-first quickstart for local storage/local model setups.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bikky",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bikky",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bikky",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Shared memory for AI coding sessions — MCP server + background daemon",
   "type": "module",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary\n- bump the core bikky package to 0.4.2\n- document the npm README republish reason in the changelog\n\n## Validation\n- git diff --check\n- npm run check\n- npm test\n- cd packages/ui && npm run typecheck && npm test && npm run build\n- npm run verify:package\n- local packed README contains GitHub docs links and no bikky jsDelivr docs links\n\nThis release updates the npmjs package page README from the stale 0.4.1 tarball to the current GitHub docs links.