### PR TITLE
fix: bump bikky-ui for usefulness metrics

### DIFF
--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bikky-ui",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bikky-ui",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@hono/node-server": "^1.13.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bikky-ui",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Local web UI for browsing and managing bikky memory",
   "type": "module",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary

- bump `bikky-ui` to unpublished patch version `0.1.17`
- enables publishing a rebuilt UI package that includes the already-merged memory usefulness badges, filters, and sort controls

Closes #140

## Validation

- `cd packages/ui && npm test`
- `cd packages/ui && npm run build`
- built bundle token check for usefulness UI labels
- `npm run verify:package`