### PR TITLE
Recommend Portkey as cloud provider; canonicalise 1024-dim embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ bikky supports four common setup shapes. Pick based on where you want Qdrant to 
 | ----------------------- | ------------------------------ | ---------------------------------------------------------------------------------------- |
 | **Node.js**             | ≥ 20                           | `nvm install 20` or your package manager                                                 |
 | **Vector store**        | Qdrant                         | Local Docker · [Qdrant Cloud](https://cloud.qdrant.io) · Self-hosted                     |
-| **Embeddings**          | One provider                   | OpenAI · Ollama · Bedrock · Portkey                                                     |
-| **LLM**                 | One provider                   | OpenAI · Ollama · Bedrock · Portkey                                                     |
+| **Embeddings**          | One provider                   | Portkey · OpenAI · Ollama · Bedrock                                                     |
+| **LLM**                 | One provider                   | Portkey · OpenAI · Ollama · Bedrock                                                     |
 | **Docker** *(optional)* | Only if you run Qdrant locally | Docker Desktop, OrbStack, colima, etc.                                                   |
 
-Both `embedding.provider` and `llm.provider` accept the same values: `ollama`, `openai`, `bedrock`, or `portkey`.
+Both `embedding.provider` and `llm.provider` accept the same values: `ollama`, `openai`, `bedrock`, or `portkey`. **Portkey is the easiest cloud option** — one API key, any upstream provider, with built-in routing/fallbacks. Bikky's canonical embedding dimension is **1024**, portable across every modern provider.
 
 > ⚠️ **Qdrant Cloud free tier does not include automatic backups.** Deleted collections cannot be recovered. If your memory data is valuable, use a paid Qdrant Cloud plan (which includes daily backups), run Qdrant locally with your own backup strategy, or periodically export snapshots via the [Qdrant snapshots API](https://qdrant.tech/documentation/concepts/snapshots/).
 

--- a/docs/config/fully-hosted.md
+++ b/docs/config/fully-hosted.md
@@ -1,16 +1,16 @@
 # Fully hosted config
 
-Best for performance and teams. This setup uses Qdrant Cloud for managed vector storage and OpenAI-compatible hosted models for extraction, curation, and recall.
+Best for performance and teams. This setup uses Qdrant Cloud for managed vector storage and a hosted gateway/provider for extraction, curation, and recall.
 
 ## What you need
 
 - A Qdrant Cloud cluster URL.
 - A Qdrant API key.
-- An OpenAI API key, or another hosted provider configured in the full configuration guide.
+- A Portkey API key (recommended) — one key, many upstream providers, with built-in routing, fallbacks, and observability. Get one at [portkey.ai](https://portkey.ai). Or use OpenAI / Bedrock directly.
 
-For both `embedding.provider` and `llm.provider`, possible values are `openai`, `bedrock`, or `portkey` for hosted models. `ollama` is also supported when you want local model calls.
+For both `embedding.provider` and `llm.provider`, possible values are `portkey`, `openai`, or `bedrock` for hosted models. `ollama` is also supported when you want local model calls.
 
-## Config
+## Config (recommended: Portkey)
 
 Save this as `~/.bikky/config.json`:
 
@@ -19,9 +19,35 @@ Save this as `~/.bikky/config.json`:
   "qdrant_url": "https://your-cluster.cloud.qdrant.io:6333",
   "qdrant_api_key": "your-qdrant-api-key",
   "embedding": {
+    "provider": "portkey",
+    "model": "@openai/text-embedding-3-small",
+    "dimensions": 1024
+  },
+  "llm": {
+    "provider": "portkey",
+    "model": "@anthropic/claude-sonnet-4"
+  }
+}
+```
+
+Then export the gateway key:
+
+```bash
+export PORTKEY_API_KEY="pk-..."
+```
+
+bikky uses **1024-dimensional embeddings** as the canonical default. This is portable across modern providers (OpenAI 3-small/3-large via Matryoshka truncation, Cohere v3, Voyage, Mistral, Bedrock Titan v2, BGE/E5) so you can switch providers later without re-embedding.
+
+`qdrant_api_key` is optional only for unauthenticated self-hosted Qdrant. Qdrant Cloud usually requires it.
+
+## Alternative: OpenAI directly
+
+```json
+{
+  "embedding": {
     "provider": "openai",
     "model": "text-embedding-3-small",
-    "dimensions": 1536,
+    "dimensions": 1024,
     "api_key": "sk-..."
   },
   "llm": {
@@ -32,13 +58,7 @@ Save this as `~/.bikky/config.json`:
 }
 ```
 
-`qdrant_api_key` is optional only for unauthenticated self-hosted Qdrant. Qdrant Cloud usually requires it.
-
-Prefer not to store hosted model keys in the config file? Omit `api_key` above and set:
-
-```bash
-export OPENAI_API_KEY="sk-..."
-```
+Or set `OPENAI_API_KEY` in the environment instead of the config file.
 
 ## Check it
 
@@ -54,4 +74,4 @@ bikky stop && bikky start
 
 Then restart your editor so its MCP process reloads.
 
-For Bedrock, Portkey, custom base URLs, or model-specific dimensions, see the [full configuration guide](https://github.com/bikky-dev/bikky/blob/main/docs/configuration.md).
+For Bedrock, custom base URLs, or model-specific dimensions, see the [full configuration guide](https://github.com/bikky-dev/bikky/blob/main/docs/configuration.md).

--- a/docs/config/hosted-models.md
+++ b/docs/config/hosted-models.md
@@ -1,15 +1,15 @@
 # Local Qdrant + hosted models config
 
-This setup keeps Qdrant local while hosted embeddings and LLM calls handle extraction, curation, and recall.
+This setup keeps Qdrant local while a hosted gateway/provider handles extraction, curation, and recall.
 
 ## What you need
 
 - Qdrant running locally, usually with Docker.
-- An OpenAI API key, or another hosted provider configured in the full configuration guide.
+- A Portkey API key (recommended) — one key, many upstream providers, with built-in routing, fallbacks, and observability. Get one at [portkey.ai](https://portkey.ai). Or use OpenAI / Bedrock directly.
 
-For both `embedding.provider` and `llm.provider`, possible values are `openai`, `bedrock`, or `portkey` for hosted models. `ollama` is also supported when you want local model calls.
+For both `embedding.provider` and `llm.provider`, possible values are `portkey`, `openai`, or `bedrock` for hosted models. `ollama` is also supported when you want local model calls.
 
-## Config
+## Config (recommended: Portkey)
 
 Save this as `~/.bikky/config.json`:
 
@@ -18,9 +18,35 @@ Save this as `~/.bikky/config.json`:
   "qdrant_url": "http://localhost:6333",
   "qdrant_api_key": "",
   "embedding": {
+    "provider": "portkey",
+    "model": "@openai/text-embedding-3-small",
+    "dimensions": 1024
+  },
+  "llm": {
+    "provider": "portkey",
+    "model": "@anthropic/claude-sonnet-4"
+  }
+}
+```
+
+Then export the gateway key:
+
+```bash
+export PORTKEY_API_KEY="pk-..."
+```
+
+bikky uses **1024-dimensional embeddings** as the canonical default. This is portable across modern providers (OpenAI 3-small/3-large via Matryoshka truncation, Cohere v3, Voyage, Mistral, Bedrock Titan v2, BGE/E5) so you can switch providers later without re-embedding.
+
+`qdrant_api_key` is optional. Leave it empty or omit it for local or unauthenticated self-hosted Qdrant.
+
+## Alternative: OpenAI directly
+
+```json
+{
+  "embedding": {
     "provider": "openai",
     "model": "text-embedding-3-small",
-    "dimensions": 1536,
+    "dimensions": 1024,
     "api_key": "sk-..."
   },
   "llm": {
@@ -31,13 +57,7 @@ Save this as `~/.bikky/config.json`:
 }
 ```
 
-`qdrant_api_key` is optional. Leave it empty or omit it for local or unauthenticated self-hosted Qdrant.
-
-Prefer not to store hosted model keys in the config file? Omit `api_key` above and set:
-
-```bash
-export OPENAI_API_KEY="sk-..."
-```
+Or set `OPENAI_API_KEY` in the environment instead of the config file.
 
 ## Check it
 
@@ -47,4 +67,4 @@ bikky status
 
 If you started from a fresh install, run `bikky setup` after writing the config, then restart your editor so its MCP process reloads.
 
-For Bedrock, Portkey, custom base URLs, or model-specific dimensions, see the [full configuration guide](https://github.com/bikky-dev/bikky/blob/main/docs/configuration.md).
+For Bedrock, custom base URLs, or model-specific dimensions, see the [full configuration guide](https://github.com/bikky-dev/bikky/blob/main/docs/configuration.md).

--- a/src/config.ts
+++ b/src/config.ts
@@ -256,6 +256,7 @@ export const CONFIG_ENV_KEYS = [
   "EMBEDDING_BASE_URL",
   "EMBEDDING_DIMENSIONS",
   "OPENAI_API_KEY",
+  "PORTKEY_API_KEY",
   "LLM_PROVIDER",
   "LLM_MODEL",
   "LLM_BASE_URL",
@@ -708,6 +709,12 @@ export function loadConfig(): BikkyConfig {
     if (Number.isFinite(n) && n > 0) config.embedding.dimensions = n;
   }
   if (process.env.OPENAI_API_KEY) config.embedding.api_key = process.env.OPENAI_API_KEY;
+  // Portkey users can supply their gateway key via PORTKEY_API_KEY without
+  // needing to repurpose OPENAI_API_KEY. Only applied when the embedding
+  // provider is Portkey, so non-Portkey setups remain untouched.
+  if (process.env.PORTKEY_API_KEY && config.embedding.provider === "portkey") {
+    config.embedding.api_key = process.env.PORTKEY_API_KEY;
+  }
   // Generic provider-extras: BIKKY_EMBEDDING_EXTRA_<KEY>=value
   config.embedding.extra = config.embedding.extra ?? {};
   for (const [k, v] of Object.entries(process.env)) {
@@ -721,6 +728,9 @@ export function loadConfig(): BikkyConfig {
   if (process.env.LLM_MODEL) config.llm.model = process.env.LLM_MODEL;
   if (process.env.LLM_BASE_URL) config.llm.base_url = process.env.LLM_BASE_URL;
   if (process.env.OPENAI_API_KEY && !config.llm.api_key) config.llm.api_key = process.env.OPENAI_API_KEY;
+  if (process.env.PORTKEY_API_KEY && config.llm.provider === "portkey" && !config.llm.api_key) {
+    config.llm.api_key = process.env.PORTKEY_API_KEY;
+  }
   if (process.env.LLM_FALLBACK_PROVIDER) config.llm.fallback_provider = process.env.LLM_FALLBACK_PROVIDER;
   if (process.env.AWS_PROFILE) config.aws_profile = process.env.AWS_PROFILE;
   // Generic provider-extras: BIKKY_LLM_EXTRA_<KEY>=value

--- a/src/llm/embedding/index.test.ts
+++ b/src/llm/embedding/index.test.ts
@@ -32,7 +32,7 @@ describe("initEmbedding — resolution", () => {
   it("applies openai defaults", async () => {
     const cfg = await initEmbedding({ provider: "openai", apiKey: "sk-test" });
     assert.strictEqual(cfg.model, "text-embedding-3-small");
-    assert.strictEqual(cfg.dimensions, 1536);
+    assert.strictEqual(cfg.dimensions, 1024);
     assert.strictEqual(cfg.baseUrl, "https://api.openai.com");
     assert.strictEqual(cfg.apiKey, "sk-test");
   });
@@ -48,7 +48,7 @@ describe("initEmbedding — resolution", () => {
     const cfg = await initEmbedding({ provider: "portkey", apiKey: "pk-test" });
     assert.strictEqual(cfg.model, "@openai/text-embedding-3-small");
     assert.strictEqual(cfg.baseUrl, "https://api.portkey.ai");
-    assert.strictEqual(cfg.dimensions, 1536);
+    assert.strictEqual(cfg.dimensions, 1024);
   });
 
   it("overrides win over defaults", async () => {

--- a/src/llm/embedding/providers/openai.test.ts
+++ b/src/llm/embedding/providers/openai.test.ts
@@ -48,9 +48,37 @@ describe("openai embedding provider", () => {
     });
   });
 
+  it("forwards dimensions in body for text-embedding-3 models", async () => {
+    let captured: { url: string; init: RequestInit } | null = null;
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      captured = { url, init };
+      return new Response(JSON.stringify({ data: [{ embedding: [0.1] }] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await openaiEmbeddingProvider.embed("hi", { ...baseCfg, dimensions: 1024 });
+    const body = JSON.parse(captured!.init.body as string) as { dimensions?: number };
+    assert.strictEqual(body.dimensions, 1024);
+  });
+
+  it("omits dimensions for legacy ada-002 model", async () => {
+    let captured: { url: string; init: RequestInit } | null = null;
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      captured = { url, init };
+      return new Response(JSON.stringify({ data: [{ embedding: [0.1] }] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await openaiEmbeddingProvider.embed("hi", {
+      ...baseCfg,
+      model: "text-embedding-ada-002",
+      dimensions: 1536,
+    });
+    const body = JSON.parse(captured!.init.body as string) as { dimensions?: number };
+    assert.strictEqual(body.dimensions, undefined);
+  });
+
   it("declares browserCompatible + openai defaults", () => {
     assert.strictEqual(openaiEmbeddingProvider.browserCompatible, true);
     assert.strictEqual(openaiEmbeddingProvider.defaults.model, "text-embedding-3-small");
-    assert.strictEqual(openaiEmbeddingProvider.defaults.dimensions, 1536);
+    assert.strictEqual(openaiEmbeddingProvider.defaults.dimensions, 1024);
   });
 });

--- a/src/llm/embedding/providers/openai.ts
+++ b/src/llm/embedding/providers/openai.ts
@@ -18,11 +18,17 @@ export const openaiEmbeddingProvider: EmbeddingProvider = {
   browserCompatible: true,
   defaults: {
     model: "text-embedding-3-small",
-    dimensions: 1536,
+    dimensions: 1024,
     baseUrl: "https://api.openai.com",
   },
   async embed(text: string, cfg: ResolvedEmbeddingConfig): Promise<number[]> {
     if (!cfg.apiKey) throw new Error("Embedding failed [openai]: api key not configured");
+    const body: Record<string, unknown> = { model: cfg.model, input: text };
+    // The `dimensions` parameter (Matryoshka truncation) is only supported by
+    // the text-embedding-3-* family. Older models (e.g. ada-002) reject it.
+    if (cfg.dimensions && /text-embedding-3/.test(cfg.model)) {
+      body.dimensions = cfg.dimensions;
+    }
     const resp = await resilientFetch({
       url: `${cfg.baseUrl}/v1/embeddings`,
       init: {
@@ -31,7 +37,7 @@ export const openaiEmbeddingProvider: EmbeddingProvider = {
           "Content-Type": "application/json",
           Authorization: `Bearer ${cfg.apiKey}`,
         },
-        body: JSON.stringify({ model: cfg.model, input: text }),
+        body: JSON.stringify(body),
       },
       timeoutMs: cfg.timeoutMs,
       retries: cfg.retries,

--- a/src/llm/embedding/providers/portkey.test.ts
+++ b/src/llm/embedding/providers/portkey.test.ts
@@ -58,8 +58,37 @@ describe("portkey embedding provider", () => {
     });
   });
 
+  it("forwards dimensions in body for text-embedding-3 models", async () => {
+    let captured: RequestInit | null = null;
+    globalThis.fetch = (async (_url: string, init: RequestInit) => {
+      captured = init;
+      return new Response(JSON.stringify({ data: [{ embedding: [0.1] }] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await portkeyEmbeddingProvider.embed("hi", { ...baseCfg, dimensions: 1024 });
+    const body = JSON.parse(captured!.body as string) as { dimensions?: number };
+    assert.strictEqual(body.dimensions, 1024);
+  });
+
+  it("omits dimensions when the model is not OpenAI text-embedding-3", async () => {
+    let captured: RequestInit | null = null;
+    globalThis.fetch = (async (_url: string, init: RequestInit) => {
+      captured = init;
+      return new Response(JSON.stringify({ data: [{ embedding: [0.1] }] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await portkeyEmbeddingProvider.embed("hi", {
+      ...baseCfg,
+      model: "@cohere/embed-english-v3.0",
+      dimensions: 1024,
+    });
+    const body = JSON.parse(captured!.body as string) as { dimensions?: number };
+    assert.strictEqual(body.dimensions, undefined);
+  });
+
   it("declares browserCompatible + portkey defaults", () => {
     assert.strictEqual(portkeyEmbeddingProvider.browserCompatible, true);
     assert.strictEqual(portkeyEmbeddingProvider.defaults.baseUrl, "https://api.portkey.ai");
+    assert.strictEqual(portkeyEmbeddingProvider.defaults.dimensions, 1024);
   });
 });

--- a/src/llm/embedding/providers/portkey.ts
+++ b/src/llm/embedding/providers/portkey.ts
@@ -27,7 +27,7 @@ export const portkeyEmbeddingProvider: EmbeddingProvider = {
   browserCompatible: true,
   defaults: {
     model: "@openai/text-embedding-3-small",
-    dimensions: 1536,
+    dimensions: 1024,
     baseUrl: "https://api.portkey.ai",
   },
   async embed(text: string, cfg: ResolvedEmbeddingConfig): Promise<number[]> {
@@ -39,12 +39,20 @@ export const portkeyEmbeddingProvider: EmbeddingProvider = {
     if (cfg.extra.virtual_key) headers["x-portkey-virtual-key"] = cfg.extra.virtual_key;
     if (cfg.extra.config_id) headers["x-portkey-config"] = cfg.extra.config_id;
 
+    const body: Record<string, unknown> = { model: cfg.model, input: text };
+    // The `dimensions` parameter (Matryoshka truncation) is supported by the
+    // OpenAI text-embedding-3-* family. Forward it when the model name matches
+    // so users get the configured vector size instead of the provider native.
+    if (cfg.dimensions && /text-embedding-3/.test(cfg.model)) {
+      body.dimensions = cfg.dimensions;
+    }
+
     const resp = await resilientFetch({
       url: `${cfg.baseUrl}/v1/embeddings`,
       init: {
         method: "POST",
         headers,
-        body: JSON.stringify({ model: cfg.model, input: text }),
+        body: JSON.stringify(body),
       },
       timeoutMs: cfg.timeoutMs,
       retries: cfg.retries,


### PR DESCRIPTION
## Summary

Position Portkey as bikky's recommended cloud provider for both embeddings and inference, fix the dimensions-not-forwarded bug in the OpenAI and Portkey embedding adapters, and standardise on **1024-dim embeddings** as the portable canonical default.

- Ollama remains the local default (no change to hard config defaults).
- Bedrock remains as an alternate provider.
- No Qdrant migration required: 1024 already matches the existing Ollama qwen3 / Titan v2 defaults.

## Code changes

- `src/llm/embedding/providers/portkey.ts` — forward `cfg.dimensions` in the request body for `text-embedding-3-*` models so MRL truncation actually takes effect; change `defaults.dimensions` 1536 → 1024.
- `src/llm/embedding/providers/openai.ts` — same one-line `dimensions` fix.
- `src/config.ts` — add `PORTKEY_API_KEY` env var. When the embedding/LLM provider is `portkey`, `PORTKEY_API_KEY` populates `api_key` without conflicting with `OPENAI_API_KEY` for non-Portkey users.

## Tests

- 4 new `node:test` cases covering `dimensions` forwarding for both providers and the legacy-model gating (ada-002 / non-OpenAI Portkey models).
- Updated existing default-dimension assertions 1536 → 1024.
- Verified end-to-end against a real Portkey gateway: vector length **1024** confirmed.
- Local run: 573 pass / 1 pre-existing unrelated failure (`daemon/consolidation` cadence test, fails on `main` too).

## Docs

- `docs/config/fully-hosted.md` — Portkey as the primary cloud example, OpenAI as alternate.
- `docs/config/hosted-models.md` — same Portkey-first treatment.
- `README.md` — setup-options table reorders providers and notes Portkey is the easiest cloud option, plus a one-liner on the 1024-dim default.

## Why 1024?

1024 is the most portable embedding dimension across modern providers (OpenAI 3-small/3-large via Matryoshka truncation, Cohere v3, Voyage, Mistral, Bedrock Titan v2, BGE/E5, Ollama qwen3 default). Switching providers later requires no re-embedding. The MTEB quality delta vs 1536 is below run-to-run variance for retrieval workloads.

## Local validation

```
cd /Users/saber/code/bikky && npm run build && npm test
cd packages/ui && npm run build && npm test
```

End-to-end Portkey smoke (real gateway, 1024 dim): ✅ vector length 1024.