### PR TITLE
Fix MCP full-context memory routing

### DIFF
--- a/src/daemon/qdrant.ts
+++ b/src/daemon/qdrant.ts
@@ -32,6 +32,7 @@ import {
   type RedactionSummary,
 } from "../privacy/redaction.js";
 import { buildOperationOrigin, type OperationOrigin } from "../provenance/origin.js";
+import { buildMemoryRoutingInput, mergeRoutingInputs } from "../routing-context.js";
 
 // ---------------------------------------------------------------------------
 // Types (local)
@@ -287,57 +288,12 @@ const routingInputForFact = (
       to_entity: fact.relation.to,
     } : {}),
   };
-  return {
-    content: routingText([
-      normalizedContent,
-      normalizedEntities,
-      metadata,
-      fact.origin,
-      fact.last_operation_origin,
-      fact.relation,
-    ]),
+  return buildMemoryRoutingInput({
+    content: normalizedContent,
     entities: normalizedEntities,
     metadata,
-  };
-};
-
-const appendRoutingText = (parts: string[], value: unknown): void => {
-  if (value === null || value === undefined) return;
-  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
-    const text = String(value).trim();
-    if (text) parts.push(text);
-    return;
-  }
-  if (Array.isArray(value)) {
-    for (const item of value) appendRoutingText(parts, item);
-    return;
-  }
-  if (typeof value === "object") {
-    for (const [key, nested] of Object.entries(value)) {
-      appendRoutingText(parts, key);
-      appendRoutingText(parts, nested);
-    }
-  }
-};
-
-const routingText = (values: unknown[]): string => {
-  const parts: string[] = [];
-  for (const value of values) appendRoutingText(parts, value);
-  return Array.from(new Set(parts)).join("\n");
-};
-
-const mergeRoutingInputs = (base: RoutingInput, override?: RoutingInput): RoutingInput => {
-  if (!override) return base;
-  return {
-    destination: override.destination ?? base.destination,
-    cwd: override.cwd ?? base.cwd,
-    content: routingText([base.content, override.content]),
-    entities: Array.from(new Set([...(base.entities ?? []), ...(override.entities ?? [])])),
-    metadata: {
-      ...(base.metadata ?? {}),
-      ...(override.metadata ?? {}),
-    },
-  };
+    extraContent: [fact.origin, fact.last_operation_origin, fact.relation],
+  });
 };
 
 // ---------------------------------------------------------------------------

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { DestinationMatch } from "../config.js";
 
 const TEST_BIKKY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-mcp-tools-"));
 process.env.BIKKY_HOME = TEST_BIKKY_HOME;
@@ -82,6 +83,58 @@ function configureDestinations(): void {
         qdrant_url: "https://work.q.test",
         qdrant_api_key: "work-key",
         collection: "work_collection",
+      },
+    ],
+    default_search_scope: "all",
+    search_scopes: [
+      { name: "personal-only", destinations: ["perso"], description: "Only personal memories" },
+    ],
+  });
+  resetConfig();
+  initEmbedding({
+    provider: "ollama",
+    baseUrl: "http://embed.test",
+    model: "qwen-test",
+    dimensions: 3,
+    timeoutMs: 100,
+    retries: 0,
+  });
+  rebuildPool();
+}
+
+function configureWorkDefaultDestinations(persoMatch: DestinationMatch): void {
+  saveConfig({
+    ...CONFIG_DEFAULTS,
+    embedding: {
+      ...CONFIG_DEFAULTS.embedding,
+      provider: "ollama",
+      base_url: "http://embed.test",
+      model: "qwen-test",
+      dimensions: 3,
+      timeout_ms: 100,
+      retries: 0,
+    },
+    qdrant_client: {
+      ...CONFIG_DEFAULTS.qdrant_client,
+      timeout_ms: 100,
+      retries: 0,
+    },
+    destinations: [
+      {
+        name: "perso",
+        description: "Personal memories",
+        qdrant_url: "https://perso.q.test",
+        qdrant_api_key: "perso-key",
+        collection: "perso_collection",
+        match: persoMatch,
+      },
+      {
+        name: "work",
+        description: "Work memories",
+        qdrant_url: "https://work.q.test",
+        qdrant_api_key: "work-key",
+        collection: "work_collection",
+        default: true,
       },
     ],
     default_search_scope: "all",
@@ -302,6 +355,87 @@ describe("mcp/tools", () => {
     assert.match(String(points[0]!.payload.content), /\[REDACTED:secret\]/);
     assert.deepEqual(points[0]!.payload.entities, ["bikky"]);
     assert.equal((points[0]!.payload.redaction as Record<string, unknown>).redacted, true);
+  });
+
+  it("routes memory_store by repo from the full memory context", async () => {
+    configureWorkDefaultDestinations({ metadata: { repo: ["^bikky-dev/bikky$"] } });
+    const calls = installStorageMock();
+    const handlers = collectTools();
+
+    const result = await handlers.get("memory_store")!({
+      content: "Dashboard quality signals should stay visible.",
+      category: "product",
+      entities: ["dashboard", "memory quality", "signals"],
+      domain: "software_engineering",
+      kind: "fact",
+      repo: "bikky-dev/bikky",
+      metadata: { source_surface: "dashboard" },
+      confidence: 0.9,
+    });
+
+    const body = parseToolJson(result);
+    assert.equal(body.action, "inserted");
+    assert.equal(body.destination, "perso");
+
+    const scroll = calls.find((call) => call.method === "POST" && call.url.endsWith("/points/scroll"));
+    assert.ok(scroll);
+    assert.equal(scroll.destination, "perso");
+
+    const upsert = calls.find((call) => call.method === "PUT" && call.url.endsWith("/points"));
+    assert.ok(upsert);
+    assert.equal(upsert.destination, "perso");
+    const points = upsert.body?.points as Array<{ payload: Record<string, unknown> }>;
+    assert.equal(points[0]!.payload.repo, "bikky-dev/bikky");
+  });
+
+  it("honors an explicit memory_store destination over full-context matches", async () => {
+    configureWorkDefaultDestinations({ metadata: { repo: ["^bikky-dev/bikky$"] } });
+    const calls = installStorageMock();
+    const handlers = collectTools();
+
+    const result = await handlers.get("memory_store")!({
+      content: "Dashboard quality signals should stay visible.",
+      category: "product",
+      entities: ["dashboard", "memory quality", "signals"],
+      domain: "software_engineering",
+      kind: "fact",
+      repo: "bikky-dev/bikky",
+      destination: "work",
+      confidence: 0.9,
+    });
+
+    const body = parseToolJson(result);
+    assert.equal(body.action, "inserted");
+    assert.equal(body.destination, "work");
+
+    const upsert = calls.find((call) => call.method === "PUT" && call.url.endsWith("/points"));
+    assert.ok(upsert);
+    assert.equal(upsert.destination, "work");
+  });
+
+  it("routes summary and distilled writes by repo from the full memory context", async () => {
+    configureWorkDefaultDestinations({ metadata: { repo: ["^bikky-dev/bikky$"] } });
+    const calls = installStorageMock();
+    const handlers = collectTools();
+
+    const summary = await handlers.get("memory_session_summary")!({
+      content: "Quality score routing was repaired and still needs release validation.",
+      entities: ["quality scores", "routing"],
+      repo: "bikky-dev/bikky",
+    });
+    const distilled = await handlers.get("memory_distill")!({
+      content: "Repository-scoped routing should use the full memory context before falling back to defaults.",
+      entities: ["routing", "repositories"],
+      repo: "bikky-dev/bikky",
+    });
+
+    const summaryBody = parseToolJson(summary);
+    const distilledBody = parseToolJson(distilled);
+    assert.equal(summaryBody.destination, "perso");
+    assert.equal(distilledBody.destination, "perso");
+
+    const upserts = calls.filter((call) => call.method === "PUT" && call.url.endsWith("/points"));
+    assert.deepEqual(upserts.map((call) => call.destination), ["perso", "perso"]);
   });
 
   it("reinforces exact memory_store matches without embedding", async () => {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -77,6 +77,7 @@ import {
   combineRedactions,
   redactStorageText,
 } from "../privacy/redaction.js";
+import { buildMemoryRoutingInput } from "../routing-context.js";
 
 // ---------------------------------------------------------------------------
 // Runtime state
@@ -120,7 +121,7 @@ function routingInput(args: {
   destination?: string;
   content?: string;
   entities?: string[];
-  metadata?: Record<string, string>;
+  metadata?: Record<string, unknown>;
 }): RoutingInput {
   return {
     destination: args.destination,
@@ -129,6 +130,46 @@ function routingInput(args: {
     entities: args.entities,
     metadata: args.metadata,
   };
+}
+
+function compactMetadata(values: Record<string, unknown>): Record<string, unknown> {
+  const metadata: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (value === undefined || value === null) continue;
+    metadata[key] = value;
+  }
+  return metadata;
+}
+
+function memoryWriteRoutingInput(args: {
+  tool: string;
+  destination?: string;
+  content: string;
+  entities: string[];
+  metadata?: Record<string, unknown>;
+  context?: Record<string, unknown>;
+  relation?: { from: string; type: string; to: string } | null;
+}): RoutingInput {
+  const relationMetadata = args.relation ? {
+    from_entity: args.relation.from,
+    relation_type: args.relation.type,
+    to_entity: args.relation.to,
+  } : {};
+  return buildMemoryRoutingInput({
+    destination: args.destination,
+    cwd: process.cwd(),
+    content: args.content,
+    entities: args.entities,
+    metadata: args.metadata,
+    context: compactMetadata({
+      origin_interface: "mcp",
+      origin_action: "create",
+      origin_tool: args.tool,
+      ...(args.context ?? {}),
+      ...relationMetadata,
+    }),
+    extraContent: args.relation ? [args.relation] : [],
+  });
 }
 
 // Resolve a destination from a routing input, returning either the destination
@@ -829,14 +870,6 @@ export function registerTools(mcp: McpServer): void {
       if (guard) return guard;
       lastStoreTime = Date.now();
       const now = nowISO();
-      const resolved = resolveDestOrError(routingInput({
-        destination,
-        content,
-        entities,
-        metadata,
-      }));
-      if (resolved.error) return resolved.error;
-      const dest = resolved.dest;
       const normalizedKind = normalizeKind(kind);
       let normalizedSubtype: string | null = null;
       try {
@@ -878,6 +911,30 @@ export function registerTools(mcp: McpServer): void {
         type: redactedRelation.type.text,
         to: redactedRelation.to.text,
       } : null;
+      const resolved = resolveDestOrError(memoryWriteRoutingInput({
+        tool: "memory_store",
+        destination,
+        content: redactedContent.text,
+        entities: normalizedEntities,
+        metadata,
+        relation: sanitizedRelation,
+        context: {
+          category: normalizedCategory,
+          domain: normalizedDomain,
+          kind: normalizedKind,
+          memory_subtype: normalizedSubtype,
+          layer: normalizedLayer,
+          episode_id,
+          workstream_key,
+          task_key,
+          repo,
+          branch,
+          review_status,
+          supersedes,
+        },
+      }));
+      if (resolved.error) return resolved.error;
+      const dest = resolved.dest;
       const createOrigin = mcpOrigin({
         action: "create",
         tool: "memory_store",
@@ -1942,16 +1999,28 @@ export function registerTools(mcp: McpServer): void {
       lastStoreTime = Date.now();
       const now = nowISO();
       try {
-        const resolved = resolveDestOrError(routingInput({
+        const normalizedEntities = (entities ?? []).map((e) => e.trim().toLowerCase()).filter(Boolean);
+        const redactedContent = redactStorageText(content);
+        const resolved = resolveDestOrError(memoryWriteRoutingInput({
+          tool: "memory_session_summary",
           destination,
-          content,
-          entities: entities ?? [],
+          content: redactedContent.text,
+          entities: normalizedEntities,
+          context: {
+            category: categoryForMemorySubtype("session_index") ?? "system",
+            domain: "software_engineering",
+            kind: "summary",
+            memory_subtype: "session_index",
+            layer: layerForMemorySubtype("session_index") ?? "episode",
+            episode_id,
+            workstream_key,
+            task_key,
+            repo,
+          },
         }));
         if (resolved.error) return resolved.error;
         const dest = resolved.dest;
-        const normalizedEntities = (entities ?? []).map((e) => e.trim().toLowerCase()).filter(Boolean);
         const summaryId = newId();
-        const redactedContent = redactStorageText(content);
         const vector = await embed(redactedContent.text);
         const origin = mcpOrigin({
           action: "create",
@@ -2034,16 +2103,27 @@ export function registerTools(mcp: McpServer): void {
       lastStoreTime = Date.now();
       const now = nowISO();
       try {
-        const resolved = resolveDestOrError(routingInput({
+        const normalizedEntities = entities.map((e) => e.trim().toLowerCase()).filter(Boolean);
+        const redactedContent = redactStorageText(content);
+        const resolved = resolveDestOrError(memoryWriteRoutingInput({
+          tool: "memory_distill",
           destination,
-          content,
-          entities,
+          content: redactedContent.text,
+          entities: normalizedEntities,
+          context: {
+            category: categoryForMemorySubtype("convention") ?? "engineering",
+            domain: "software_engineering",
+            kind: "distilled",
+            memory_subtype: "convention",
+            layer: layerForMemorySubtype("convention") ?? "domain",
+            task_key,
+            repo,
+            supersedes,
+          },
         }));
         if (resolved.error) return resolved.error;
         const dest = resolved.dest;
-        const normalizedEntities = entities.map((e) => e.trim().toLowerCase()).filter(Boolean);
         const distilledId = newId();
-        const redactedContent = redactStorageText(content);
         const vector = await embed(redactedContent.text);
         const origin = mcpOrigin({
           action: "create",

--- a/src/routing-context.ts
+++ b/src/routing-context.ts
@@ -1,0 +1,66 @@
+import type { RoutingInput } from "./routing.js";
+
+type RoutingMetadata = Record<string, unknown>;
+
+export interface MemoryRoutingInput {
+  destination?: string | null;
+  cwd?: string;
+  content?: string | null;
+  entities?: ReadonlyArray<string>;
+  metadata?: RoutingMetadata | null;
+  context?: RoutingMetadata | null;
+  extraContent?: ReadonlyArray<unknown>;
+}
+
+const appendRoutingText = (parts: string[], value: unknown): void => {
+  if (value === null || value === undefined) return;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    const text = String(value).trim();
+    if (text) parts.push(text);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) appendRoutingText(parts, item);
+    return;
+  }
+  if (typeof value === "object") {
+    for (const [key, nested] of Object.entries(value)) {
+      appendRoutingText(parts, key);
+      appendRoutingText(parts, nested);
+    }
+  }
+};
+
+export const routingText = (values: ReadonlyArray<unknown>): string => {
+  const parts: string[] = [];
+  for (const value of values) appendRoutingText(parts, value);
+  return Array.from(new Set(parts)).join("\n");
+};
+
+export const buildMemoryRoutingInput = (input: MemoryRoutingInput): RoutingInput => {
+  const metadata = {
+    ...(input.metadata ?? {}),
+    ...(input.context ?? {}),
+  };
+  return {
+    destination: input.destination,
+    cwd: input.cwd,
+    content: routingText([input.content, input.entities, metadata, ...(input.extraContent ?? [])]),
+    entities: input.entities,
+    metadata,
+  };
+};
+
+export const mergeRoutingInputs = (base: RoutingInput, override?: RoutingInput): RoutingInput => {
+  if (!override) return base;
+  return {
+    destination: override.destination ?? base.destination,
+    cwd: override.cwd ?? base.cwd,
+    content: routingText([base.content, override.content]),
+    entities: Array.from(new Set([...(base.entities ?? []), ...(override.entities ?? [])])),
+    metadata: {
+      ...(base.metadata ?? {}),
+      ...(override.metadata ?? {}),
+    },
+  };
+};


### PR DESCRIPTION
## Summary
- share the flattened full-memory routing input builder between daemon and MCP code
- route MCP writes with repo, branch, task/workstream keys, subtype, relation fields, metadata, and origin context before default fallback
- cover repo-only routing for memory_store, summaries, distillations, and explicit destination overrides

Closes #148

## Validation
- npm run typecheck
- npm run check
- rm -rf dist && npm test
- npm run verify:package