### PR TITLE
Add persistent session destination override

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,9 @@ We use the Node.js built-in test runner ([`node:test`](https://nodejs.org/api/te
 # Core (CLI, daemon, MCP server) — 300+ tests
 npm test
 
+# Opt-in integration suites (*.itest.ts)
+npm run test:integration
+
 # UI server + libraries — 50+ tests
 cd packages/ui && npm test
 ```
@@ -85,16 +88,18 @@ Good references for new tests:
 | Mocking `globalThis.fetch`       | `src/mcp/api.test.ts`, `packages/ui/src/lib/qdrant.test.ts` |
 | Hono route via `app.fetch`       | `packages/ui/src/routes/memory.test.ts` |
 
-### Integration tests (opt-in, real Qdrant)
+### Integration tests (opt-in)
 
-The default `npm test` mocks every external call. We also ship one **opt-in** end-to-end smoke test that talks to a real Qdrant instance (Cloud, local Docker, or self-hosted) and a real embedding provider — it's the only thing that catches filter-shape rejections, payload-index mismatches, vector-dimension drift, and whether the dedup similarity thresholds (`THRESHOLD_DUPLICATE`, `THRESHOLD_RELATED`) actually correspond to near-duplicates against your embedding model.
+The default `npm test` mocks every external call. Opt-in integration suites live in `*.itest.ts` and run through `npm run test:integration`; they may exercise multiple modules together with mocked network calls, or talk to real backing services when the test explicitly documents that requirement.
+
+Real Qdrant + embedding integration smoke tests should use a throwaway collection and require `BIKKY_INTEGRATION=1`:
 
 ```bash
 # Uses your existing ~/.bikky/config.json + QDRANT_URL (and QDRANT_API_KEY if your Qdrant requires it).
 BIKKY_INTEGRATION=1 npm run test:integration
 ```
 
-What it does:
+What a real-Qdrant smoke should do:
 
 1. Creates a throwaway collection named `bikky-it-<short-uuid>` with the real payload indexes.
 2. Exercises `memory_store` (insert, exact-dup, near-duplicate paraphrase), `memory_recall`, `memory_entity`, and `memory_forget` against live Qdrant + your real embeddings.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -359,6 +359,14 @@ Matching details:
 - Read/search tools also accept `search_scope`; call `memory_search_scopes` or `get_setup_status` to see available scopes and descriptions.
 - All destinations share one embedding provider, so every destination collection must use the same vector dimensions.
 
+Temporary session write override:
+
+- Use the MCP tool `memory_set_session_destination({ "destination": "client-a" })` when new memories from the current local MCP/daemon session should be forced into one configured destination.
+- The override is stored in `~/.bikky/state/session-destination-override.json` (or `BIKKY_HOME/state/session-destination-override.json`) and persists until `memory_clear_session_destination()` is called.
+- Precedence is explicit per-call `destination`, then the session write override, then normal destination routing rules, then default/first fallback.
+- `memory_get_session_destination()`, `memory_search_scopes`, and `get_setup_status` report the current override. If the configured destination is later removed or renamed, Bikky reports the stale override as invalid and ignores it for routing until it is reset or cleared.
+- The override affects new writes and daemon-captured memories. Read tools still use `search_scope` / explicit read destinations so recall can remain narrow or fan out across stores as needed.
+
 Migrating from `workspace_id` pre-v0.4:
 
 - Existing top-level `qdrant_url`, `qdrant_api_key`, and `collection` configs still work as a single synthesized destination.

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,9 @@ export function getPidPath(): string {
 export function getExtractionHealthPath(): string {
   return path.join(getStateDir(), "extraction-health.json");
 }
+export function getSessionDestinationOverridePath(): string {
+  return path.join(getStateDir(), "session-destination-override.json");
+}
 
 // Legacy constant exports — captured at module load. Prefer the getter
 // functions above when you need fresh values (e.g. inside tests, or after

--- a/src/daemon/qdrant.test.ts
+++ b/src/daemon/qdrant.test.ts
@@ -14,7 +14,8 @@ import os from "node:os";
 const TEST_BIKKY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-daemon-qdrant-"));
 process.env.BIKKY_HOME = TEST_BIKKY_HOME;
 
-const { resetConfig, saveConfig, CONFIG_DEFAULTS, getConfigPath } = await import("../config.js");
+const { resetConfig, saveConfig, CONFIG_DEFAULTS, getConfigPath, getEffectiveDestinations, loadConfig } = await import("../config.js");
+const { clearSessionDestinationOverride, setSessionDestinationOverride } = await import("../session-destination-override.js");
 const {
   init,
   isReady,
@@ -57,6 +58,7 @@ describe("daemon/qdrant", () => {
     }
     fs.rmSync(TEST_BIKKY_HOME, { recursive: true, force: true });
     globalThis.fetch = realFetch;
+    clearSessionDestinationOverride();
     resetConfig();
   });
 
@@ -395,6 +397,78 @@ describe("daemon/qdrant", () => {
       assert.equal(upsertUrls.length, 2);
       assert.ok(upsertUrls[0]?.startsWith("https://perso-qdrant.example.com:6333/collections/perso-memory/points"));
       assert.ok(upsertUrls[1]?.startsWith("https://work-qdrant.example.com:6333/collections/work-memory/points"));
+    });
+
+    it("uses the persisted session override before destination match routing", async () => {
+      const upsertUrls: string[] = [];
+      const scrollUrls: string[] = [];
+
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/v1/embeddings")) {
+          return new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2, 0.3] }] }), { status: 200 });
+        }
+        if (url.includes("/points/scroll")) {
+          scrollUrls.push(url);
+          return new Response(JSON.stringify({ result: { points: [] } }), { status: 200 });
+        }
+        if (init?.method === "PUT" && url.includes("/collections/")) {
+          upsertUrls.push(url);
+        }
+        return new Response(JSON.stringify({ result: {} }), { status: 200 });
+      }) as typeof fetch;
+
+      saveConfig({
+        ...CONFIG_DEFAULTS,
+        qdrant_url: null,
+        qdrant_api_key: null,
+        embedding: {
+          ...CONFIG_DEFAULTS.embedding,
+          provider: "ollama",
+          model: "test-model",
+          base_url: "http://embed.test:11434",
+          dimensions: 3,
+        },
+        destinations: [
+          {
+            name: "perso",
+            qdrant_url: "https://perso-qdrant.example.com:6333",
+            qdrant_api_key: null,
+            collection: "perso-memory",
+            match: { content: ["[Bb]ikky"], entity: ["[Bb]ikky"] },
+          },
+          {
+            name: "work",
+            qdrant_url: "https://work-qdrant.example.com:6333",
+            qdrant_api_key: null,
+            collection: "work-memory",
+            default: true,
+          },
+        ],
+      });
+      resetConfig();
+      init();
+      setSessionDestinationOverride("work", getEffectiveDestinations(loadConfig()));
+
+      await storeFact({
+        content: "Bikky daemon routing should obey the session override.",
+        category: "engineering",
+        entities: ["bikky"],
+        content_hash: "bikky-override-hash",
+      });
+      const dedup = await dedupCheck(
+        "Bikky override fact",
+        "bikky-override-hash-2",
+        undefined,
+        undefined,
+        { content: "Bikky override fact", entities: ["bikky"] },
+      );
+
+      assert.equal(dedup.destination, "work");
+      assert.equal(upsertUrls.length, 1);
+      assert.ok(upsertUrls[0]?.startsWith("https://work-qdrant.example.com:6333/collections/work-memory/points"));
+      assert.equal(scrollUrls.some((url) => url.startsWith("https://work-qdrant.example.com:6333/")), true);
+      assert.equal(scrollUrls.some((url) => url.startsWith("https://perso-qdrant.example.com:6333/")), false);
     });
 
     it("keeps dedup follow-up mutations in the matched destination", async () => {

--- a/src/daemon/qdrant.ts
+++ b/src/daemon/qdrant.ts
@@ -16,6 +16,7 @@ import type { InitEmbeddingInput } from "../llm/index.js";
 import { type QdrantLogLevel } from "../lib/qdrant-client.js";
 import { QdrantPool } from "../lib/qdrant-pool.js";
 import { buildResolver, type RoutingInput } from "../routing.js";
+import { applySessionDestinationOverride } from "../session-destination-override.js";
 import {
   DEFAULT_DOMAIN,
   QDRANT_INDEXES,
@@ -229,7 +230,7 @@ const fallbackDestination = (): Destination => {
 
 const resolveDestination = (input: RoutingInput = {}): Destination => {
   if (!resolver) return fallbackDestination();
-  return resolver(input);
+  return resolver(applySessionDestinationOverride(input, destinations));
 };
 
 const destinationFromRef = (ref?: DestinationRef): Destination => {

--- a/src/mcp/api.ts
+++ b/src/mcp/api.ts
@@ -23,6 +23,7 @@ import { createLogger } from "../logger.js";
 import { BIKKY_DIR, LOG_DIR, loadConfig, getEffectiveDestinations, type Destination } from "../config.js";
 import { QdrantPool } from "../lib/qdrant-pool.js";
 import { resolveDestination, buildResolver, type RoutingInput } from "../routing.js";
+import { applySessionDestinationOverride } from "../session-destination-override.js";
 import type { QdrantLogLevel } from "../lib/qdrant-client.js";
 
 // ---------------------------------------------------------------------------
@@ -119,12 +120,16 @@ export function anyCollectionReady(): boolean {
 
 /** Resolve a destination from caller input. Throws if not configured/found. */
 export function resolveDest(input: RoutingInput): Destination {
-  return resolveDestination(input, listDestinations());
+  const destinations = listDestinations();
+  return resolveDestination(applySessionDestinationOverride(input, destinations), destinations);
 }
 
 /** Build a resolver closure from the current pool's destinations. */
 export function makeResolver(): (input: RoutingInput) => Destination {
-  return buildResolver(listDestinations());
+  const destinations = listDestinations();
+  const resolve = buildResolver(destinations);
+  return (input: RoutingInput): Destination =>
+    resolve(applySessionDestinationOverride(input, destinations));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -11,6 +11,8 @@ process.env.BIKKY_HOME = TEST_BIKKY_HOME;
 const { registerTools } = await import("./tools.js");
 const {
   CONFIG_DEFAULTS,
+  getEffectiveDestinations,
+  loadConfig,
   resetConfig,
   saveConfig,
 } = await import("../config.js");
@@ -20,6 +22,7 @@ const {
   setReady,
   setSetupError,
 } = await import("./api.js");
+const { clearSessionDestinationOverride, setSessionDestinationOverride } = await import("../session-destination-override.js");
 
 const realFetch = globalThis.fetch;
 
@@ -184,6 +187,7 @@ describe("mcp/tools", () => {
 
   beforeEach(() => {
     configureDestinations();
+    clearSessionDestinationOverride();
     setSetupError(null);
     setReady(true);
     globalThis.fetch = realFetch;
@@ -199,6 +203,9 @@ describe("mcp/tools", () => {
       "memory_recall",
       "memory_entity",
       "memory_relations",
+      "memory_set_session_destination",
+      "memory_get_session_destination",
+      "memory_clear_session_destination",
     ]) {
       assert.equal(handlers.has(name), true, `expected ${name} to be registered`);
     }
@@ -231,6 +238,7 @@ describe("mcp/tools", () => {
     const result = await handlers.get("memory_search_scopes")!();
     const body = parseToolJson(result) as {
       default_search_scope: string;
+      session_destination_override: Record<string, unknown>;
       scopes: Array<{ name: string; destinations: "routed" | "all" | string[] }>;
     };
 
@@ -239,6 +247,37 @@ describe("mcp/tools", () => {
     assert.ok(body.scopes.some((scope) => scope.name === "all" && scope.destinations === "all"));
     assert.ok(body.scopes.some((scope) => scope.name === "perso" && destinationList(scope.destinations) === "perso"));
     assert.ok(body.scopes.some((scope) => scope.name === "personal-only" && destinationList(scope.destinations) === "perso"));
+    assert.equal(body.session_destination_override.active, false);
+  });
+
+  it("sets, reports, and clears a session destination override", async () => {
+    const handlers = collectTools();
+
+    const setResult = await handlers.get("memory_set_session_destination")!({ destination: "work" });
+    const setBody = parseToolJson(setResult);
+    assert.equal(setBody.status, "session_destination_set");
+    assert.equal(((setBody.session_destination_override as Record<string, unknown>).destination), "work");
+
+    const getResult = await handlers.get("memory_get_session_destination")!();
+    const getBody = parseToolJson(getResult);
+    assert.equal(getBody.status, "session_destination_active");
+    assert.equal(((getBody.session_destination_override as Record<string, unknown>).active), true);
+
+    const clearResult = await handlers.get("memory_clear_session_destination")!();
+    const clearBody = parseToolJson(clearResult);
+    assert.equal(clearBody.status, "session_destination_cleared");
+    assert.equal(((clearBody.session_destination_override as Record<string, unknown>).active), false);
+  });
+
+  it("rejects unknown session destination overrides", async () => {
+    const handlers = collectTools();
+
+    const result = await handlers.get("memory_set_session_destination")!({ destination: "ghost" });
+    const body = parseToolJson(result);
+
+    assert.equal(result.isError, true);
+    assert.equal(body.status, "destination_not_found");
+    assert.deepEqual(body.available_destinations, ["perso", "work"]);
   });
 
   it("rejects ambiguous recall destination and search_scope before embedding", async () => {
@@ -302,6 +341,41 @@ describe("mcp/tools", () => {
     assert.match(String(points[0]!.payload.content), /\[REDACTED:secret\]/);
     assert.deepEqual(points[0]!.payload.entities, ["bikky"]);
     assert.equal((points[0]!.payload.redaction as Record<string, unknown>).redacted, true);
+  });
+
+  it("uses the session destination override for MCP writes unless a call has an explicit destination", async () => {
+    const calls = installStorageMock();
+    setSessionDestinationOverride("work", getEffectiveDestinations(loadConfig()));
+    const handlers = collectTools();
+
+    const routedResult = await handlers.get("memory_store")!({
+      content: "Bikky would normally route to perso.",
+      category: "engineering",
+      entities: ["bikky"],
+      domain: "software_engineering",
+      kind: "fact",
+      source: "agent",
+      confidence: 0.9,
+    });
+    const routedBody = parseToolJson(routedResult);
+    assert.equal(routedBody.destination, "work");
+
+    const explicitResult = await handlers.get("memory_store")!({
+      content: "Bikky explicit destination still wins.",
+      category: "engineering",
+      entities: ["bikky"],
+      domain: "software_engineering",
+      kind: "fact",
+      source: "agent",
+      confidence: 0.9,
+      destination: "perso",
+    });
+    const explicitBody = parseToolJson(explicitResult);
+    assert.equal(explicitBody.destination, "perso");
+
+    const upserts = calls.filter((call) => call.method === "PUT" && call.url.endsWith("/points"));
+    assert.equal(upserts[0]?.destination, "work");
+    assert.equal(upserts[1]?.destination, "perso");
   });
 
   it("reinforces exact memory_store matches without embedding", async () => {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -61,7 +61,7 @@ import {
 } from "./api.js";
 import { DestinationNotFoundError, type RoutingInput } from "../routing.js";
 import type { Destination } from "../config.js";
-import { saveConfig, loadConfig, EXTRACTION_HEALTH_PATH } from "../config.js";
+import { saveConfig, loadConfig, getEffectiveDestinations, EXTRACTION_HEALTH_PATH } from "../config.js";
 import {
   availableSearchScopes,
   resolveSearchScope,
@@ -77,6 +77,12 @@ import {
   combineRedactions,
   redactStorageText,
 } from "../privacy/redaction.js";
+import {
+  clearSessionDestinationOverride,
+  getSessionDestinationOverrideStatus,
+  setSessionDestinationOverride,
+  type SessionDestinationOverrideStatus,
+} from "../session-destination-override.js";
 
 // ---------------------------------------------------------------------------
 // Runtime state
@@ -157,6 +163,36 @@ function resolveDestOrError(input: RoutingInput): { dest: Destination; error?: n
       },
     };
   }
+}
+
+function destinationsForOverrideStatus(): Destination[] {
+  const activeDestinations = listDestinations();
+  if (activeDestinations.length > 0) return activeDestinations;
+  return getEffectiveDestinations(loadConfig());
+}
+
+function sessionDestinationStatusName(status: SessionDestinationOverrideStatus): string {
+  if (status.active) return "session_destination_active";
+  if (status.exists && !status.valid) return "session_destination_invalid";
+  return "session_destination_unset";
+}
+
+function destinationOverrideErrorResult(e: unknown): McpToolResult {
+  const msg = e instanceof Error ? e.message : String(e);
+  if (e instanceof DestinationNotFoundError) {
+    return {
+      content: [{ type: "text", text: JSON.stringify({
+        status: "destination_not_found",
+        message: msg,
+        available_destinations: e.available,
+      }, null, 2) }],
+      isError: true,
+    };
+  }
+  return {
+    content: [{ type: "text", text: JSON.stringify({ status: "error", message: msg }, null, 2) }],
+    isError: true,
+  };
 }
 
 type ScopedPoint = QdrantPoint & {
@@ -521,6 +557,7 @@ export function registerTools(mcp: McpServer): void {
       status["destinations"] = destStatus;
       status["default_search_scope"] = cfg.default_search_scope;
       status["search_scopes"] = availableSearchScopes(cfg, dests);
+      status["session_destination_override"] = getSessionDestinationOverrideStatus(destinationsForOverrideStatus());
       status["search_scope_hint"] =
         "Read/search tools accept search_scope: 'routed', 'all', a destination name, a configured scope name, a comma-separated destination list, or an array of destination names. Use destination only when you want an exact single-destination override.";
 
@@ -610,11 +647,79 @@ export function registerTools(mcp: McpServer): void {
       return {
         content: [{ type: "text", text: JSON.stringify({
           default_search_scope: cfg.default_search_scope,
+          session_destination_override: getSessionDestinationOverrideStatus(destinationsForOverrideStatus()),
           scopes: availableSearchScopes(cfg, dests),
           usage: {
             search_scope: "Pass one scope name, 'routed', 'all', a destination name, a comma-separated destination list, or an array of destination names.",
             destination: "Use this older parameter only for an exact single-destination override. Do not combine it with search_scope.",
           },
+        }, null, 2) }],
+      };
+    },
+  );
+
+  // ── Session destination override ─────────────────────────────────────────
+
+  mcp.tool(
+    "memory_set_session_destination",
+    [
+      "Persist a session-level write destination override.",
+      "Use this when all new memories from this local MCP/daemon session should go to one configured Qdrant destination until explicitly cleared.",
+      "Explicit per-call destination values still take precedence.",
+    ].join(" "),
+    {
+      destination: z.string().min(1).describe("Configured Qdrant destination name to use for new memory writes until cleared."),
+    },
+    async ({ destination }): Promise<McpToolResult> => {
+      try {
+        const status = setSessionDestinationOverride(destination, destinationsForOverrideStatus());
+        return {
+          content: [{ type: "text", text: JSON.stringify({
+            status: "session_destination_set",
+            session_destination_override: status,
+          }, null, 2) }],
+        };
+      } catch (e) {
+        return destinationOverrideErrorResult(e);
+      }
+    },
+  );
+
+  mcp.tool(
+    "memory_get_session_destination",
+    [
+      "Read the current session-level write destination override.",
+      "Use this to confirm whether new MCP writes and daemon captures are being forced to a configured Qdrant destination.",
+      "Read-only.",
+    ].join(" "),
+    {},
+    async (): Promise<McpToolResult> => {
+      const status = getSessionDestinationOverrideStatus(destinationsForOverrideStatus());
+      return {
+        content: [{ type: "text", text: JSON.stringify({
+          status: sessionDestinationStatusName(status),
+          session_destination_override: status,
+        }, null, 2) }],
+      };
+    },
+  );
+
+  mcp.tool(
+    "memory_clear_session_destination",
+    [
+      "Clear the persisted session-level write destination override.",
+      "After this, new memory writes return to explicit destination, routing rules, default destination, then first destination fallback.",
+    ].join(" "),
+    {},
+    async (): Promise<McpToolResult> => {
+      const cleared = clearSessionDestinationOverride();
+      const status = getSessionDestinationOverrideStatus(destinationsForOverrideStatus());
+      return {
+        content: [{ type: "text", text: JSON.stringify({
+          status: "session_destination_cleared",
+          cleared: cleared.cleared,
+          path: cleared.path,
+          session_destination_override: status,
         }, null, 2) }],
       };
     },

--- a/src/session-destination-override-e2e.test.ts
+++ b/src/session-destination-override-e2e.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const cliPath = fileURLToPath(new URL("./cli.js", import.meta.url));
+const testHome = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-session-destination-e2e-"));
+
+const stringEnv = (): Record<string, string> => Object.fromEntries(
+  Object.entries(process.env).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+);
+
+interface TextContent {
+  type: "text";
+  text: string;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isTextContent = (value: unknown): value is TextContent =>
+  isRecord(value) && value.type === "text" && typeof value.text === "string";
+
+const writeConfig = (): void => {
+  fs.mkdirSync(testHome, { recursive: true });
+  fs.writeFileSync(path.join(testHome, "config.json"), JSON.stringify({
+    qdrant_url: null,
+    qdrant_api_key: null,
+    collection: "bikky",
+    destinations: [
+      {
+        name: "perso",
+        qdrant_url: "http://127.0.0.1:9",
+        qdrant_api_key: "",
+        collection: "perso_collection",
+        match: { entity: ["[Bb]ikky"], content: ["[Bb]ikky"] },
+      },
+      {
+        name: "work",
+        qdrant_url: "http://127.0.0.1:9",
+        qdrant_api_key: "",
+        collection: "work_collection",
+        default: true,
+      },
+    ],
+    qdrant_client: {
+      timeout_ms: 25,
+      retries: 0,
+      retry_base_delay_ms: 1,
+    },
+    embedding: {
+      provider: "ollama",
+      model: "qwen-test",
+      dimensions: 3,
+      base_url: "http://127.0.0.1:9",
+      api_key: null,
+      timeout_ms: 25,
+      retries: 0,
+      retry_base_delay_ms: 1,
+    },
+  }, null, 2) + "\n", "utf-8");
+};
+
+const parseToolJson = (result: Awaited<ReturnType<Client["callTool"]>>): Record<string, unknown> => {
+  const content = isRecord(result) ? result.content : null;
+  assert.ok(Array.isArray(content), "expected tool result content array");
+  const text = content.find(isTextContent);
+  assert.ok(text, "expected text tool result");
+  return JSON.parse(text.text) as Record<string, unknown>;
+};
+
+describe("session destination override MCP e2e", () => {
+  before(() => {
+    writeConfig();
+  });
+
+  after(() => {
+    fs.rmSync(testHome, { recursive: true, force: true });
+  });
+
+  it("sets, reads, and clears the override through the real MCP stdio server", async () => {
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [cliPath, "mcp"],
+      cwd: path.dirname(path.dirname(cliPath)),
+      env: {
+        ...stringEnv(),
+        BIKKY_HOME: testHome,
+        CI: "1",
+        FORCE_COLOR: "0",
+      },
+      stderr: "pipe",
+    });
+    let stderr = "";
+    transport.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf-8");
+    });
+    const client = new Client({ name: "bikky-session-destination-e2e", version: "1.0.0" });
+
+    try {
+      await client.connect(transport);
+      const tools = await client.listTools();
+      const toolNames = new Set(tools.tools.map((tool) => tool.name));
+      assert.equal(toolNames.has("memory_set_session_destination"), true);
+      assert.equal(toolNames.has("memory_get_session_destination"), true);
+      assert.equal(toolNames.has("memory_clear_session_destination"), true);
+
+      const setBody = parseToolJson(await client.callTool({
+        name: "memory_set_session_destination",
+        arguments: { destination: "work" },
+      }));
+      assert.equal(setBody.status, "session_destination_set");
+      assert.equal((setBody.session_destination_override as Record<string, unknown>).destination, "work");
+
+      const getBody = parseToolJson(await client.callTool({
+        name: "memory_get_session_destination",
+        arguments: {},
+      }));
+      assert.equal(getBody.status, "session_destination_active");
+      assert.equal((getBody.session_destination_override as Record<string, unknown>).active, true);
+      assert.equal(fs.existsSync(path.join(testHome, "state", "session-destination-override.json")), true);
+
+      const clearBody = parseToolJson(await client.callTool({
+        name: "memory_clear_session_destination",
+        arguments: {},
+      }));
+      assert.equal(clearBody.status, "session_destination_cleared");
+      assert.equal((clearBody.session_destination_override as Record<string, unknown>).active, false);
+      assert.equal(fs.existsSync(path.join(testHome, "state", "session-destination-override.json")), false);
+    } catch (e) {
+      assert.fail(`${e instanceof Error ? e.message : String(e)}\nMCP stderr:\n${stderr}`);
+    } finally {
+      await client.close();
+    }
+  });
+});

--- a/src/session-destination-override.itest.ts
+++ b/src/session-destination-override.itest.ts
@@ -1,0 +1,184 @@
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const TEST_BIKKY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-session-destination-it-"));
+process.env.BIKKY_HOME = TEST_BIKKY_HOME;
+
+const { registerTools } = await import("./mcp/tools.js");
+const { CONFIG_DEFAULTS, resetConfig, saveConfig } = await import("./config.js");
+const {
+  initEmbedding,
+  rebuildPool,
+  setReady,
+  setSetupError,
+} = await import("./mcp/api.js");
+const {
+  init: initDaemonQdrant,
+  storeFact: daemonStoreFact,
+} = await import("./daemon/qdrant.js");
+const { clearSessionDestinationOverride } = await import("./session-destination-override.js");
+
+const realFetch = globalThis.fetch;
+
+type ToolHandler = (args?: Record<string, unknown>) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>;
+
+interface FetchCall {
+  destination: string | null;
+  url: string;
+  method: string;
+  body: Record<string, unknown> | null;
+}
+
+const collectTools = (): Map<string, ToolHandler> => {
+  const handlers = new Map<string, ToolHandler>();
+  registerTools({
+    tool(name: string, _description: string, _schema: unknown, handler: ToolHandler) {
+      handlers.set(name, handler);
+    },
+  } as unknown as McpServer);
+  return handlers;
+};
+
+const parseToolJson = (result: Awaited<ReturnType<ToolHandler>>): Record<string, unknown> =>
+  JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+
+const configureDestinations = (): void => {
+  saveConfig({
+    ...CONFIG_DEFAULTS,
+    embedding: {
+      ...CONFIG_DEFAULTS.embedding,
+      provider: "ollama",
+      base_url: "http://embed.test",
+      model: "qwen-test",
+      dimensions: 3,
+      timeout_ms: 100,
+      retries: 0,
+    },
+    qdrant_client: {
+      ...CONFIG_DEFAULTS.qdrant_client,
+      timeout_ms: 100,
+      retries: 0,
+    },
+    qdrant_url: null,
+    qdrant_api_key: null,
+    destinations: [
+      {
+        name: "perso",
+        qdrant_url: "https://perso.q.test",
+        qdrant_api_key: null,
+        collection: "perso_collection",
+        match: { content: ["[Bb]ikky"], entity: ["[Bb]ikky"] },
+      },
+      {
+        name: "work",
+        qdrant_url: "https://work.q.test",
+        qdrant_api_key: null,
+        collection: "work_collection",
+        default: true,
+      },
+    ],
+  });
+  resetConfig();
+  initEmbedding({
+    provider: "ollama",
+    baseUrl: "http://embed.test",
+    model: "qwen-test",
+    dimensions: 3,
+    timeoutMs: 100,
+    retries: 0,
+  });
+  rebuildPool();
+  setSetupError(null);
+  setReady(true);
+  initDaemonQdrant();
+};
+
+const installStorageMock = (): FetchCall[] => {
+  const calls: FetchCall[] = [];
+  const destinationForUrl = (url: string): string | null => {
+    if (url.startsWith("https://perso.q.test/")) return "perso";
+    if (url.startsWith("https://work.q.test/")) return "work";
+    return null;
+  };
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init: RequestInit = {}) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init.method ?? "GET").toUpperCase();
+    const body = init.body ? JSON.parse(String(init.body)) as Record<string, unknown> : null;
+    const destination = destinationForUrl(url);
+    calls.push({ destination, url, method, body });
+
+    if (url === "http://embed.test/v1/embeddings") {
+      return new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2, 0.3] }] }), { status: 200 });
+    }
+
+    if (url.endsWith("/points/scroll")) {
+      return new Response(JSON.stringify({ result: { points: [] } }), { status: 200 });
+    }
+
+    if (url.endsWith("/points/search")) {
+      return new Response(JSON.stringify({ result: [] }), { status: 200 });
+    }
+
+    if (method === "PUT" && url.endsWith("/points")) {
+      return new Response(JSON.stringify({ result: { status: "ok" } }), { status: 200 });
+    }
+
+    return new Response(JSON.stringify({ result: {} }), { status: 200 });
+  }) as typeof fetch;
+
+  return calls;
+};
+
+describe("session destination override integration", () => {
+  before(() => {
+    fs.mkdirSync(TEST_BIKKY_HOME, { recursive: true });
+  });
+
+  after(() => {
+    globalThis.fetch = realFetch;
+    fs.rmSync(TEST_BIKKY_HOME, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    fs.rmSync(TEST_BIKKY_HOME, { recursive: true, force: true });
+    fs.mkdirSync(TEST_BIKKY_HOME, { recursive: true });
+    globalThis.fetch = realFetch;
+    configureDestinations();
+    clearSessionDestinationOverride();
+  });
+
+  it("routes both MCP and daemon writes through the persisted session override", async () => {
+    const calls = installStorageMock();
+    const handlers = collectTools();
+
+    const setResult = await handlers.get("memory_set_session_destination")!({ destination: "work" });
+    assert.equal(parseToolJson(setResult).status, "session_destination_set");
+
+    const mcpResult = await handlers.get("memory_store")!({
+      content: "Bikky integration routing would match perso without the override.",
+      category: "engineering",
+      entities: ["bikky"],
+      domain: "software_engineering",
+      kind: "fact",
+      confidence: 0.9,
+    });
+    assert.equal(parseToolJson(mcpResult).destination, "work");
+
+    await daemonStoreFact({
+      content: "Bikky daemon integration routing would match perso without the override.",
+      category: "engineering",
+      entities: ["bikky"],
+      content_hash: "daemon-integration-hash",
+    });
+
+    const upserts = calls.filter((call) => call.method === "PUT" && call.url.endsWith("/points"));
+    assert.equal(upserts.length, 2);
+    assert.deepEqual(upserts.map((call) => call.destination), ["work", "work"]);
+    assert.equal(calls.some((call) => call.destination === "perso" && call.method !== "GET"), false);
+  });
+});

--- a/src/session-destination-override.test.ts
+++ b/src/session-destination-override.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_BIKKY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-session-destination-"));
+process.env.BIKKY_HOME = TEST_BIKKY_HOME;
+
+const {
+  applySessionDestinationOverride,
+  clearSessionDestinationOverride,
+  getSessionDestinationOverrideStatus,
+  setSessionDestinationOverride,
+} = await import("./session-destination-override.js");
+const { getSessionDestinationOverridePath } = await import("./config.js");
+const { DestinationNotFoundError } = await import("./routing.js");
+import type { Destination } from "./config.js";
+
+const destinations: Destination[] = [
+  {
+    name: "perso",
+    qdrant_url: "https://perso.q.test",
+    qdrant_api_key: null,
+    collection: "perso_memory",
+    match: { entity: ["[Bb]ikky"] },
+  },
+  {
+    name: "work",
+    qdrant_url: "https://work.q.test",
+    qdrant_api_key: null,
+    collection: "work_memory",
+    default: true,
+  },
+];
+
+describe("session destination override", () => {
+  before(() => {
+    fs.mkdirSync(TEST_BIKKY_HOME, { recursive: true });
+  });
+
+  after(() => {
+    fs.rmSync(TEST_BIKKY_HOME, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    fs.rmSync(path.join(TEST_BIKKY_HOME, "state"), { recursive: true, force: true });
+  });
+
+  it("persists, reads, and clears an override", () => {
+    const setStatus = setSessionDestinationOverride("work", destinations, new Date("2026-01-01T00:00:00.000Z"));
+
+    assert.equal(setStatus.active, true);
+    assert.equal(setStatus.destination, "work");
+    assert.equal(setStatus.set_at, "2026-01-01T00:00:00.000Z");
+    assert.equal(fs.existsSync(getSessionDestinationOverridePath()), true);
+
+    const readStatus = getSessionDestinationOverrideStatus(destinations);
+    assert.equal(readStatus.active, true);
+    assert.equal(readStatus.destination, "work");
+
+    const cleared = clearSessionDestinationOverride();
+    assert.equal(cleared.cleared, true);
+    assert.equal(getSessionDestinationOverrideStatus(destinations).active, false);
+  });
+
+  it("applies the override unless a caller supplied an explicit destination", () => {
+    setSessionDestinationOverride("work", destinations);
+
+    assert.deepEqual(
+      applySessionDestinationOverride({ content: "Bikky should normally route to perso.", entities: ["bikky"] }, destinations),
+      { content: "Bikky should normally route to perso.", entities: ["bikky"], destination: "work" },
+    );
+    assert.deepEqual(
+      applySessionDestinationOverride({ destination: "perso", content: "Bikky", entities: ["bikky"] }, destinations),
+      { destination: "perso", content: "Bikky", entities: ["bikky"] },
+    );
+  });
+
+  it("reports and ignores stale override destinations", () => {
+    setSessionDestinationOverride("work", destinations);
+
+    const status = getSessionDestinationOverrideStatus([destinations[0]!]);
+    assert.equal(status.exists, true);
+    assert.equal(status.active, false);
+    assert.equal(status.valid, false);
+    assert.equal(status.destination, "work");
+    assert.match(status.error ?? "", /unknown destination 'work'/);
+    assert.deepEqual(
+      applySessionDestinationOverride({ content: "Bikky", entities: ["bikky"] }, [destinations[0]!]),
+      { content: "Bikky", entities: ["bikky"] },
+    );
+  });
+
+  it("rejects unknown destination names when setting", () => {
+    assert.throws(
+      () => setSessionDestinationOverride("ghost", destinations),
+      DestinationNotFoundError,
+    );
+  });
+});

--- a/src/session-destination-override.ts
+++ b/src/session-destination-override.ts
@@ -1,0 +1,157 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+
+import {
+  getSessionDestinationOverridePath,
+  getStateDir,
+  type Destination,
+} from "./config.js";
+import { DestinationNotFoundError, type RoutingInput } from "./routing.js";
+
+export interface SessionDestinationOverride {
+  version: 1;
+  destination: string;
+  set_at: string;
+}
+
+export interface SessionDestinationOverrideStatus {
+  path: string;
+  exists: boolean;
+  active: boolean;
+  valid: boolean;
+  destination: string | null;
+  set_at: string | null;
+  error: string | null;
+  available_destinations: string[];
+}
+
+interface ResolvedSessionDestinationOverride {
+  status: SessionDestinationOverrideStatus;
+  destination: Destination | null;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const hasExplicitDestination = (input: RoutingInput): boolean =>
+  typeof input.destination === "string" && input.destination.trim() !== "";
+
+function availableNames(destinations: ReadonlyArray<Destination>): string[] {
+  return destinations.map((destination) => destination.name);
+}
+
+function baseStatus(destinations: ReadonlyArray<Destination>): SessionDestinationOverrideStatus {
+  return {
+    path: getSessionDestinationOverridePath(),
+    exists: false,
+    active: false,
+    valid: true,
+    destination: null,
+    set_at: null,
+    error: null,
+    available_destinations: availableNames(destinations),
+  };
+}
+
+function parseOverride(raw: unknown): { override: SessionDestinationOverride | null; error: string | null } {
+  if (!isRecord(raw)) {
+    return { override: null, error: "session destination override file must contain an object" };
+  }
+  if (raw.version !== 1) {
+    return { override: null, error: "unsupported session destination override version" };
+  }
+  if (typeof raw.destination !== "string" || raw.destination.trim() === "") {
+    return { override: null, error: "session destination override destination must be a non-empty string" };
+  }
+  if (typeof raw.set_at !== "string" || raw.set_at.trim() === "") {
+    return { override: null, error: "session destination override set_at must be a non-empty string" };
+  }
+  return {
+    override: {
+      version: 1,
+      destination: raw.destination.trim(),
+      set_at: raw.set_at,
+    },
+    error: null,
+  };
+}
+
+export function getSessionDestinationOverrideStatus(
+  destinations: ReadonlyArray<Destination>,
+): SessionDestinationOverrideStatus {
+  return resolveSessionDestinationOverride(destinations).status;
+}
+
+export function resolveSessionDestinationOverride(
+  destinations: ReadonlyArray<Destination>,
+): ResolvedSessionDestinationOverride {
+  const status = baseStatus(destinations);
+  if (!existsSync(status.path)) return { status, destination: null };
+
+  status.exists = true;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(status.path, "utf-8")) as unknown;
+  } catch (e) {
+    status.valid = false;
+    status.error = `failed to read session destination override: ${e instanceof Error ? e.message : String(e)}`;
+    return { status, destination: null };
+  }
+
+  const { override, error } = parseOverride(parsed);
+  if (error || !override) {
+    status.valid = false;
+    status.error = error ?? "invalid session destination override";
+    return { status, destination: null };
+  }
+
+  status.destination = override.destination;
+  status.set_at = override.set_at;
+
+  const destination = destinations.find((candidate) => candidate.name === override.destination);
+  if (!destination) {
+    status.valid = false;
+    status.error = `unknown destination '${override.destination}'`;
+    return { status, destination: null };
+  }
+
+  status.active = true;
+  return { status, destination };
+}
+
+export function applySessionDestinationOverride(
+  input: RoutingInput,
+  destinations: ReadonlyArray<Destination>,
+): RoutingInput {
+  if (hasExplicitDestination(input)) return input;
+  const resolved = resolveSessionDestinationOverride(destinations);
+  if (!resolved.destination) return input;
+  return { ...input, destination: resolved.destination.name };
+}
+
+export function setSessionDestinationOverride(
+  destinationName: string,
+  destinations: ReadonlyArray<Destination>,
+  now = new Date(),
+): SessionDestinationOverrideStatus {
+  const wanted = destinationName.trim();
+  const destination = destinations.find((candidate) => candidate.name === wanted);
+  if (!destination) {
+    throw new DestinationNotFoundError(wanted, availableNames(destinations));
+  }
+
+  mkdirSync(getStateDir(), { recursive: true });
+  const override: SessionDestinationOverride = {
+    version: 1,
+    destination: destination.name,
+    set_at: now.toISOString(),
+  };
+  writeFileSync(getSessionDestinationOverridePath(), JSON.stringify(override, null, 2) + "\n", "utf-8");
+  return getSessionDestinationOverrideStatus(destinations);
+}
+
+export function clearSessionDestinationOverride(): { path: string; cleared: boolean } {
+  const path = getSessionDestinationOverridePath();
+  if (!existsSync(path)) return { path, cleared: false };
+  rmSync(path, { force: true });
+  return { path, cleared: true };
+}


### PR DESCRIPTION
## Summary
- add a file-backed session destination override under Bikky state
- add MCP tools to set, inspect, and clear the override
- apply the override to MCP writes and daemon write/dedup routing while preserving explicit destination precedence
- surface override status in setup/search-scope tools and document the workflow

Closes #143.

## Validation
- npm run typecheck
- npm test -- --test-name-pattern="session destination override|mcp/tools|daemon/qdrant"
- node --test --test-concurrency=1 dist/session-destination-override.test.js dist/mcp/tools.test.js dist/daemon/qdrant.test.js
- npm run check
- npm run verify:package
