### PR TITLE
fix: route writes using full memory context

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -282,7 +282,7 @@ Most users only need one Qdrant destination. Use `destinations[]` when you want 
 
 Each destination has its own Qdrant credentials and collection. Add `description` when you have more than one destination; MCP tools expose those descriptions so LLM clients can pick the right search scope.
 
-Writes still target one destination. A destination can include a `match` block with JavaScript `RegExp` strings for `cwd`, `entity`, `content`, or `metadata`. Destinations are evaluated in array order; the first destination with any matching pattern wins. If no pattern matches, bikky uses the destination marked `default: true`, or the first destination.
+Writes still target one destination. A destination can include a `match` block with JavaScript `RegExp` strings for `cwd`, `entity`, `content`, or `metadata`. For memory writes, `content` matching uses a flattened routing view of the full memory context: stored content, entities, repo, branch, task/workstream keys, metadata, origin, relation fields, and other stored payload fields. Destinations are evaluated in array order; the first destination with any matching pattern wins. If no pattern matches, bikky uses the destination marked `default: true`, or the first destination.
 
 Read tools (`memory_recall`, `memory_entity`, and `memory_relations`) can search one destination, the routed destination, or multiple destinations. Configure `default_search_scope` to control the default read behavior:
 
@@ -351,6 +351,7 @@ MCP clients can override this per call with `search_scope`. The value accepts `"
 Matching details:
 
 - `match.cwd`, `match.entity`, and `match.content` are lists of JavaScript `RegExp` strings.
+- On memory writes, `match.content` sees the full flattened memory context, so a pattern can match values such as `repo`, `branch`, `task_key`, origin fields, metadata values, or relation endpoints even when the visible memory text does not contain that term.
 - `match.metadata` maps metadata keys to lists of JavaScript `RegExp` strings matched against that key's value.
 - Matching uses OR logic across fields and within each list; any matching pattern selects the destination.
 - Put the most specific destinations first because first match wins.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1737,6 +1737,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -1941,6 +1942,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2279,6 +2281,7 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2484,6 +2487,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2523,12 +2527,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -2561,9 +2565,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -2816,10 +2820,11 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2887,9 +2892,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3267,6 +3272,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3749,6 +3755,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3865,6 +3872,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.1.tgz",
       "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/daemon/qdrant.test.ts
+++ b/src/daemon/qdrant.test.ts
@@ -397,6 +397,73 @@ describe("daemon/qdrant", () => {
       assert.ok(upsertUrls[1]?.startsWith("https://work-qdrant.example.com:6333/collections/work-memory/points"));
     });
 
+    it("routes stored facts using repo and metadata from the full memory context", async () => {
+      const upsertUrls: string[] = [];
+
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const body = init?.body ? JSON.parse(String(init.body)) : null;
+        if (url.includes("/v1/embeddings")) {
+          return new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2, 0.3] }] }), { status: 200 });
+        }
+        if (init?.method === "PUT" && url.includes("/collections/")) {
+          assert.ok(body?.points, "expected Qdrant upsert points");
+          upsertUrls.push(url);
+        }
+        return new Response(JSON.stringify({ result: {} }), { status: 200 });
+      }) as typeof fetch;
+
+      saveConfig({
+        ...CONFIG_DEFAULTS,
+        qdrant_url: null,
+        qdrant_api_key: null,
+        embedding: {
+          ...CONFIG_DEFAULTS.embedding,
+          provider: "ollama",
+          model: "test-model",
+          base_url: "http://embed.test:11434",
+          dimensions: 3,
+        },
+        destinations: [
+          {
+            name: "perso",
+            qdrant_url: "https://perso-qdrant.example.com:6333",
+            qdrant_api_key: null,
+            collection: "perso-memory",
+            match: {
+              content: ["[Bb]ikky"],
+              entity: ["[Bb]ikky"],
+            },
+          },
+          {
+            name: "work",
+            qdrant_url: "https://work-qdrant.example.com:6333",
+            qdrant_api_key: null,
+            collection: "work-memory",
+            default: true,
+          },
+        ],
+      });
+      resetConfig();
+      init();
+
+      await storeFact({
+        content: "Dashboard quality signals should stay visible.",
+        category: "product",
+        entities: ["dashboard", "memory quality", "signals"],
+        repo: "bikky-dev/bikky",
+        metadata: { source_surface: "dashboard" },
+        content_hash: "repo-only-bikky-hash",
+      }, {
+        content: "daemon supplied routing context",
+        entities: ["dashboard"],
+        metadata: { source_surface: "daemon" },
+      });
+
+      assert.equal(upsertUrls.length, 1);
+      assert.ok(upsertUrls[0]?.startsWith("https://perso-qdrant.example.com:6333/collections/perso-memory/points"));
+    });
+
     it("keeps dedup follow-up mutations in the matched destination", async () => {
       const mutationUrls: string[] = [];
 

--- a/src/daemon/qdrant.ts
+++ b/src/daemon/qdrant.ts
@@ -252,10 +252,8 @@ const routingInputForFact = (
   normalizedContent: string,
   normalizedEntities: string[],
   extraMetadata: Record<string, unknown> = {},
-): RoutingInput => ({
-  content: normalizedContent,
-  entities: normalizedEntities,
-  metadata: {
+): RoutingInput => {
+  const metadata = {
     ...(fact.metadata ?? {}),
     ...extraMetadata,
     category: fact.category,
@@ -271,8 +269,76 @@ const routingInputForFact = (
     ...(fact.repo ? { repo: fact.repo } : {}),
     ...(fact.branch ? { branch: fact.branch } : {}),
     ...(fact.surface ? { surface: fact.surface } : {}),
-  },
-});
+    ...(fact.issue_id ? { issue_id: fact.issue_id } : {}),
+    ...(fact.pr_id ? { pr_id: fact.pr_id } : {}),
+    ...(fact.source_event_ids ? { source_event_ids: fact.source_event_ids } : {}),
+    ...(fact.source_fact_ids ? { source_fact_ids: fact.source_fact_ids } : {}),
+    ...(fact.source_episode_ids ? { source_episode_ids: fact.source_episode_ids } : {}),
+    ...(fact.prompt_version ? { prompt_version: fact.prompt_version } : {}),
+    ...(fact.capture_policy_version ? { capture_policy_version: fact.capture_policy_version } : {}),
+    ...(fact.review_status ? { review_status: fact.review_status } : {}),
+    ...(fact.volatility ? { volatility: fact.volatility } : {}),
+    ...(fact.valid_from ? { valid_from: fact.valid_from } : {}),
+    ...(fact.expires_at ? { expires_at: fact.expires_at } : {}),
+    ...(fact.confidence_reason ? { confidence_reason: fact.confidence_reason } : {}),
+    ...(fact.relation ? {
+      from_entity: fact.relation.from,
+      relation_type: fact.relation.type,
+      to_entity: fact.relation.to,
+    } : {}),
+  };
+  return {
+    content: routingText([
+      normalizedContent,
+      normalizedEntities,
+      metadata,
+      fact.origin,
+      fact.last_operation_origin,
+      fact.relation,
+    ]),
+    entities: normalizedEntities,
+    metadata,
+  };
+};
+
+const appendRoutingText = (parts: string[], value: unknown): void => {
+  if (value === null || value === undefined) return;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    const text = String(value).trim();
+    if (text) parts.push(text);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) appendRoutingText(parts, item);
+    return;
+  }
+  if (typeof value === "object") {
+    for (const [key, nested] of Object.entries(value)) {
+      appendRoutingText(parts, key);
+      appendRoutingText(parts, nested);
+    }
+  }
+};
+
+const routingText = (values: unknown[]): string => {
+  const parts: string[] = [];
+  for (const value of values) appendRoutingText(parts, value);
+  return Array.from(new Set(parts)).join("\n");
+};
+
+const mergeRoutingInputs = (base: RoutingInput, override?: RoutingInput): RoutingInput => {
+  if (!override) return base;
+  return {
+    destination: override.destination ?? base.destination,
+    cwd: override.cwd ?? base.cwd,
+    content: routingText([base.content, override.content]),
+    entities: Array.from(new Set([...(base.entities ?? []), ...(override.entities ?? [])])),
+    metadata: {
+      ...(base.metadata ?? {}),
+      ...(override.metadata ?? {}),
+    },
+  };
+};
 
 // ---------------------------------------------------------------------------
 // Init — reads credentials from loadConfig()
@@ -620,7 +686,7 @@ const storeFact = async (fact: StoreFact, routeInput?: RoutingInput): Promise<st
     payload.redaction = redaction;
   }
 
-  const destination = resolveDestination(routeInput ?? routingInputForFact(
+  const destination = resolveDestination(mergeRoutingInputs(routingInputForFact(
     fact,
     redactedContent.text,
     payload.entities,
@@ -630,7 +696,7 @@ const storeFact = async (fact: StoreFact, routeInput?: RoutingInput): Promise<st
       kind: normalizedKind,
       ...(normalizedSubtype ? { memory_subtype: normalizedSubtype } : {}),
     },
-  ));
+  ), routeInput));
   const vector = await embed(redactedContent.text);
 
   await qdrantRequest("PUT", `/collections/${destination.collection}/points`, {


### PR DESCRIPTION
## Summary
- route daemon memory writes using a flattened full memory context
- merge caller-provided route input with fact-derived routing input instead of replacing it
- document full-context routing and add a regression test for repo-only Bikky routing

## Validation
- npm run typecheck
- npm run check
- rm -rf dist && npm test
- npm run verify:package