### PR TITLE
test: isolate daemon config tests

### DIFF
--- a/src/daemon/loop.test.ts
+++ b/src/daemon/loop.test.ts
@@ -4,19 +4,22 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { CONFIG_DEFAULTS, resetConfig, saveConfig } from "../config.js";
 import { QDRANT_INDEXES } from "../mcp/taxonomy.js";
-import { startDaemon, stopDaemon } from "./loop.js";
+
+const TEST_BIKKY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-daemon-loop-"));
+process.env.BIKKY_HOME = TEST_BIKKY_HOME;
+
+const { CONFIG_DEFAULTS, resetConfig, saveConfig, getConfigPath } = await import("../config.js");
+const { startDaemon, stopDaemon } = await import("./loop.js");
 
 interface FetchCall {
   input: string | URL | Request;
   init?: RequestInit;
 }
 
-const configPath = path.join(os.homedir(), ".bikky", "config.json");
+const configPath = path.join(TEST_BIKKY_HOME, "config.json");
 const qdrantEnvKeys = ["QDRANT_URL", "QDRANT_API_KEY"] as const;
 
-let savedConfig: string | null = null;
 const savedQdrantEnv: Record<string, string | undefined> = {};
 let savedFetch: typeof fetch;
 let calls: FetchCall[] = [];
@@ -24,9 +27,7 @@ let calls: FetchCall[] = [];
 describe("daemon loop", () => {
   before(() => {
     savedFetch = globalThis.fetch;
-    if (fs.existsSync(configPath)) {
-      savedConfig = fs.readFileSync(configPath, "utf-8");
-    }
+    assert.equal(getConfigPath(), configPath);
     for (const key of qdrantEnvKeys) {
       savedQdrantEnv[key] = process.env[key];
     }
@@ -42,16 +43,14 @@ describe("daemon loop", () => {
         process.env[key] = savedQdrantEnv[key];
       }
     }
-    if (savedConfig !== null) {
-      fs.writeFileSync(configPath, savedConfig);
-    } else if (fs.existsSync(configPath)) {
-      fs.rmSync(configPath);
-    }
+    fs.rmSync(TEST_BIKKY_HOME, { recursive: true, force: true });
     resetConfig();
   });
 
   beforeEach(() => {
     stopDaemon();
+    fs.rmSync(TEST_BIKKY_HOME, { recursive: true, force: true });
+    fs.mkdirSync(TEST_BIKKY_HOME, { recursive: true });
     calls = [];
     for (const key of qdrantEnvKeys) {
       delete process.env[key];

--- a/src/daemon/qdrant.test.ts
+++ b/src/daemon/qdrant.test.ts
@@ -11,8 +11,11 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
-import { resetConfig, saveConfig, CONFIG_DEFAULTS } from "../config.js";
-import {
+const TEST_BIKKY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-daemon-qdrant-"));
+process.env.BIKKY_HOME = TEST_BIKKY_HOME;
+
+const { resetConfig, saveConfig, CONFIG_DEFAULTS, getConfigPath } = await import("../config.js");
+const {
   init,
   isReady,
   setLogger,
@@ -20,15 +23,14 @@ import {
   storeFact,
   dedupCheck,
   reinforceFact,
-} from "./qdrant.js";
+} = await import("./qdrant.js");
 import type { StoreFact } from "./qdrant.js";
 
 // ---------------------------------------------------------------------------
 // Setup
 // ---------------------------------------------------------------------------
 
-let savedConfig: string | null = null;
-const configPath = path.join(os.homedir(), ".bikky", "config.json");
+const configPath = path.join(TEST_BIKKY_HOME, "config.json");
 const realFetch = globalThis.fetch;
 
 // Env vars that override config — must be cleared for null-credential tests
@@ -37,9 +39,7 @@ const savedQdrantEnv: Record<string, string | undefined> = {};
 
 describe("daemon/qdrant", () => {
   before(() => {
-    if (fs.existsSync(configPath)) {
-      savedConfig = fs.readFileSync(configPath, "utf-8");
-    }
+    assert.equal(getConfigPath(), configPath);
     // Save env vars
     for (const key of QDRANT_ENV_KEYS) {
       savedQdrantEnv[key] = process.env[key];
@@ -55,15 +55,14 @@ describe("daemon/qdrant", () => {
         process.env[key] = savedQdrantEnv[key];
       }
     }
-    // Restore config
-    if (savedConfig !== null) {
-      fs.writeFileSync(configPath, savedConfig);
-    }
+    fs.rmSync(TEST_BIKKY_HOME, { recursive: true, force: true });
     globalThis.fetch = realFetch;
     resetConfig();
   });
 
   beforeEach(() => {
+    fs.rmSync(TEST_BIKKY_HOME, { recursive: true, force: true });
+    fs.mkdirSync(TEST_BIKKY_HOME, { recursive: true });
     // Clear qdrant env vars so saveConfig controls the values
     for (const key of QDRANT_ENV_KEYS) {
       delete process.env[key];
@@ -71,10 +70,6 @@ describe("daemon/qdrant", () => {
     globalThis.fetch = realFetch;
     resetConfig();
   });
-
-  // Restore config after all tests in this file
-  // Note: this runs once since we only save the original once
-
   // ── isReady ──────────────────────────────────────────────────────────────
 
   describe("isReady", () => {


### PR DESCRIPTION
## Summary\n- set temp BIKKY_HOME before importing daemon loop/qdrant test modules\n- remove backup/restore of the user's real ~/.bikky/config.json\n- assert the active config path resolves inside the temp Bikky home\n\n## Validation\n- npm run build && node --test --test-concurrency=1 dist/daemon/loop.test.js dist/daemon/qdrant.test.js dist/config.test.js dist/lifecycle.test.js dist/status.test.js\n- npm run check\n- npm test\n- cd packages/ui && npm run typecheck && npm test && npm run build\n- npm run verify:package\n\nNotion: T-E3-02