### PR TITLE
Release bikky 0.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bikky",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bikky",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bikky",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Shared memory for AI coding sessions — MCP server + background daemon",
   "type": "module",
   "license": "AGPL-3.0-or-later",

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bikky-ui",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bikky-ui",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@hono/node-server": "^1.13.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bikky-ui",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Local web UI for browsing and managing bikky memory",
   "type": "module",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary
- bump `bikky` to `0.4.3`
- bump `bikky-ui` to `0.1.16`
- prepare both packages for npm publishing via the existing publish workflow

## Validation
- `rm -rf dist packages/ui/dist && npm run check && npm test`
- `cd packages/ui && npm run typecheck && npm test && npm run build`
- `npm run verify:package`

After merge, run `Publish to npm` with `package=both` and `dry_run=false` from `main`.