### PR TITLE
Fix daemon destination routing

### DIFF
--- a/src/daemon/consolidation.ts
+++ b/src/daemon/consolidation.ts
@@ -90,6 +90,8 @@ const autoDistill = async (
   if (!qdrant.isReady()) return { distilled: false };
 
   try {
+    const destination = qdrant.resolveDestination({}).name;
+    const collection = qdrant.collectionForDestination(destination);
     // Find undistilled session summaries (support both legacy and new taxonomy)
     const legacyFilter = {
       must: [
@@ -107,12 +109,12 @@ const autoDistill = async (
     type ScrollResponse = { result?: { points?: Array<{ id: string; payload?: QdrantPayload }> } };
 
     const [legacyRes, newRes] = await Promise.all([
-      qdrant.qdrantRequest("POST", `/collections/${qdrant.collection}/points/scroll`, {
+      qdrant.qdrantRequest("POST", `/collections/${collection}/points/scroll`, {
         filter: legacyFilter, limit: 50, with_payload: true,
-      }) as Promise<ScrollResponse>,
-      qdrant.qdrantRequest("POST", `/collections/${qdrant.collection}/points/scroll`, {
+      }, destination) as Promise<ScrollResponse>,
+      qdrant.qdrantRequest("POST", `/collections/${collection}/points/scroll`, {
         filter: newFilter, limit: 50, with_payload: true,
-      }) as Promise<ScrollResponse>,
+      }, destination) as Promise<ScrollResponse>,
     ]);
 
     // Deduplicate by ID
@@ -199,12 +201,12 @@ const autoDistill = async (
           distilled_at: new Date().toISOString(),
           distilled_by_prompt: promptStamp,
         },
-      });
+      }, { destination });
     }
 
     // Supersede the source summaries
     for (const pt of batch) {
-      await qdrant.supersedeFact(pt.id, `distilled:${new Date().toISOString()}`);
+      await qdrant.supersedeFact(pt.id, `distilled:${new Date().toISOString()}`, destination);
     }
 
     logFn("INFO", `Auto-distill: consolidated ${batch.length} summaries into ${patterns.length} patterns`);
@@ -224,7 +226,7 @@ const autoDistill = async (
 const detectContradiction = async (
   fact: { content: string; category: string; entities: string[]; importance?: number },
   _config: BikkyConfig,
-  telemetry?: { sessionId?: string; workstreamKey?: string },
+  telemetry?: { sessionId?: string; workstreamKey?: string; destination?: string },
 ): Promise<ContradictionResult> => {
   if (!qdrant.isReady()) return { contradiction: false };
   if ((fact.importance || 0) < 0.3) return { contradiction: false };
@@ -232,12 +234,13 @@ const detectContradiction = async (
   try {
     const vector = await qdrant.embed(fact.content);
     // Search across all categories because contradictions can cross category lines.
-    const results = await qdrant.qdrantRequest("POST", `/collections/${qdrant.collection}/points/search`, {
+    const collection = qdrant.collectionForDestination(telemetry?.destination);
+    const results = await qdrant.qdrantRequest("POST", `/collections/${collection}/points/search`, {
       vector,
       filter: { must: [{ is_null: { key: "superseded_by" } }] },
       limit: 5,
       with_payload: true,
-    });
+    }, telemetry?.destination);
 
     const candidates = ((results.result || []) as Array<{ id: string; score: number; payload?: QdrantPayload }>)
       .filter(r => r.score >= 0.75 && r.score < 0.92);

--- a/src/daemon/episode-summary.ts
+++ b/src/daemon/episode-summary.ts
@@ -66,6 +66,7 @@ export interface EpisodeSummaryWriteResult {
   action: "stored" | "updated" | "skipped";
   factId?: string;
   episodeId?: string;
+  destination?: string;
   workstreamKey?: string | null;
   reason?: string;
 }
@@ -278,12 +279,14 @@ const summarizeEpisodeTranscript = async (input: {
 const findExistingEpisodeSummary = async (
   episodeId: string,
   scope: WorkspaceScope,
+  destination?: string,
 ): Promise<{ id: string; payload?: Partial<QdrantPayload> } | null> => {
-  const result = await qdrant.qdrantRequest("POST", `/collections/${qdrant.collection}/points/scroll`, {
+  const collection = qdrant.collectionForDestination(destination);
+  const result = await qdrant.qdrantRequest("POST", `/collections/${collection}/points/scroll`, {
     filter: buildEpisodeSummaryFilter(episodeId, scope),
     limit: 1,
     with_payload: true,
-  }) as { result?: { points?: Array<{ id: string; payload?: Partial<QdrantPayload> }> } };
+  }, destination) as { result?: { points?: Array<{ id: string; payload?: Partial<QdrantPayload> }> } };
 
   return result.result?.points?.[0] ?? null;
 };
@@ -299,7 +302,22 @@ export const updateEpisodeSummary = async (input: {
     return { action: "skipped", reason: "empty_transcript", episodeId: input.segment.episode_id };
   }
 
-  const existing = await findExistingEpisodeSummary(input.segment.episode_id, input.scope);
+  const destination = qdrant.resolveDestination({
+    content: input.segment.transcript,
+    entities: [
+      input.sessionId,
+      ...(input.segment.workstream_key ? [input.segment.workstream_key] : []),
+    ],
+    metadata: {
+      session_id: input.sessionId,
+      episode_id: input.segment.episode_id,
+      ...(input.segment.workstream_key ? { workstream_key: input.segment.workstream_key } : {}),
+      memory_subtype: "episode",
+      kind: "summary",
+      source: "system",
+    },
+  });
+  const existing = await findExistingEpisodeSummary(input.segment.episode_id, input.scope, destination.name);
   const draft = await summarizeEpisodeTranscript({
     transcript: input.segment.transcript,
     sessionId: input.sessionId,
@@ -335,14 +353,15 @@ export const updateEpisodeSummary = async (input: {
   const vector = await qdrant.embed(String(payload.content));
   const factId = existing?.id ?? randomUUID();
 
-  await qdrant.qdrantRequest("PUT", `/collections/${qdrant.collection}/points`, {
+  await qdrant.qdrantRequest("PUT", `/collections/${destination.collection}/points`, {
     points: [{ id: factId, vector, payload }],
-  });
+  }, destination.name);
 
   return {
     action: existing ? "updated" : "stored",
     factId,
     episodeId: input.segment.episode_id,
+    destination: destination.name,
     workstreamKey: resolved.key,
   };
 };

--- a/src/daemon/extraction.ts
+++ b/src/daemon/extraction.ts
@@ -534,14 +534,27 @@ const storeFacts = async (
       entities: fact.entities.map((entity) => entity.toLowerCase()),
     };
     const hash = contentHash(sanitizedFact.content);
+    const routeInput = {
+      content: sanitizedFact.content,
+      entities: sanitizedFact.entities,
+      metadata: {
+        ...baseMeta,
+        ...(fact.repo ? { repo: fact.repo } : {}),
+        ...(fact.branch ? { branch: fact.branch } : {}),
+        ...(fact.task_key ? { task_key: fact.task_key } : {}),
+        ...(fact.workstream_key ? { workstream_key: fact.workstream_key } : {}),
+        ...(actor.actor_id ? { actor_id: actor.actor_id } : {}),
+        category: fact.category,
+      },
+    };
 
     try {
-      const dedup = await qdrant.dedupCheck(sanitizedFact.content, hash);
+      const dedup = await qdrant.dedupCheck(sanitizedFact.content, hash, undefined, undefined, routeInput);
 
       if (dedup.action === "skip") {
         // Reinforce existing fact
         if (dedup.existingId) {
-          await qdrant.reinforceFact(dedup.existingId, dedup.existingCount || 1);
+          await qdrant.reinforceFact(dedup.existingId, dedup.existingCount || 1, dedup.destination);
         }
         continue;
       }
@@ -552,6 +565,7 @@ const storeFacts = async (
           const contradiction = await detectContradiction(sanitizedFact, config, {
             sessionId,
             workstreamKey: sanitizedFact.workstream_key ?? undefined,
+            destination: dedup.destination,
           });
           if (contradiction.contradiction && contradiction.existingId) {
             logFn("INFO", `Extraction: contradiction detected for "${fact.content.slice(0, 60)}..." vs ${contradiction.existingId}: ${contradiction.reason}`);
@@ -644,7 +658,7 @@ const storeFacts = async (
       // Downgrade to candidate with reduced confidence rather than dropping
       // outright: similarity is a soft signal, not a hard reject.
       try {
-        const badMatch = await qdrant.badExemplarCheck(sanitizedFact.content);
+        const badMatch = await qdrant.badExemplarCheck(sanitizedFact.content, undefined, routeInput);
         if (badMatch && badMatch.score >= 0.85) {
           effectiveConfidence = clamp01(effectiveConfidence - 0.2);
           reviewStatus = "candidate";
@@ -690,11 +704,11 @@ const storeFacts = async (
       }
 
       if (dedup.action === "supersede" && dedup.existingId) {
-        const newId = await qdrant.storeFact(storePayload);
-        await qdrant.supersedeFact(dedup.existingId, newId);
+        const newId = await qdrant.storeFact(storePayload, routeInput);
+        await qdrant.supersedeFact(dedup.existingId, newId, dedup.destination);
         stored++;
       } else {
-        await qdrant.storeFact(storePayload);
+        await qdrant.storeFact(storePayload, routeInput);
         stored++;
       }
     } catch (e) {

--- a/src/daemon/qdrant.test.ts
+++ b/src/daemon/qdrant.test.ts
@@ -18,6 +18,8 @@ import {
   setLogger,
   setEmbeddingConfig,
   storeFact,
+  dedupCheck,
+  reinforceFact,
 } from "./qdrant.js";
 import type { StoreFact } from "./qdrant.js";
 
@@ -155,6 +157,27 @@ describe("daemon/qdrant", () => {
 
       init();
       assert.strictEqual(isReady(), false);
+    });
+
+    it("returns true when only destinations are configured", () => {
+      saveConfig({
+        ...CONFIG_DEFAULTS,
+        qdrant_url: null,
+        qdrant_api_key: null,
+        destinations: [
+          {
+            name: "work",
+            qdrant_url: "https://work-qdrant.example.com:6333",
+            qdrant_api_key: null,
+            collection: "work-memory",
+            default: true,
+          },
+        ],
+      });
+      resetConfig();
+
+      init();
+      assert.strictEqual(isReady(), true);
     });
   });
 
@@ -303,6 +326,141 @@ describe("daemon/qdrant", () => {
         summary: "secret:1",
         matches: [{ type: "secret", count: 1 }],
       });
+    });
+
+    it("routes stored facts by destination match before default fallback", async () => {
+      const upsertUrls: string[] = [];
+
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const body = init?.body ? JSON.parse(String(init.body)) : null;
+        if (url.includes("/v1/embeddings")) {
+          return new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2, 0.3] }] }), { status: 200 });
+        }
+        if (init?.method === "PUT" && url.includes("/collections/")) {
+          assert.ok(body?.points, "expected Qdrant upsert points");
+          upsertUrls.push(url);
+        }
+        return new Response(JSON.stringify({ result: {} }), { status: 200 });
+      }) as typeof fetch;
+
+      saveConfig({
+        ...CONFIG_DEFAULTS,
+        qdrant_url: null,
+        qdrant_api_key: null,
+        embedding: {
+          ...CONFIG_DEFAULTS.embedding,
+          provider: "ollama",
+          model: "test-model",
+          base_url: "http://embed.test:11434",
+          dimensions: 3,
+        },
+        destinations: [
+          {
+            name: "perso",
+            qdrant_url: "https://perso-qdrant.example.com:6333",
+            qdrant_api_key: null,
+            collection: "perso-memory",
+            match: {
+              content: ["[Bb]ikky"],
+              entity: ["[Bb]ikky"],
+            },
+          },
+          {
+            name: "work",
+            qdrant_url: "https://work-qdrant.example.com:6333",
+            qdrant_api_key: null,
+            collection: "work-memory",
+            default: true,
+          },
+        ],
+      });
+      resetConfig();
+      init();
+
+      await storeFact({
+        content: "Bikky daemon routing should use destinations.",
+        category: "engineering",
+        entities: ["bikky"],
+        content_hash: "bikky-hash",
+      });
+      await storeFact({
+        content: "Client deployment notes should use the default destination.",
+        category: "engineering",
+        entities: ["client"],
+        content_hash: "work-hash",
+      });
+
+      assert.equal(upsertUrls.length, 2);
+      assert.ok(upsertUrls[0]?.startsWith("https://perso-qdrant.example.com:6333/collections/perso-memory/points"));
+      assert.ok(upsertUrls[1]?.startsWith("https://work-qdrant.example.com:6333/collections/work-memory/points"));
+    });
+
+    it("keeps dedup follow-up mutations in the matched destination", async () => {
+      const mutationUrls: string[] = [];
+
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/collections/perso-memory/points/scroll")) {
+          return new Response(JSON.stringify({
+            result: {
+              points: [
+                {
+                  id: "existing-bikky-fact",
+                  payload: { reinforcement_count: 4 },
+                },
+              ],
+            },
+          }), { status: 200 });
+        }
+        if (url.includes("/collections/work-memory/points/scroll")) {
+          return new Response(JSON.stringify({ result: { points: [] } }), { status: 200 });
+        }
+        if (init?.method === "POST" && url.includes("/points/payload")) {
+          mutationUrls.push(url);
+        }
+        return new Response(JSON.stringify({ result: {} }), { status: 200 });
+      }) as typeof fetch;
+
+      saveConfig({
+        ...CONFIG_DEFAULTS,
+        qdrant_url: null,
+        qdrant_api_key: null,
+        destinations: [
+          {
+            name: "perso",
+            qdrant_url: "https://perso-qdrant.example.com:6333",
+            qdrant_api_key: null,
+            collection: "perso-memory",
+            match: { content: ["[Bb]ikky"], entity: ["[Bb]ikky"] },
+          },
+          {
+            name: "work",
+            qdrant_url: "https://work-qdrant.example.com:6333",
+            qdrant_api_key: null,
+            collection: "work-memory",
+            default: true,
+          },
+        ],
+      });
+      resetConfig();
+      init();
+
+      const dedup = await dedupCheck(
+        "Bikky existing fact",
+        "bikky-hash",
+        undefined,
+        undefined,
+        { content: "Bikky existing fact", entities: ["bikky"] },
+      );
+      assert.equal(dedup.action, "skip");
+      assert.equal(dedup.destination, "perso");
+
+      await reinforceFact(dedup.existingId!, dedup.existingCount!, dedup.destination);
+
+      assert.deepEqual(mutationUrls, [
+        "https://perso-qdrant.example.com:6333/collections/perso-memory/points/payload",
+      ]);
     });
   });
 });

--- a/src/daemon/qdrant.ts
+++ b/src/daemon/qdrant.ts
@@ -10,10 +10,12 @@
 
 import { createHash, randomUUID } from "node:crypto";
 
-import { loadConfig } from "../config.js";
+import { getEffectiveDestinations, loadConfig, type Destination } from "../config.js";
 import { embed, initEmbedding, getEmbeddingConfig } from "../llm/index.js";
 import type { InitEmbeddingInput } from "../llm/index.js";
-import { QdrantClient, type QdrantLogLevel } from "../lib/qdrant-client.js";
+import { type QdrantLogLevel } from "../lib/qdrant-client.js";
+import { QdrantPool } from "../lib/qdrant-pool.js";
+import { buildResolver, type RoutingInput } from "../routing.js";
 import {
   DEFAULT_DOMAIN,
   QDRANT_INDEXES,
@@ -124,6 +126,7 @@ export interface StoreFact {
 
 export interface QdrantSearchResult {
   id: string;
+  destination?: string;
   score: number;
   content: string;
   category: string;
@@ -135,6 +138,7 @@ export interface QdrantSearchResult {
 
 export interface QdrantScrollResult {
   id: string;
+  destination?: string;
   content: string;
   category: string;
   entities: string[];
@@ -177,6 +181,7 @@ export type DedupAction = "insert" | "skip" | "supersede";
 
 export interface DedupResult {
   action: DedupAction;
+  destination?: string;
   existingId?: string;
   existingCount?: number;
   score?: number;
@@ -191,11 +196,11 @@ export interface DedupThresholds {
 // State
 // ---------------------------------------------------------------------------
 
-let qdrantUrl: string | null = null;
-let qdrantApiKey: string | null = null;
 let collection: string = "bikky";
 let logFn: LogFn = () => {};
-let client: QdrantClient | null = null;
+let destinations: Destination[] = [];
+let pool: QdrantPool | null = null;
+let resolver: ((input: RoutingInput) => Destination) | null = null;
 
 const setLogger = (fn: LogFn): void => { logFn = fn; };
 const setEmbeddingConfig = (overrides?: Partial<InitEmbeddingInput>): void => {
@@ -204,6 +209,62 @@ const setEmbeddingConfig = (overrides?: Partial<InitEmbeddingInput>): void => {
 
 const clientLogAdapter = (level: QdrantLogLevel, msg: string): void => logFn(level, msg);
 
+type DestinationRef = Destination | string | null | undefined;
+
+const fallbackDestination = (): Destination => {
+  if (destinations.length === 0) {
+    throw new Error("Qdrant client not initialized — call init() first");
+  }
+  return destinations.find((destination) => destination.default === true) ?? destinations[0]!;
+};
+
+const resolveDestination = (input: RoutingInput = {}): Destination => {
+  if (!resolver) return fallbackDestination();
+  return resolver(input);
+};
+
+const destinationFromRef = (ref?: DestinationRef): Destination => {
+  if (!ref) return fallbackDestination();
+  if (typeof ref !== "string") return ref;
+  const found = destinations.find((destination) => destination.name === ref);
+  if (!found) {
+    throw new Error(`Unknown Qdrant destination '${ref}'. Configured destinations: ${destinations.map((d) => d.name).join(", ") || "(none)"}`);
+  }
+  return found;
+};
+
+const pathForDestination = (urlPath: string, destination: Destination): string => {
+  if (!urlPath.startsWith("/collections/")) return urlPath;
+  return urlPath.replace(/^\/collections\/[^/]+/, `/collections/${destination.collection}`);
+};
+
+const routingInputForFact = (
+  fact: StoreFact,
+  normalizedContent: string,
+  normalizedEntities: string[],
+  extraMetadata: Record<string, unknown> = {},
+): RoutingInput => ({
+  content: normalizedContent,
+  entities: normalizedEntities,
+  metadata: {
+    ...(fact.metadata ?? {}),
+    ...extraMetadata,
+    category: fact.category,
+    domain: fact.domain ?? DEFAULT_DOMAIN,
+    kind: fact.kind ?? "fact",
+    ...(fact.memory_subtype ? { memory_subtype: fact.memory_subtype } : {}),
+    ...(fact.source ? { source: fact.source } : {}),
+    ...(fact.actor_id ? { actor_id: fact.actor_id } : {}),
+    ...(fact.session_id ? { session_id: fact.session_id } : {}),
+    ...(fact.episode_id ? { episode_id: fact.episode_id } : {}),
+    ...(fact.workstream_key ? { workstream_key: fact.workstream_key } : {}),
+    ...(fact.task_key ? { task_key: fact.task_key } : {}),
+    ...(fact.repo ? { repo: fact.repo } : {}),
+    ...(fact.branch ? { branch: fact.branch } : {}),
+    ...(fact.surface ? { surface: fact.surface } : {}),
+  },
+});
+
 // ---------------------------------------------------------------------------
 // Init — reads credentials from loadConfig()
 // ---------------------------------------------------------------------------
@@ -211,11 +272,10 @@ const clientLogAdapter = (level: QdrantLogLevel, msg: string): void => logFn(lev
 const init = (): boolean => {
   const cfg = loadConfig();
 
-  qdrantUrl = cfg.qdrant_url;
-  qdrantApiKey = cfg.qdrant_api_key;
-  collection = cfg.collection || "bikky";
-
-  if (qdrantUrl) qdrantUrl = qdrantUrl.replace(/\/+$/, "");
+  destinations = getEffectiveDestinations(cfg);
+  collection = (destinations.find((destination) => destination.default === true) ?? destinations[0])?.collection
+    ?? cfg.collection
+    ?? "bikky";
 
   // Initialize embedding provider from config
   const embCfg = initEmbedding({
@@ -231,33 +291,43 @@ const init = (): boolean => {
   });
   logFn("INFO", `Embedding provider: ${embCfg.provider}/${embCfg.model} (${embCfg.dimensions}d) @ ${embCfg.baseUrl}`);
 
-  const ready = !!qdrantUrl;
+  const ready = destinations.length > 0;
   if (ready) {
-    client = new QdrantClient({
-      url: qdrantUrl as string,
-      apiKey: qdrantApiKey,
-      collection,
-      timeoutMs: cfg.qdrant_client.timeout_ms,
-      retries: cfg.qdrant_client.retries,
-      retryBaseDelayMs: cfg.qdrant_client.retry_base_delay_ms,
+    pool = new QdrantPool(destinations, {
+      client: cfg.qdrant_client,
       log: clientLogAdapter,
     });
+    resolver = buildResolver(destinations);
+    logFn("INFO", `Qdrant destinations: ${destinations.map((destination) => `${destination.name}/${destination.collection}`).join(", ")}`);
   } else {
-    client = null;
+    pool = null;
+    resolver = null;
     logFn("WARN", "Qdrant client: missing URL (some memory features disabled)");
   }
   return ready;
 };
 
-const isReady = (): boolean => !!(qdrantUrl && client);
+const isReady = (): boolean => !!(pool && destinations.length > 0);
 
 const ensureCollection = async (): Promise<void> => {
-  if (!client) {
+  if (!pool) {
     throw new Error("Qdrant client not initialized — call init() first");
   }
   const embCfg = getEmbeddingConfig();
-  await client.ensureCollection(embCfg.dimensions, QDRANT_INDEXES);
-  logFn("INFO", `Qdrant collection '${collection}' ready (${QDRANT_INDEXES.length} indexes)`);
+  const results = await Promise.all(destinations.map(async (destination) => {
+    try {
+      await pool!.ensureCollection(destination.name, embCfg.dimensions, QDRANT_INDEXES);
+      logFn("INFO", `Qdrant destination '${destination.name}' collection '${destination.collection}' ready (${QDRANT_INDEXES.length} indexes)`);
+      return { destination, ok: true, error: null as string | null };
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      logFn("WARN", `Qdrant destination '${destination.name}' readiness check failed: ${message}`);
+      return { destination, ok: false, error: message };
+    }
+  }));
+  if (!results.some((result) => result.ok)) {
+    throw new Error(`No Qdrant destinations ready: ${results.map((result) => `${result.destination.name}: ${result.error}`).join("; ")}`);
+  }
 };
 
 
@@ -265,13 +335,38 @@ const ensureCollection = async (): Promise<void> => {
 // HTTP requests
 // ---------------------------------------------------------------------------
 
-const qdrantRequest = async (method: string, urlPath: string, body?: unknown): Promise<Record<string, unknown>> => {
-  if (!client) {
+const qdrantRequest = async (
+  method: string,
+  urlPath: string,
+  body?: unknown,
+  destinationRef?: DestinationRef,
+): Promise<Record<string, unknown>> => {
+  if (!pool) {
     throw new Error(`Qdrant client not initialized — call init() first (${method} ${urlPath})`);
   }
-  const result = await client.request<Record<string, unknown> | undefined>(method, urlPath, body);
+  const destination = destinationFromRef(destinationRef);
+  const result = await pool.client(destination.name).request<Record<string, unknown> | undefined>(
+    method,
+    pathForDestination(urlPath, destination),
+    body,
+  );
   // Some Qdrant endpoints return empty bodies on success — preserve old return shape.
   return result ?? {};
+};
+
+const collectionForDestination = (destinationRef?: DestinationRef): string =>
+  destinationFromRef(destinationRef).collection;
+
+const destinationNames = (): string[] => destinations.map((destination) => destination.name);
+
+const readyDestinations = (): Destination[] => {
+  if (!pool) return [];
+  return destinations.filter((destination) => pool!.isCollectionReady(destination.name));
+};
+
+const activeDestinations = (): Destination[] => {
+  const ready = readyDestinations();
+  return ready.length > 0 ? ready : destinations;
 };
 
 // ---------------------------------------------------------------------------
@@ -282,7 +377,9 @@ const searchFacts = async (
   query: string,
   filters: QdrantSearchFilters = {},
   limit = 10,
+  destinationRef?: DestinationRef,
 ): Promise<QdrantSearchResult[]> => {
+  const destination = destinationFromRef(destinationRef);
   const vector = await embed(query);
 
   const must: Record<string, unknown>[] = [
@@ -308,15 +405,16 @@ const searchFacts = async (
     must.push({ key: "workspace_id", match: { value: filters.workspaceId } });
   }
 
-  const result = await qdrantRequest("POST", `/collections/${collection}/points/search`, {
+  const result = await qdrantRequest("POST", `/collections/${destination.collection}/points/search`, {
     vector,
     filter: { must },
     limit,
     with_payload: true,
-  }) as { result?: Array<{ id: string; score: number; payload?: Partial<QdrantPayload> }> };
+  }, destination) as { result?: Array<{ id: string; score: number; payload?: Partial<QdrantPayload> }> };
 
   return (result.result || []).map((hit) => ({
     id: hit.id,
+    destination: destination.name,
     score: hit.score,
     content: hit.payload?.content ?? "",
     category: hit.payload?.category ?? "",
@@ -330,7 +428,9 @@ const searchFacts = async (
 const scrollFacts = async (
   filters: QdrantScrollFilters = {},
   limit = 10,
+  destinationRef?: DestinationRef,
 ): Promise<QdrantScrollResult[]> => {
+  const destination = destinationFromRef(destinationRef);
   const must: Record<string, unknown>[] = [
     { is_null: { key: "superseded_by" } },
   ];
@@ -382,15 +482,16 @@ const scrollFacts = async (
   if (filters.workspaceId) {
     must.push({ key: "workspace_id", match: { value: filters.workspaceId } });
   }
-  const result = await qdrantRequest("POST", `/collections/${collection}/points/scroll`, {
+  const result = await qdrantRequest("POST", `/collections/${destination.collection}/points/scroll`, {
     filter: { must, must_not },
     limit,
     ...(filters.orderBy ? { order_by: { key: filters.orderBy.key, direction: filters.orderBy.direction } } : {}),
     with_payload: true,
-  }) as { result?: { points?: Array<{ id: string; payload?: Partial<QdrantPayload> }> } };
+  }, destination) as { result?: { points?: Array<{ id: string; payload?: Partial<QdrantPayload> }> } };
 
   return (result.result?.points || []).map((pt) => ({
     id: pt.id,
+    destination: destination.name,
     content: pt.payload?.content ?? "",
     category: pt.payload?.category ?? "",
     entities: pt.payload?.entities || [],
@@ -408,11 +509,24 @@ const scrollFacts = async (
   }));
 };
 
+const scrollFactsAcrossDestinations = async (
+  filters: QdrantScrollFilters = {},
+  limit = 10,
+): Promise<QdrantScrollResult[]> => {
+  const results = await Promise.all(activeDestinations().map((destination) =>
+    scrollFacts(filters, limit, destination).catch((e) => {
+      logFn("WARN", `Qdrant scroll failed for destination '${destination.name}': ${(e as Error).message}`);
+      return [] as QdrantScrollResult[];
+    }),
+  ));
+  return results.flat();
+};
+
 // ---------------------------------------------------------------------------
 // Write methods
 // ---------------------------------------------------------------------------
 
-const storeFact = async (fact: StoreFact): Promise<string> => {
+const storeFact = async (fact: StoreFact, routeInput?: RoutingInput): Promise<string> => {
   const normalizedKind = normalizeKind(fact.kind);
   const normalizedSubtype = validateMemorySubtype(normalizedKind, fact.memory_subtype);
   const normalizedCategory = normalizedSubtype
@@ -432,7 +546,6 @@ const storeFact = async (fact: StoreFact): Promise<string> => {
     ...redactedEntities,
     ...(redactedRelation ? [redactedRelation.from, redactedRelation.type, redactedRelation.to] : []),
   ]);
-  const vector = await embed(redactedContent.text);
   const now = new Date().toISOString();
   const id = randomUUID();
   const payload: QdrantPayload = {
@@ -488,38 +601,53 @@ const storeFact = async (fact: StoreFact): Promise<string> => {
     payload.redaction = redaction;
   }
 
-  await qdrantRequest("PUT", `/collections/${collection}/points`, {
-    points: [{ id, vector, payload }],
-  });
+  const destination = resolveDestination(routeInput ?? routingInputForFact(
+    fact,
+    redactedContent.text,
+    payload.entities,
+    {
+      category: normalizedCategory,
+      domain: normalizedDomain,
+      kind: normalizedKind,
+      ...(normalizedSubtype ? { memory_subtype: normalizedSubtype } : {}),
+    },
+  ));
+  const vector = await embed(redactedContent.text);
 
-  logFn("DEBUG", `Qdrant: stored fact ${id} [${normalizedCategory}] ${redactedContent.text.slice(0, 60)}`);
+  await qdrantRequest("PUT", `/collections/${destination.collection}/points`, {
+    points: [{ id, vector, payload }],
+  }, destination);
+
+  logFn("DEBUG", `Qdrant: stored fact ${id} in '${destination.name}' [${normalizedCategory}] ${redactedContent.text.slice(0, 60)}`);
   return id;
 };
 
-const supersedeFact = async (oldFactId: string, newFactId: string): Promise<void> => {
+const supersedeFact = async (oldFactId: string, newFactId: string, destinationRef?: DestinationRef): Promise<void> => {
+  const destination = destinationFromRef(destinationRef);
   const now = new Date().toISOString();
-  await qdrantRequest("POST", `/collections/${collection}/points/payload`, {
+  await qdrantRequest("POST", `/collections/${destination.collection}/points/payload`, {
     payload: {
       superseded_by: newFactId,
       superseded_at: now,
       updated_at: now,
     },
     points: [oldFactId],
-  });
-  logFn("DEBUG", `Qdrant: superseded fact ${oldFactId} → ${newFactId}`);
+  }, destination);
+  logFn("DEBUG", `Qdrant: superseded fact ${oldFactId} → ${newFactId} in '${destination.name}'`);
 };
 
-const reinforceFact = async (factId: string, currentCount: number): Promise<void> => {
+const reinforceFact = async (factId: string, currentCount: number, destinationRef?: DestinationRef): Promise<void> => {
+  const destination = destinationFromRef(destinationRef);
   const now = new Date().toISOString();
-  await qdrantRequest("POST", `/collections/${collection}/points/payload`, {
+  await qdrantRequest("POST", `/collections/${destination.collection}/points/payload`, {
     payload: {
       reinforcement_count: (currentCount || 1) + 1,
       last_reinforced_at: now,
       updated_at: now,
     },
     points: [factId],
-  });
-  logFn("DEBUG", `Qdrant: reinforced fact ${factId}`);
+  }, destination);
+  logFn("DEBUG", `Qdrant: reinforced fact ${factId} in '${destination.name}'`);
 };
 
 const dedupCheck = async (
@@ -527,7 +655,9 @@ const dedupCheck = async (
   contentHashVal: string,
   { exactThreshold = 0.92, supersedeThreshold = 0.80 }: DedupThresholds = {},
   workspaceId?: string,
+  routeInput?: RoutingInput,
 ): Promise<DedupResult> => {
+  const destination = resolveDestination(routeInput ?? { content });
   // First: hash-based exact check (fast, no embedding)
   try {
     const must: Record<string, unknown>[] = [
@@ -535,16 +665,17 @@ const dedupCheck = async (
       { is_null: { key: "superseded_by" } },
     ];
     if (workspaceId) must.push({ key: "workspace_id", match: { value: workspaceId } });
-    const hashResult = await qdrantRequest("POST", `/collections/${collection}/points/scroll`, {
+    const hashResult = await qdrantRequest("POST", `/collections/${destination.collection}/points/scroll`, {
       filter: { must },
       limit: 1,
       with_payload: true,
-    }) as { result?: { points?: Array<{ id: string; payload?: Partial<QdrantPayload> }> } };
+    }, destination) as { result?: { points?: Array<{ id: string; payload?: Partial<QdrantPayload> }> } };
 
     const existing = hashResult.result?.points?.[0];
     if (existing) {
       return {
         action: "skip" as DedupAction,
+        destination: destination.name,
         existingId: existing.id,
         existingCount: existing.payload?.reinforcement_count || 1,
         score: 1.0,
@@ -560,19 +691,20 @@ const dedupCheck = async (
     const vector = await embed(content);
     const must: Record<string, unknown>[] = [{ is_null: { key: "superseded_by" } }];
     if (workspaceId) must.push({ key: "workspace_id", match: { value: workspaceId } });
-    const searchResult = await qdrantRequest("POST", `/collections/${collection}/points/search`, {
+    const searchResult = await qdrantRequest("POST", `/collections/${destination.collection}/points/search`, {
       vector,
       filter: { must },
       limit: 1,
       with_payload: true,
-    }) as { result?: Array<{ id: string; score: number; payload?: Partial<QdrantPayload> }> };
+    }, destination) as { result?: Array<{ id: string; score: number; payload?: Partial<QdrantPayload> }> };
 
     const top = searchResult.result?.[0];
-    if (!top) return { action: "insert" };
+    if (!top) return { action: "insert", destination: destination.name };
 
     if (top.score >= exactThreshold) {
       return {
         action: "skip",
+        destination: destination.name,
         existingId: top.id,
         existingCount: top.payload?.reinforcement_count || 1,
         score: top.score,
@@ -582,17 +714,18 @@ const dedupCheck = async (
     if (top.score >= supersedeThreshold) {
       return {
         action: "supersede",
+        destination: destination.name,
         existingId: top.id,
         existingCount: top.payload?.reinforcement_count || 1,
         score: top.score,
       };
     }
 
-    return { action: "insert" };
+    return { action: "insert", destination: destination.name };
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);
     logFn("WARN", `Qdrant dedup vector check failed: ${msg}`);
-    return { action: "insert" }; // fail open — better to duplicate than lose
+    return { action: "insert", destination: destination.name }; // fail open — better to duplicate than lose
   }
 };
 
@@ -608,19 +741,21 @@ const dedupCheck = async (
 const badExemplarCheck = async (
   content: string,
   workspaceId?: string,
+  routeInput?: RoutingInput,
 ): Promise<{ score: number; exemplarId: string; reason?: string } | null> => {
+  const destination = resolveDestination(routeInput ?? { content });
   try {
     const vector = await embed(content);
     const must: Record<string, unknown>[] = [
       { key: "is_bad_exemplar", match: { value: true } },
     ];
     if (workspaceId) must.push({ key: "workspace_id", match: { value: workspaceId } });
-    const result = await qdrantRequest("POST", `/collections/${collection}/points/search`, {
+    const result = await qdrantRequest("POST", `/collections/${destination.collection}/points/search`, {
       vector,
       filter: { must },
       limit: 1,
       with_payload: true,
-    }) as { result?: Array<{ id: string; score: number; payload?: Partial<QdrantPayload> }> };
+    }, destination) as { result?: Array<{ id: string; score: number; payload?: Partial<QdrantPayload> }> };
     const top = result.result?.[0];
     if (!top) return null;
     return {
@@ -646,9 +781,15 @@ export {
   setLogger,
   setEmbeddingConfig,
   qdrantRequest,
+  resolveDestination,
+  collectionForDestination,
+  destinationNames,
+  readyDestinations,
+  activeDestinations,
   embed,
   searchFacts,
   scrollFacts,
+  scrollFactsAcrossDestinations,
   storeFact,
   supersedeFact,
   reinforceFact,

--- a/src/daemon/relations.ts
+++ b/src/daemon/relations.ts
@@ -122,8 +122,9 @@ const buildChangedCoOccurrenceCandidates = (facts: QdrantScrollResult[]): Change
  * Get the set of entity pairs that already have a system-inferred relation.
  * Returns a Set of pairKeys.
  */
-const getExistingRelations = async (): Promise<Set<string>> => {
+const getExistingRelations = async (destination?: string): Promise<Set<string>> => {
   const existing = new Set<string>();
+  const collection = qdrant.collectionForDestination(destination);
 
   let offset: string | null = null;
   for (;;) {
@@ -142,8 +143,9 @@ const getExistingRelations = async (): Promise<Set<string>> => {
 
     const result = await qdrant.qdrantRequest(
       "POST",
-      `/collections/${qdrant.collection}/points/scroll`,
+      `/collections/${collection}/points/scroll`,
       body,
+      destination,
     ) as {
       result?: {
         points?: Array<{ id: string; payload?: { from_entity?: string; to_entity?: string } }>;
@@ -171,10 +173,12 @@ const getExistingRelations = async (): Promise<Set<string>> => {
 const fetchSupportingFacts = async (
   entityA: string,
   entityB: string,
+  destination?: string,
 ): Promise<RelationFact[]> => {
+  const collection = qdrant.collectionForDestination(destination);
   const result = await qdrant.qdrantRequest(
     "POST",
-    `/collections/${qdrant.collection}/points/scroll`,
+    `/collections/${collection}/points/scroll`,
     {
       filter: {
         must: [
@@ -191,6 +195,7 @@ const fetchSupportingFacts = async (
       limit: SUPPORTING_FACTS_LIMIT,
       with_payload: true,
     },
+    destination,
   ) as { result?: { points?: Array<{ id: string; payload?: Partial<QdrantPayload> }> } };
 
   return (result.result?.points ?? []).map((point) => ({
@@ -206,8 +211,9 @@ const fetchSupportingFacts = async (
 
 const buildRelationCandidate = async (
   changed: ChangedCoOccurrence,
+  destination?: string,
 ): Promise<RelationCandidate | null> => {
-  const supportingFacts = await fetchSupportingFacts(changed.entityA, changed.entityB);
+  const supportingFacts = await fetchSupportingFacts(changed.entityA, changed.entityB, destination);
   if (supportingFacts.length < MIN_SHARED_FACTS) return null;
 
   return {
@@ -332,6 +338,7 @@ const storeRelation = async (
   relationType: string,
   content: string,
   candidate: RelationCandidate,
+  destination?: string,
   extras: { evidence?: string; confidence?: number; inVocabulary?: boolean; judgment?: { evidence_strength?: number; durability?: string; directionality_clarity?: string } } = {},
 ): Promise<string> => {
   const hash = createHash("sha256")
@@ -373,7 +380,7 @@ const storeRelation = async (
       type: relationType,
       to: toEntity,
     },
-  });
+  }, destination ? { destination } : undefined);
 
   logFn("INFO", `Relations: inferred ${fromEntity} —[${relationType}]→ ${toEntity} (id: ${id})`);
   return id;
@@ -393,13 +400,14 @@ const tick = async (config: BikkyConfig): Promise<void> => {
   const attempts = pruneRecentAttempts(job.recent_attempts, now, RELATION_ATTEMPT_BACKOFF_MS);
   const maxPairs = config.daemon.relation_inference_max_pairs_per_run ?? 3;
   const since = job.cursor_updated_at ?? new Date(now.getTime() - DEFAULT_LOOKBACK_MS).toISOString();
+  const destination = qdrant.resolveDestination({}).name;
 
   try {
     const changedFacts = await qdrant.scrollFacts({
       sinceUpdated: since,
       excludeKinds: ["relation"],
       orderBy: { key: "updated_at", direction: "asc" },
-    }, CHANGED_FACTS_LIMIT);
+    }, CHANGED_FACTS_LIMIT, destination);
 
     if (changedFacts.length === 0) {
       recordMaintenanceRun("relation_inference", {
@@ -428,7 +436,7 @@ const tick = async (config: BikkyConfig): Promise<void> => {
       return;
     }
 
-    const existing = await getExistingRelations();
+    const existing = await getExistingRelations(destination);
     const touchedPairs = changedPairs
       .filter((pair) => !existing.has(pairKey(pair.entityA, pair.entityB)))
       .filter((pair) => !isAttemptBackedOff(attempts, pairKey(pair.entityA, pair.entityB), now, RELATION_ATTEMPT_BACKOFF_MS));
@@ -436,7 +444,7 @@ const tick = async (config: BikkyConfig): Promise<void> => {
     const supportLookupLimit = Math.max(maxPairs * 5, maxPairs);
     const relationCandidates: RelationCandidate[] = [];
     for (const changed of touchedPairs.slice(0, supportLookupLimit)) {
-      const candidate = await buildRelationCandidate(changed);
+      const candidate = await buildRelationCandidate(changed, destination);
       if (candidate) relationCandidates.push(candidate);
       if (relationCandidates.length >= maxPairs) break;
     }
@@ -456,7 +464,7 @@ const tick = async (config: BikkyConfig): Promise<void> => {
         const hash = createHash("sha256")
           .update(`daemon-relation:${pairKey(result.from, result.to)}:${result.type}`)
           .digest("hex");
-        const dedup = await qdrant.dedupCheck(result.content, hash);
+        const dedup = await qdrant.dedupCheck(result.content, hash, undefined, undefined, { destination });
         if (dedup.action === "skip") {
           logFn("DEBUG", `Relations: skipping duplicate ${candidate.entityA}↔${candidate.entityB}`);
           continue;
@@ -468,6 +476,7 @@ const tick = async (config: BikkyConfig): Promise<void> => {
           result.type,
           result.content,
           candidate,
+          destination,
           { evidence: result.evidence, confidence: result.confidence, inVocabulary: result.inVocabulary, judgment: result.judgment },
         );
         inferred++;

--- a/src/daemon/session-index.ts
+++ b/src/daemon/session-index.ts
@@ -146,12 +146,14 @@ export const buildSessionIndexPayload = (input: {
 const findExistingSessionIndex = async (
   sessionId: string,
   scope: WorkspaceScope,
+  destination?: string,
 ): Promise<{ id: string; payload?: Partial<QdrantPayload> } | null> => {
-  const result = await qdrant.qdrantRequest("POST", `/collections/${qdrant.collection}/points/scroll`, {
+  const collection = qdrant.collectionForDestination(destination);
+  const result = await qdrant.qdrantRequest("POST", `/collections/${collection}/points/scroll`, {
     filter: buildSessionIndexFilter(sessionId, scope),
     limit: 1,
     with_payload: true,
-  }) as { result?: { points?: Array<{ id: string; payload?: Partial<QdrantPayload> }> } };
+  }, destination) as { result?: { points?: Array<{ id: string; payload?: Partial<QdrantPayload> }> } };
 
   return result.result?.points?.[0] ?? null;
 };
@@ -162,16 +164,29 @@ export const updateSessionIndex = async (input: {
   episodeResults: EpisodeSummaryWriteResult[];
   scope: WorkspaceScope;
   config: BikkyConfig;
-}): Promise<{ action: "stored" | "updated" | "skipped"; factId?: string; reason?: string }> => {
+  destination?: string;
+}): Promise<{ action: "stored" | "updated" | "skipped"; factId?: string; destination?: string; reason?: string }> => {
   if (input.episodeResults.length === 0) {
     return { action: "skipped", reason: "no_episode_results" };
   }
-  const existing = await findExistingSessionIndex(input.sessionId, input.scope);
   const draft = buildSessionIndexDraft({
     sessionId: input.sessionId,
     eventCount: input.eventCount,
     episodeResults: input.episodeResults,
   });
+  const destination = input.destination
+    ?? input.episodeResults.find((result) => result.destination)?.destination
+    ?? qdrant.resolveDestination({
+      content: draft.content,
+      entities: draft.entities,
+      metadata: {
+        session_id: input.sessionId,
+        memory_subtype: "session_index",
+        kind: "summary",
+        source: "system",
+      },
+    }).name;
+  const existing = await findExistingSessionIndex(input.sessionId, input.scope, destination);
   const now = new Date().toISOString();
   const { payload } = buildSessionIndexPayload({
     draft,
@@ -188,9 +203,10 @@ export const updateSessionIndex = async (input: {
   const vector = await qdrant.embed(String(payload.content));
   const factId = existing?.id ?? randomUUID();
 
-  await qdrant.qdrantRequest("PUT", `/collections/${qdrant.collection}/points`, {
+  const collection = qdrant.collectionForDestination(destination);
+  await qdrant.qdrantRequest("PUT", `/collections/${collection}/points`, {
     points: [{ id: factId, vector, payload }],
-  });
+  }, destination);
 
-  return { action: existing ? "updated" : "stored", factId };
+  return { action: existing ? "updated" : "stored", factId, destination };
 };

--- a/src/daemon/session-summary.ts
+++ b/src/daemon/session-summary.ts
@@ -249,18 +249,42 @@ export const updateSessionSummary = async (input: {
     return { action: "skipped", reason: "no_episode_summaries" };
   }
 
-  const indexResult = await updateSessionIndex({
-    sessionId: input.sessionId,
-    eventCount: input.eventCount,
-    episodeResults,
-    scope,
-    config,
-  });
+  let indexResult: Awaited<ReturnType<typeof updateSessionIndex>> | null = null;
+  const episodeResultsByDestination = new Map<string, typeof episodeResults>();
+  for (const result of episodeResults) {
+    const destination = result.destination ?? qdrant.resolveDestination({
+      content: result.workstreamKey ?? result.episodeId ?? input.sessionId,
+      entities: [result.workstreamKey, result.episodeId].filter((value): value is string => Boolean(value)),
+      metadata: {
+        session_id: input.sessionId,
+        ...(result.episodeId ? { episode_id: result.episodeId } : {}),
+        ...(result.workstreamKey ? { workstream_key: result.workstreamKey } : {}),
+        kind: "summary",
+        memory_subtype: "session_index",
+        source: "system",
+      },
+    }).name;
+    const bucket = episodeResultsByDestination.get(destination) ?? [];
+    bucket.push(result);
+    episodeResultsByDestination.set(destination, bucket);
+  }
+
+  for (const [destination, destinationEpisodeResults] of episodeResultsByDestination) {
+    const result = await updateSessionIndex({
+      sessionId: input.sessionId,
+      eventCount: input.eventCount,
+      episodeResults: destinationEpisodeResults,
+      scope,
+      config,
+      destination,
+    });
+    indexResult ??= result;
+  }
   await updateWorkstreamSummaries({ episodeResults, scope, config });
 
   return {
-    action: indexResult.action,
-    factId: indexResult.factId,
-    reason: indexResult.reason,
+    action: indexResult?.action ?? "skipped",
+    factId: indexResult?.factId,
+    reason: indexResult?.reason,
   };
 };

--- a/src/daemon/staleness.ts
+++ b/src/daemon/staleness.ts
@@ -23,7 +23,7 @@ export interface StaleDeps {
 
 const defaultDeps: StaleDeps = {
   isReady: qdrantMod.isReady,
-  scrollFacts: qdrantMod.scrollFacts,
+  scrollFacts: qdrantMod.scrollFactsAcrossDestinations,
 };
 
 /**
@@ -55,7 +55,7 @@ export const scanStaleFacts = async (config: BikkyConfig, deps: StaleDeps = defa
 
     if (staleFacts.length > 0) {
       // Deduplicate: only log if the set of stale fact IDs has changed
-      const currentIds = staleFacts.map((f) => f.id).sort().join(",");
+      const currentIds = staleFacts.map((f) => `${f.destination ?? "default"}:${f.id}`).sort().join(",");
       if (currentIds === lastStaleIds) {
         logFn("DEBUG", `Staleness scan: same ${staleFacts.length} fact(s) still stale, skipping duplicate log`);
         return;

--- a/src/daemon/workstream-summary.ts
+++ b/src/daemon/workstream-summary.ts
@@ -50,6 +50,7 @@ export interface WorkstreamSummaryPayloadResult {
 export interface WorkstreamUpdateResult {
   action: "stored" | "updated" | "skipped";
   factId?: string;
+  destination?: string;
   workstreamKey?: string;
   reason?: string;
 }
@@ -83,6 +84,22 @@ export const groupEpisodeResultsByWorkstream = (
     const existing = grouped.get(key) ?? [];
     existing.push(result);
     grouped.set(key, existing);
+  }
+  return grouped;
+};
+
+const groupEpisodeResultsByWorkstreamDestination = (
+  episodeResults: EpisodeSummaryWriteResult[],
+): Map<string, { workstreamKey: string; destination?: string; results: EpisodeSummaryWriteResult[] }> => {
+  const grouped = new Map<string, { workstreamKey: string; destination?: string; results: EpisodeSummaryWriteResult[] }>();
+  for (const result of episodeResults) {
+    const workstreamKey = result.workstreamKey?.trim();
+    if (!workstreamKey || !result.episodeId) continue;
+    const destination = result.destination?.trim();
+    const groupKey = `${destination ?? ""}::${workstreamKey}`;
+    const existing = grouped.get(groupKey) ?? { workstreamKey, destination, results: [] };
+    existing.results.push(result);
+    grouped.set(groupKey, existing);
   }
   return grouped;
 };
@@ -229,24 +246,28 @@ const findExistingWorkstreamSummary = async (
   workstreamKey: string,
   scope: WorkspaceScope,
   repo?: string | null,
+  destination?: string,
 ): Promise<{ id: string; payload?: Partial<QdrantPayload> } | null> => {
-  const result = await qdrant.qdrantRequest("POST", `/collections/${qdrant.collection}/points/scroll`, {
+  const collection = qdrant.collectionForDestination(destination);
+  const result = await qdrant.qdrantRequest("POST", `/collections/${collection}/points/scroll`, {
     filter: buildWorkstreamSummaryFilter(workstreamKey, scope, repo),
     limit: 1,
     with_payload: true,
-  }) as { result?: { points?: Array<{ id: string; payload?: Partial<QdrantPayload> }> } };
+  }, destination) as { result?: { points?: Array<{ id: string; payload?: Partial<QdrantPayload> }> } };
   return result.result?.points?.[0] ?? null;
 };
 
 const loadEpisodeSummaries = async (
   workstreamKey: string,
   scope: WorkspaceScope,
+  destination?: string,
 ): Promise<Array<{ id: string; payload?: Partial<QdrantPayload> }>> => {
-  const result = await qdrant.qdrantRequest("POST", `/collections/${qdrant.collection}/points/scroll`, {
+  const collection = qdrant.collectionForDestination(destination);
+  const result = await qdrant.qdrantRequest("POST", `/collections/${collection}/points/scroll`, {
     filter: buildWorkstreamEpisodeFilter(workstreamKey, scope),
     limit: CAPTURE_TRIGGERS.workstreamSummary.maxEpisodesPerUpdate,
     with_payload: true,
-  }) as { result?: { points?: Array<{ id: string; payload?: Partial<QdrantPayload> }> } };
+  }, destination) as { result?: { points?: Array<{ id: string; payload?: Partial<QdrantPayload> }> } };
   return result.result?.points ?? [];
 };
 
@@ -269,21 +290,32 @@ export const updateWorkstreamSummaries = async (input: {
   scope: WorkspaceScope;
   config: BikkyConfig;
 }): Promise<WorkstreamUpdateResult[]> => {
-  const grouped = groupEpisodeResultsByWorkstream(input.episodeResults);
+  const grouped = groupEpisodeResultsByWorkstreamDestination(input.episodeResults);
   if (grouped.size === 0) return [{ action: "skipped", reason: "no_workstream_keys" }];
 
   const results: WorkstreamUpdateResult[] = [];
-  for (const [workstreamKey] of grouped) {
-    const episodes = await loadEpisodeSummaries(workstreamKey, input.scope);
+  for (const { workstreamKey, destination: groupDestination } of grouped.values()) {
+    const destination = groupDestination
+      ?? qdrant.resolveDestination({
+        content: workstreamKey,
+        entities: [workstreamKey],
+        metadata: {
+          workstream_key: workstreamKey,
+          memory_subtype: "workstream",
+          kind: "summary",
+          source: "system",
+        },
+      }).name;
+    const episodes = await loadEpisodeSummaries(workstreamKey, input.scope, destination);
     const episodeSummaries = episodes
       .map((episode) => episode.payload?.content)
       .filter((content): content is string => Boolean(content?.trim()));
     if (episodeSummaries.length < CAPTURE_TRIGGERS.workstreamSummary.minEpisodeCount) {
-      results.push({ action: "skipped", reason: "not_enough_episodes", workstreamKey });
+      results.push({ action: "skipped", reason: "not_enough_episodes", workstreamKey, destination });
       continue;
     }
 
-    const existing = await findExistingWorkstreamSummary(workstreamKey, input.scope, null);
+    const existing = await findExistingWorkstreamSummary(workstreamKey, input.scope, null, destination);
     const draft = await summarizeWorkstream({
       workstreamKey,
       existingSummary: existing?.payload?.content ?? null,
@@ -305,10 +337,11 @@ export const updateWorkstreamSummaries = async (input: {
     });
     const vector = await qdrant.embed(String(payload.content));
     const factId = existing?.id ?? randomUUID();
-    await qdrant.qdrantRequest("PUT", `/collections/${qdrant.collection}/points`, {
+    const collection = qdrant.collectionForDestination(destination);
+    await qdrant.qdrantRequest("PUT", `/collections/${collection}/points`, {
       points: [{ id: factId, vector, payload }],
-    });
-    results.push({ action: existing ? "updated" : "stored", factId, workstreamKey });
+    }, destination);
+    results.push({ action: existing ? "updated" : "stored", factId, workstreamKey, destination });
   }
 
   return results;


### PR DESCRIPTION
## Summary

Closes #123.

- refactor daemon Qdrant initialization to use effective destinations, QdrantPool, and routing resolver
- route extraction dedup, bad-exemplar checks, contradiction lookup, store, reinforce, and supersede through the resolved destination
- carry destination context through episode/session/workstream summary writes and derived relation/distill writes
- add daemon Qdrant regression coverage for destinations-only init, routed stores, and dedup follow-up mutations

## Validation

- npm run check
- npm test
- npm run verify:package