### PR TITLE
fix(config): dynamic config paths + provider base_url fallback

### DIFF
--- a/packages/ui/src/lib/config.ts
+++ b/packages/ui/src/lib/config.ts
@@ -8,8 +8,17 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
-export const BIKKY_DIR = process.env.BIKKY_HOME ?? path.join(os.homedir(), ".bikky");
-export const CONFIG_PATH = path.join(BIKKY_DIR, "config.json");
+export function getBikkyDir(): string {
+  return process.env.BIKKY_HOME ?? path.join(os.homedir(), ".bikky");
+}
+export function getConfigPath(): string {
+  return path.join(getBikkyDir(), "config.json");
+}
+
+// Legacy constants — captured at module load. Prefer getBikkyDir()/getConfigPath()
+// when sandboxing in tests or after mutating BIKKY_HOME at runtime.
+export const BIKKY_DIR = getBikkyDir();
+export const CONFIG_PATH = getConfigPath();
 
 export interface UIDestination {
   name: string;
@@ -65,9 +74,10 @@ export function loadConfig(): BikkyUIConfig {
 
   let config = structuredClone(DEFAULTS);
 
-  if (fs.existsSync(CONFIG_PATH)) {
+  const configPath = getConfigPath();
+  if (fs.existsSync(configPath)) {
     try {
-      const raw = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")) as Record<string, unknown>;
+      const raw = JSON.parse(fs.readFileSync(configPath, "utf-8")) as Record<string, unknown>;
       if (raw.qdrant_url) config.qdrant_url = raw.qdrant_url as string;
       if (raw.qdrant_api_key) config.qdrant_api_key = raw.qdrant_api_key as string;
       if (raw.collection) config.collection = raw.collection as string;
@@ -97,7 +107,7 @@ export function loadConfig(): BikkyUIConfig {
         if (typeof identity.user_name === "string") config.identity.user_name = identity.user_name;
       }
     } catch {
-      console.error(`bikky-ui: failed to parse ${CONFIG_PATH}`);
+      console.error(`bikky-ui: failed to parse ${configPath}`);
     }
   }
 

--- a/packages/ui/src/lib/embed.test.ts
+++ b/packages/ui/src/lib/embed.test.ts
@@ -6,15 +6,21 @@ import { describe, it, before, after, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
+import os from "node:os";
 
 import { embed, isEmbeddingAvailable } from "./embed.js";
-import { CONFIG_PATH, _resetConfig } from "./config.js";
+
+// Sandbox the bikky config dir to a tempdir so tests can never clobber the
+// developer's real ~/.bikky/config.json (root cause of issue #130).
+const TEST_BIKKY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-ui-embed-"));
+process.env.BIKKY_HOME = TEST_BIKKY_HOME;
+const CONFIG_PATH = path.join(TEST_BIKKY_HOME, "config.json");
+
+const { _resetConfig } = await import("./config.js");
 
 const realFetch = globalThis.fetch;
 const ENV_KEYS = ["EMBEDDING_PROVIDER", "EMBEDDING_MODEL", "EMBEDDING_BASE_URL", "OPENAI_API_KEY"];
 const savedEnv: Record<string, string | undefined> = {};
-let savedConfig: string | null = null;
-let configExisted = false;
 
 interface FetchCall { url: string; init: RequestInit }
 
@@ -37,10 +43,7 @@ function writeConfig(cfg: object): void {
 describe("ui/lib/embed", () => {
   before(() => {
     for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
-    if (fs.existsSync(CONFIG_PATH)) {
-      configExisted = true;
-      savedConfig = fs.readFileSync(CONFIG_PATH, "utf-8");
-    }
+    fs.mkdirSync(TEST_BIKKY_HOME, { recursive: true });
   });
 
   after(() => {
@@ -48,8 +51,7 @@ describe("ui/lib/embed", () => {
       if (savedEnv[k] === undefined) delete process.env[k];
       else process.env[k] = savedEnv[k];
     }
-    if (savedConfig !== null) fs.writeFileSync(CONFIG_PATH, savedConfig);
-    else if (!configExisted && fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
+    fs.rmSync(TEST_BIKKY_HOME, { recursive: true, force: true });
     _resetConfig();
     globalThis.fetch = realFetch;
   });

--- a/packages/ui/src/lib/qdrant.test.ts
+++ b/packages/ui/src/lib/qdrant.test.ts
@@ -7,6 +7,7 @@ import { describe, it, before, after, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
+import os from "node:os";
 
 import {
   QdrantClient,
@@ -15,13 +16,18 @@ import {
   createQdrantClient,
   QdrantNotConfiguredError,
 } from "./qdrant.js";
-import { CONFIG_PATH, _resetConfig } from "./config.js";
+
+// Sandbox the bikky config dir to a tempdir so tests can never clobber the
+// developer's real ~/.bikky/config.json (root cause of issue #130).
+const TEST_BIKKY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-ui-qdrant-"));
+process.env.BIKKY_HOME = TEST_BIKKY_HOME;
+const CONFIG_PATH = path.join(TEST_BIKKY_HOME, "config.json");
+
+const { _resetConfig } = await import("./config.js");
 
 const realFetch = globalThis.fetch;
 const ENV_KEYS = ["QDRANT_URL", "QDRANT_API_KEY", "BIKKY_COLLECTION"];
 const savedEnv: Record<string, string | undefined> = {};
-let savedConfig: string | null = null;
-let configExisted = false;
 
 interface FetchCall { url: string; init: RequestInit }
 
@@ -198,10 +204,7 @@ describe("ui/lib/qdrant", () => {
   describe("createQdrantClient / isQdrantConfigured", () => {
     before(() => {
       for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
-      if (fs.existsSync(CONFIG_PATH)) {
-        configExisted = true;
-        savedConfig = fs.readFileSync(CONFIG_PATH, "utf-8");
-      }
+      fs.mkdirSync(TEST_BIKKY_HOME, { recursive: true });
     });
 
     after(() => {
@@ -209,8 +212,7 @@ describe("ui/lib/qdrant", () => {
         if (savedEnv[k] === undefined) delete process.env[k];
         else process.env[k] = savedEnv[k];
       }
-      if (savedConfig !== null) fs.writeFileSync(CONFIG_PATH, savedConfig);
-      else if (!configExisted && fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
+      fs.rmSync(TEST_BIKKY_HOME, { recursive: true, force: true });
       _resetConfig();
     });
 

--- a/packages/ui/src/routes/memory.test.ts
+++ b/packages/ui/src/routes/memory.test.ts
@@ -6,16 +6,25 @@
 import { describe, it, before, after, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
 
 import { Hono } from "hono";
 import { memoryRoutes } from "./memory.js";
-import { CONFIG_PATH, _resetConfig } from "../lib/config.js";
+
+// Sandbox the bikky config dir to a tempdir so tests can never clobber the
+// developer's real ~/.bikky/config.json (root cause of issue #130). BIKKY_HOME
+// must be set before any import that touches the config module — including the
+// dynamic import below.
+const TEST_BIKKY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-ui-memory-routes-"));
+process.env.BIKKY_HOME = TEST_BIKKY_HOME;
+const CONFIG_PATH = path.join(TEST_BIKKY_HOME, "config.json");
+
+const { _resetConfig } = await import("../lib/config.js");
 
 const realFetch = globalThis.fetch;
 const ENV_KEYS = ["QDRANT_URL", "QDRANT_API_KEY", "BIKKY_COLLECTION", "EMBEDDING_PROVIDER", "EMBEDDING_MODEL", "EMBEDDING_BASE_URL", "OPENAI_API_KEY"];
 const savedEnv: Record<string, string | undefined> = {};
-let savedConfig: string | null = null;
-let configExisted = false;
 
 interface QdrantCall { method: string; url: string; host: string; path: string; body: any }
 
@@ -130,10 +139,7 @@ function writeMultiDestinationConfig(): void {
 describe("ui/routes/memory", () => {
   before(() => {
     for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
-    if (fs.existsSync(CONFIG_PATH)) {
-      configExisted = true;
-      savedConfig = fs.readFileSync(CONFIG_PATH, "utf-8");
-    }
+    fs.mkdirSync(TEST_BIKKY_HOME, { recursive: true });
   });
 
   after(() => {
@@ -141,15 +147,14 @@ describe("ui/routes/memory", () => {
       if (savedEnv[k] === undefined) delete process.env[k];
       else process.env[k] = savedEnv[k];
     }
-    if (savedConfig !== null) fs.writeFileSync(CONFIG_PATH, savedConfig);
-    else if (!configExisted && fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
+    fs.rmSync(TEST_BIKKY_HOME, { recursive: true, force: true });
     _resetConfig();
     globalThis.fetch = realFetch;
   });
 
   beforeEach(() => {
     for (const k of ENV_KEYS) delete process.env[k];
-    fs.mkdirSync(CONFIG_PATH.replace(/\/[^/]+$/, ""), { recursive: true });
+    fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
     fs.writeFileSync(CONFIG_PATH, JSON.stringify({
       qdrant_url: "https://q.test",
       qdrant_api_key: "test-key",

--- a/packages/ui/src/server.test.ts
+++ b/packages/ui/src/server.test.ts
@@ -5,18 +5,24 @@
 import { describe, it, before, after, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
 
-import { createApp } from "./server.js";
-import { CONFIG_PATH, _resetConfig } from "./lib/config.js";
+// Sandbox the bikky config dir to a tempdir so tests can never clobber the
+// developer's real ~/.bikky/config.json (root cause of issue #130).
+const TEST_BIKKY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-ui-server-"));
+process.env.BIKKY_HOME = TEST_BIKKY_HOME;
+const CONFIG_PATH = path.join(TEST_BIKKY_HOME, "config.json");
+
+const { createApp } = await import("./server.js");
+const { _resetConfig } = await import("./lib/config.js");
 
 const ENV_KEYS = ["QDRANT_URL", "QDRANT_API_KEY", "BIKKY_COLLECTION", "EMBEDDING_PROVIDER", "EMBEDDING_MODEL", "EMBEDDING_BASE_URL", "OPENAI_API_KEY"];
 const savedEnv: Record<string, string | undefined> = {};
-let savedConfig: string | null = null;
-let configExisted = false;
 const realFetch = globalThis.fetch;
 
 function writeMultiDestinationConfig(): void {
-  fs.mkdirSync(CONFIG_PATH.replace(/\/[^/]+$/, ""), { recursive: true });
+  fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
   fs.writeFileSync(CONFIG_PATH, JSON.stringify({
     collection: "fallback",
     destinations: [
@@ -41,10 +47,7 @@ function writeMultiDestinationConfig(): void {
 describe("ui/server", () => {
   before(() => {
     for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
-    if (fs.existsSync(CONFIG_PATH)) {
-      configExisted = true;
-      savedConfig = fs.readFileSync(CONFIG_PATH, "utf-8");
-    }
+    fs.mkdirSync(TEST_BIKKY_HOME, { recursive: true });
   });
 
   after(() => {
@@ -52,8 +55,7 @@ describe("ui/server", () => {
       if (savedEnv[k] === undefined) delete process.env[k];
       else process.env[k] = savedEnv[k];
     }
-    if (savedConfig !== null) fs.writeFileSync(CONFIG_PATH, savedConfig);
-    else if (!configExisted && fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
+    fs.rmSync(TEST_BIKKY_HOME, { recursive: true, force: true });
     _resetConfig();
   });
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -28,6 +28,10 @@ const {
   getActiveConfigEnvOverrides,
   inspectConfigFile,
   validateConfigObject,
+  getBikkyDir,
+  getConfigPath,
+  getLogDir,
+  getStateDir,
 } = await import("./config.js");
 
 // ---------------------------------------------------------------------------
@@ -151,6 +155,47 @@ describe("config", () => {
 
     it("STATE_DIR is state inside BIKKY_DIR", () => {
       assert.strictEqual(STATE_DIR, path.join(BIKKY_DIR, "state"));
+    });
+
+    it("getBikkyDir() re-reads BIKKY_HOME on every call (issue #130)", () => {
+      // The legacy const exports cache the env var at module load. The getter
+      // form must re-evaluate so tests (and dynamic config moves) actually
+      // sandbox writes.
+      const original = process.env.BIKKY_HOME;
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-home-dynamic-"));
+      try {
+        process.env.BIKKY_HOME = tmp;
+        assert.strictEqual(getBikkyDir(), tmp);
+        assert.strictEqual(getConfigPath(), path.join(tmp, "config.json"));
+        assert.strictEqual(getLogDir(), path.join(tmp, "logs"));
+        assert.strictEqual(getStateDir(), path.join(tmp, "state"));
+      } finally {
+        if (original === undefined) delete process.env.BIKKY_HOME;
+        else process.env.BIKKY_HOME = original;
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it("saveConfig() writes to the live BIKKY_HOME, not the cached one (issue #130)", () => {
+      // Critical regression: even if the test runner has loaded config.ts
+      // before BIKKY_HOME was set, saveConfig() must honour the env var at
+      // call time so it cannot clobber the user's real ~/.bikky/config.json.
+      const original = process.env.BIKKY_HOME;
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-home-savesafe-"));
+      try {
+        process.env.BIKKY_HOME = tmp;
+        const cfg = loadConfig();
+        saveConfig(cfg);
+        assert.ok(fs.existsSync(path.join(tmp, "config.json")));
+        // And the cached CONFIG_PATH (set at module load) must not have been written.
+        // It points at TEST_BIKKY_HOME — different dir than `tmp`.
+        assert.notStrictEqual(path.join(tmp, "config.json"), CONFIG_PATH);
+      } finally {
+        if (original === undefined) delete process.env.BIKKY_HOME;
+        else process.env.BIKKY_HOME = original;
+        fs.rmSync(tmp, { recursive: true, force: true });
+        resetConfig();
+      }
     });
   });
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -302,6 +302,37 @@ describe("config", () => {
       assert.deepStrictEqual(cfg.default_search_scope, "routed");
       assert.deepStrictEqual(cfg.search_scopes, []);
     });
+
+    it("clears the inherited ollama base_url when user picks a non-ollama embedding provider (issue #131)", () => {
+      // Otherwise initEmbedding() would forward localhost:11434 to Portkey/OpenAI/Bedrock,
+      // and bikky would POST every embedding request to a local Ollama daemon.
+      fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+        embedding: { provider: "portkey", model: "@openai/text-embedding-3-small", api_key: "k" },
+      }));
+      resetConfig();
+      const cfg = loadConfig();
+      assert.strictEqual(cfg.embedding.provider, "portkey");
+      assert.strictEqual(cfg.embedding.base_url, "");
+    });
+
+    it("preserves an explicit base_url even for non-ollama providers", () => {
+      fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+        embedding: { provider: "portkey", base_url: "https://custom.gateway.example", api_key: "k" },
+      }));
+      resetConfig();
+      const cfg = loadConfig();
+      assert.strictEqual(cfg.embedding.base_url, "https://custom.gateway.example");
+    });
+
+    it("clears the inherited ollama base_url when user picks a non-ollama llm provider (issue #131)", () => {
+      fs.writeFileSync(CONFIG_PATH, JSON.stringify({
+        llm: { provider: "portkey", model: "@anthropic/claude-sonnet-4", api_key: "k" },
+      }));
+      resetConfig();
+      const cfg = loadConfig();
+      assert.strictEqual(cfg.llm.provider, "portkey");
+      assert.strictEqual(cfg.llm.base_url, "");
+    });
   });
 
   // ── CONFIG_DEFAULTS export ────────────────────────────────────────────────
@@ -567,8 +598,10 @@ describe("config", () => {
       assert.strictEqual(cfg.embedding.provider, "openai");
       assert.strictEqual(cfg.embedding.model, "text-embedding-3-small");
       assert.strictEqual(cfg.embedding.dimensions, 1536);
-      // base_url should still be default
-      assert.strictEqual(cfg.embedding.base_url, "http://localhost:11434");
+      // base_url should be cleared because user picked a non-ollama provider
+      // without an explicit base_url (issue #131) — initEmbedding() will then
+      // apply the openai provider default.
+      assert.strictEqual(cfg.embedding.base_url, "");
     });
 
     it("nested identity config merges correctly", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -727,13 +727,37 @@ export function loadConfig(): BikkyConfig {
 
   // Merge config file
   const configPath = getConfigPath();
+  let fileConfig: Record<string, unknown> = {};
   if (fs.existsSync(configPath)) {
     try {
-      const fileConfig = JSON.parse(fs.readFileSync(configPath, "utf-8")) as Record<string, unknown>;
+      fileConfig = JSON.parse(fs.readFileSync(configPath, "utf-8")) as Record<string, unknown>;
       config = deepMerge(config as unknown as Record<string, unknown>, fileConfig) as unknown as BikkyConfig;
     } catch (e) {
       console.error(`bikky: failed to parse ${configPath}: ${e instanceof Error ? e.message : String(e)}`);
     }
+  }
+
+  // Provider/base_url consistency (issue #131): the DEFAULTS.embedding.base_url
+  // is the ollama localhost URL, baked in for the default ollama provider. If
+  // the user picks a different provider (portkey/openai/bedrock) but doesn't
+  // set an explicit base_url, drop the inherited ollama URL so initEmbedding()
+  // can apply the provider's own default — otherwise we'd POST every embedding
+  // request to localhost:11434 and Ollama would reject the foreign model name.
+  const fileEmbedding = (fileConfig.embedding ?? {}) as Record<string, unknown>;
+  if (
+    config.embedding.provider !== DEFAULTS.embedding.provider
+    && typeof fileEmbedding.base_url !== "string"
+    && !process.env.EMBEDDING_BASE_URL
+  ) {
+    config.embedding.base_url = "";
+  }
+  const fileLlm = (fileConfig.llm ?? {}) as Record<string, unknown>;
+  if (
+    config.llm.provider !== DEFAULTS.llm.provider
+    && typeof fileLlm.base_url !== "string"
+    && !process.env.LLM_BASE_URL
+  ) {
+    config.llm.base_url = "";
   }
 
   // Env var overrides (highest priority)

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,15 +15,43 @@ import { z } from "zod";
 // ---------------------------------------------------------------------------
 
 // BIKKY_HOME env var lets tests (and advanced users) override the config dir
-// without touching the real ~/.bikky/. Tests MUST set this to an isolated
-// tempdir before importing this module — otherwise saveConfig() will write to
-// the user's real config file.
-export const BIKKY_DIR = process.env.BIKKY_HOME ?? path.join(os.homedir(), ".bikky");
-export const CONFIG_PATH = path.join(BIKKY_DIR, "config.json");
-export const LOG_DIR = path.join(BIKKY_DIR, "logs");
-export const STATE_DIR = path.join(BIKKY_DIR, "state");
-export const PID_PATH = path.join(STATE_DIR, "daemon.pid");
-export const EXTRACTION_HEALTH_PATH = path.join(STATE_DIR, "extraction-health.json");
+// without touching the real ~/.bikky/. The getter functions below re-read the
+// env var on every call, so changing BIKKY_HOME at runtime (e.g. in a test
+// setup hook) takes effect for all subsequent saveConfig()/loadConfig() calls.
+//
+// The legacy `BIKKY_DIR` / `CONFIG_PATH` / etc. exports are kept for
+// backward-compatibility, but they capture the env state at module load
+// time and should NOT be relied on for safe writes. Internal callers — and
+// any test that wants sandboxing — should call the getter functions instead.
+
+export function getBikkyDir(): string {
+  return process.env.BIKKY_HOME ?? path.join(os.homedir(), ".bikky");
+}
+export function getConfigPath(): string {
+  return path.join(getBikkyDir(), "config.json");
+}
+export function getLogDir(): string {
+  return path.join(getBikkyDir(), "logs");
+}
+export function getStateDir(): string {
+  return path.join(getBikkyDir(), "state");
+}
+export function getPidPath(): string {
+  return path.join(getStateDir(), "daemon.pid");
+}
+export function getExtractionHealthPath(): string {
+  return path.join(getStateDir(), "extraction-health.json");
+}
+
+// Legacy constant exports — captured at module load. Prefer the getter
+// functions above when you need fresh values (e.g. inside tests, or after
+// mutating BIKKY_HOME at runtime).
+export const BIKKY_DIR = getBikkyDir();
+export const CONFIG_PATH = getConfigPath();
+export const LOG_DIR = getLogDir();
+export const STATE_DIR = getStateDir();
+export const PID_PATH = getPidPath();
+export const EXTRACTION_HEALTH_PATH = getExtractionHealthPath();
 
 // ---------------------------------------------------------------------------
 // Config types
@@ -641,7 +669,7 @@ export function validateConfigObject(raw: unknown): ConfigIssue[] {
   return issues;
 }
 
-export function inspectConfigFile(configPath = CONFIG_PATH): ConfigFileDiagnostics {
+export function inspectConfigFile(configPath = getConfigPath()): ConfigFileDiagnostics {
   if (!fs.existsSync(configPath)) {
     return { path: configPath, exists: false, parse_error: null, issues: [] };
   }
@@ -690,20 +718,21 @@ export function loadConfig(): BikkyConfig {
   if (_config) return _config;
 
   // Ensure dirs exist
-  fs.mkdirSync(BIKKY_DIR, { recursive: true });
-  fs.mkdirSync(LOG_DIR, { recursive: true });
-  fs.mkdirSync(STATE_DIR, { recursive: true });
+  fs.mkdirSync(getBikkyDir(), { recursive: true });
+  fs.mkdirSync(getLogDir(), { recursive: true });
+  fs.mkdirSync(getStateDir(), { recursive: true });
 
   // Start from defaults
   let config = structuredClone(DEFAULTS);
 
   // Merge config file
-  if (fs.existsSync(CONFIG_PATH)) {
+  const configPath = getConfigPath();
+  if (fs.existsSync(configPath)) {
     try {
-      const fileConfig = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8")) as Record<string, unknown>;
+      const fileConfig = JSON.parse(fs.readFileSync(configPath, "utf-8")) as Record<string, unknown>;
       config = deepMerge(config as unknown as Record<string, unknown>, fileConfig) as unknown as BikkyConfig;
     } catch (e) {
-      console.error(`bikky: failed to parse ${CONFIG_PATH}: ${e instanceof Error ? e.message : String(e)}`);
+      console.error(`bikky: failed to parse ${configPath}: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 
@@ -861,8 +890,8 @@ export function getEffectiveDestinations(config: BikkyConfig = loadConfig()): De
 
 /** Save config to disk (used by setup command). */
 export function saveConfig(config: BikkyConfig): void {
-  fs.mkdirSync(BIKKY_DIR, { recursive: true });
-  fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n");
+  fs.mkdirSync(getBikkyDir(), { recursive: true });
+  fs.writeFileSync(getConfigPath(), JSON.stringify(config, null, 2) + "\n");
   _config = config;
 }
 

--- a/src/llm/embedding/index.test.ts
+++ b/src/llm/embedding/index.test.ts
@@ -71,6 +71,27 @@ describe("initEmbedding — resolution", () => {
     assert.strictEqual(cfg.baseUrl, "http://localhost:11434");
   });
 
+  it("falls back to provider default when baseUrl is an empty string (issue #131)", async () => {
+    // Config layers may normalise an absent base_url to "" instead of leaving
+    // it undefined; nullish-coalesce alone won't fall through "" so we used to
+    // ship an empty baseUrl to the provider. Verify the provider default wins.
+    const cfg = await initEmbedding({
+      provider: "portkey",
+      apiKey: "pk-test",
+      baseUrl: "",
+    });
+    assert.strictEqual(cfg.baseUrl, "https://api.portkey.ai");
+  });
+
+  it("falls back to provider default when baseUrl is whitespace only", async () => {
+    const cfg = await initEmbedding({
+      provider: "openai",
+      apiKey: "sk-test",
+      baseUrl: "   ",
+    });
+    assert.strictEqual(cfg.baseUrl, "https://api.openai.com");
+  });
+
   it("passes extra bag through unchanged", async () => {
     const cfg = await initEmbedding({
       provider: "portkey",

--- a/src/llm/embedding/index.ts
+++ b/src/llm/embedding/index.ts
@@ -21,6 +21,7 @@ import "./providers/index.js";
 
 import { getEmbeddingProvider } from "./registry.js";
 import { EmbeddingDimensionMismatchError } from "../errors.js";
+import { firstNonEmptyString } from "../util.js";
 import type { ResolvedEmbeddingConfig } from "./types.js";
 
 export type { EmbeddingProvider, ResolvedEmbeddingConfig } from "./types.js";
@@ -59,7 +60,7 @@ export function initEmbedding(input: InitEmbeddingInput): ResolvedEmbeddingConfi
     provider: provider.name,
     model: input.model ?? provider.defaults.model,
     dimensions: input.dimensions ?? provider.defaults.dimensions,
-    baseUrl: (input.baseUrl ?? provider.defaults.baseUrl ?? "").replace(/\/+$/, ""),
+    baseUrl: (firstNonEmptyString(input.baseUrl, provider.defaults.baseUrl) ?? "").replace(/\/+$/, ""),
     apiKey: input.apiKey ?? null,
     extra: input.extra ?? {},
     timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,

--- a/src/llm/inference/index.test.ts
+++ b/src/llm/inference/index.test.ts
@@ -65,6 +65,11 @@ describe("initLLM — resolution", () => {
     const cfg = initLLM({ config: { provider: "ollama", baseUrl: "http://x///" } });
     assert.strictEqual(cfg.baseUrl, "http://x");
   });
+
+  it("falls back to provider default when baseUrl is an empty string (issue #131)", () => {
+    const cfg = initLLM({ config: { provider: "portkey", apiKey: "pk", baseUrl: "" } });
+    assert.strictEqual(cfg.baseUrl, "https://api.portkey.ai");
+  });
 });
 
 describe("getInferenceConfig", () => {

--- a/src/llm/inference/index.ts
+++ b/src/llm/inference/index.ts
@@ -27,6 +27,7 @@ import type {
   ResolvedInferenceConfig,
 } from "./types.js";
 import type { LlmHttpError } from "../errors.js";
+import { firstNonEmptyString } from "../util.js";
 import { estimateTokens, writeTelemetry } from "../telemetry.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -44,7 +45,7 @@ export function initLLM(opts: { config: InitLLMInput; logger?: LogFn }): Resolve
   resolved = {
     provider: provider.name,
     model: opts.config.model ?? provider.defaults.model,
-    baseUrl: (opts.config.baseUrl ?? provider.defaults.baseUrl ?? "").replace(/\/+$/, ""),
+    baseUrl: (firstNonEmptyString(opts.config.baseUrl, provider.defaults.baseUrl) ?? "").replace(/\/+$/, ""),
     apiKey: opts.config.apiKey ?? null,
     fallback: opts.config.fallback ?? null,
     extra: opts.config.extra ?? {},

--- a/src/llm/util.ts
+++ b/src/llm/util.ts
@@ -1,0 +1,17 @@
+/**
+ * Tiny helpers shared by the embedding and inference layers.
+ */
+
+/**
+ * Returns the first argument that is a non-empty trimmed string, or undefined.
+ *
+ * Useful when a value may come from a config layer that normalises absent
+ * fields to `""` instead of leaving them undefined — `??` alone won't fall
+ * through `""`, but this will. See issue #131.
+ */
+export function firstNonEmptyString(...candidates: Array<string | undefined | null>): string | undefined {
+  for (const c of candidates) {
+    if (typeof c === "string" && c.trim().length > 0) return c;
+  }
+  return undefined;
+}


### PR DESCRIPTION
Two coupled fixes that surfaced while testing the memory MCP tool. Both target latent bugs that bite users of the new Portkey-as-default path shipped in #128.

## Bug 1 — UI test suite clobbers `~/.bikky/config.json` (refs closed #130)

Several test files write directly to the real user `CONFIG_PATH` and rely on a backup/restore dance. Any unhandled exception, crash, or concurrent test run leaves the user's config replaced with test fixtures (`https://q.test`, `ollama/qwen`, dimensions 3). The MCP server then loads garbage and the memory tools go dead until the user manually restores their config.

Root cause: `src/config.ts` and `packages/ui/src/lib/config.ts` captured `BIKKY_DIR` / `CONFIG_PATH` at module load. Once imported, mutating `BIKKY_HOME` mid-run had no effect.

Fix (commit 1):
- Add dynamic `getBikkyDir()` / `getConfigPath()` / `getLogDir()` / `getStateDir()` / `getPidPath()` / `getExtractionHealthPath()` getters that re-read `BIKKY_HOME` on every call.
- Internal callers (`loadConfig`, `saveConfig`, `inspectConfigFile`, the UI mirror) now use the getters.
- Legacy const exports preserved for backward compat.
- Sandbox the four leaky UI test files (`memory`, `server`, `qdrant`, `embed`) with `BIKKY_HOME = mkdtempSync(...)` + dynamic import + local `CONFIG_PATH`. Backup/restore dance removed.
- 2 new regression tests proving `getBikkyDir()` reflects live `BIKKY_HOME` and `saveConfig()` writes there.

## Bug 2 — `initEmbedding` / `initInference` ignore provider default `base_url` (refs closed #131)

When a user picked a non-default provider (portkey, openai, bedrock) and omitted `base_url` from `~/.bikky/config.json`, bikky still POSTed every request to `http://localhost:11434` and got back the cryptic Ollama error:

```
unqualified name: registry.ollama.ai/@openai/text-embedding-3-small
```

Two coupled root causes:

1. `CONFIG_DEFAULTS.embedding.base_url` and `CONFIG_DEFAULTS.llm.base_url` are hard-coded to `http://localhost:11434` (sensible for the default ollama provider, but `deepMerge` then leaks that URL onto any non-ollama config that omits `base_url`).
2. `initEmbedding()` / `initInference()` used `?? provider.defaults.baseUrl`, which only falls through on `null` / `undefined` — an empty-string `base_url` short-circuits to `""` and breaks the SDK call.

Fix (commit 2):
- `loadConfig()` now clears the inherited Ollama `base_url` when the user picks a non-ollama provider without an explicit `base_url` (and no `EMBEDDING_BASE_URL` / `LLM_BASE_URL` env override). Explicit user values are preserved.
- New `firstNonEmptyString()` helper in `src/llm/util.ts` used by both `initEmbedding` and `initInference` so empty / whitespace `base_url` falls through to the provider default.
- 5 new regression tests (3 in `config.test.ts`, 2 in `embedding/index.test.ts`, 1 in `inference/index.test.ts`).

## Verification

- `npm run build` clean (root + `packages/ui`).
- `npm test`: 600/600 root, 90/90 + 9/9 vitest in `packages/ui`.
- Manual end-to-end: stripped `base_url` from a real `~/.bikky/config.json` (portkey provider) → `bikky status` reports embedding/llm 🟢 with no manual workaround.

## Out of scope

- Re-opening #130 / #131 (closed by user; this PR ships the code fixes anyway because they affect the new Portkey path).
- Dropping the `""` normalisation from the config schema.
- Any change to merged PR #128 itself.