### PR TITLE
Fix bikky-ui localhost:0 browser launches

### DIFF
--- a/packages/ui/src/cli.test.ts
+++ b/packages/ui/src/cli.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const cliPath = path.join(__dirname, "cli.js");
+
+describe("ui/cli", () => {
+  it("prints the actual bound URL instead of localhost:0 for ephemeral ports", async () => {
+    const child = spawn(process.execPath, [cliPath], {
+      env: {
+        ...process.env,
+        BIKKY_UI_PORT: "0",
+        BIKKY_UI_NO_OPEN: "1",
+        CI: "1",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    try {
+      await waitForOutput(() => stdout.includes("bikky ui running at http://localhost:"));
+      assert.equal(stdout.includes("http://localhost:0"), false);
+      assert.match(stdout, /bikky ui running at http:\/\/localhost:\d+/);
+    } finally {
+      child.kill("SIGTERM");
+      await waitForExit(child);
+    }
+
+    assert.equal(child.exitCode === 0 || child.signalCode === "SIGTERM", true, stderr);
+  });
+});
+
+async function waitForOutput(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("Timed out waiting for bikky-ui to start");
+}
+
+function waitForExit(child: ReturnType<typeof spawn>): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+  return new Promise((resolve) => child.once("close", resolve));
+}

--- a/packages/ui/src/cli.ts
+++ b/packages/ui/src/cli.ts
@@ -5,10 +5,12 @@
  */
 
 import { startServer, stopServer } from "./server.js";
+import type { AddressInfo } from "node:net";
 
 const PORT = parseInt(process.env.BIKKY_UI_PORT || "1422", 10);
+const SHOULD_OPEN_BROWSER = !process.env.BIKKY_UI_NO_OPEN && process.env.CI !== "1";
 
-console.log(`🧠 bikky ui starting on http://localhost:${PORT}`);
+console.log(`🧠 bikky ui starting on ${PORT === 0 ? "an available local port" : `http://localhost:${PORT}`}`);
 
 try {
   const server = startServer(PORT);
@@ -22,13 +24,20 @@ try {
     throw err;
   });
 
-  // Open browser after server confirms listening
   server.on("listening", () => {
-    console.log(`✅ bikky ui running — press Ctrl+C to stop\n`);
+    const address = server.address();
+    const actualPort = typeof address === "object" && address !== null
+      ? (address as AddressInfo).port
+      : PORT;
+    const url = `http://localhost:${actualPort}`;
+
+    console.log(`✅ bikky ui running at ${url} — press Ctrl+C to stop\n`);
+    if (!SHOULD_OPEN_BROWSER) return;
+
     import("open")
-      .then((mod) => mod.default(`http://localhost:${PORT}`))
+      .then((mod) => mod.default(url))
       .catch(() => {
-        console.log(`  → Open http://localhost:${PORT} in your browser`);
+        console.log(`  → Open ${url} in your browser`);
       });
   });
 } catch (err) {

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -61,7 +61,13 @@ const packages = [
       "LICENSE",
     ],
     smoke: async (binPath, env) => {
-      await assertLongRunning(binPath, [], { ...env, BIKKY_UI_PORT: "0" }, "bikky-ui", "bikky ui running");
+      await assertLongRunning(
+        binPath,
+        [],
+        { ...env, BIKKY_UI_PORT: "0", BIKKY_UI_NO_OPEN: "1" },
+        "bikky-ui",
+        "bikky ui running",
+      );
     },
   },
 ];


### PR DESCRIPTION
## Summary
- resolve the actual bound bikky-ui port before printing/opening URLs when `BIKKY_UI_PORT=0`
- skip browser auto-open during package smoke verification via `BIKKY_UI_NO_OPEN=1`
- add a CLI regression test for ephemeral port startup

## Validation
- `cd packages/ui && npm run typecheck && npm test && npm run build`
- `rm -rf dist && npm run check && npm test && npm run verify:package`