### PR TITLE
fix: filter memory dashboard internals

### DIFF
--- a/packages/ui/app/src/components/FactCard.test.ts
+++ b/packages/ui/app/src/components/FactCard.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  memoryLastOperationLabel,
+  memoryLastOperationUserName,
+  memoryOriginAgentLabel,
+  memoryOriginLabel,
+  memoryUserName,
+  type Fact,
+} from "./FactCard";
+
+const baseFact: Fact = {
+  id: "fact-1",
+  content: "Remember this",
+  category: "engineering",
+  entities: [],
+  confidence: 0.9,
+  created_at: "2026-01-01T00:00:00.000Z",
+};
+
+describe("FactCard provenance labels", () => {
+  it("uses origin user.name as the visible memory user", () => {
+    const fact: Fact = {
+      ...baseFact,
+      origin: {
+        user: { name: "Saber", id: "git-saber", type: "user" },
+        agent: { name: "Bikky daemon", id: "daemon:local", type: "daemon" },
+        interface: "daemon",
+        operation: { action: "create", subsystem: "extraction" },
+      },
+    };
+
+    expect(memoryUserName(fact)).toBe("Saber");
+    expect(memoryOriginAgentLabel(fact)).toBe("Bikky daemon");
+    expect(memoryOriginLabel(fact)).toBe("daemon/extraction/create");
+  });
+
+  it("falls back to legacy metadata actor labels and last-operation labels", () => {
+    const fact: Fact = {
+      ...baseFact,
+      metadata: { actor_label: "Legacy Actor" },
+      last_operation_origin: {
+        user: { name: "Updater", id: "user:updater", type: "user" },
+        agent: { name: "Bikky UI", id: "ui:local", type: "ui" },
+        interface: "ui",
+        operation: { action: "update", route: "PUT /api/memory/facts/:id" },
+      },
+    };
+
+    expect(memoryUserName(fact)).toBe("Legacy Actor");
+    expect(memoryLastOperationUserName(fact)).toBe("Updater");
+    expect(memoryLastOperationLabel(fact)).toBe("ui/update");
+  });
+});

--- a/packages/ui/app/src/components/FactCard.tsx
+++ b/packages/ui/app/src/components/FactCard.tsx
@@ -7,15 +7,19 @@ export interface Fact {
   id: string;
   content: string;
   category: string;
+  user_name?: string;
   domain?: string;
   kind?: string;
   memory_subtype?: string | null;
   actor_id?: string;
   entities: string[];
   source?: string;
+  origin?: OperationOrigin | null;
+  last_operation_origin?: OperationOrigin | null;
   confidence: number;
   created_at: string;
   updated_at?: string;
+  metadata?: Record<string, unknown>;
   from_entity?: string;
   relation_type?: string;
   to_entity?: string;
@@ -38,12 +42,34 @@ export interface Fact {
   _destination?: string;
 }
 
+interface OriginIdentity {
+  type?: string | null;
+  id?: string | null;
+  name?: string | null;
+  source?: string | null;
+}
+
+interface OperationOrigin {
+  user?: OriginIdentity | null;
+  agent?: OriginIdentity | null;
+  interface?: string | null;
+  operation?: {
+    action?: string | null;
+    tool?: string | null;
+    route?: string | null;
+    subsystem?: string | null;
+  } | null;
+}
+
 interface FactCardProps {
   fact: Fact;
   onClick?: () => void;
 }
 
 export default function FactCard({ fact, onClick }: FactCardProps) {
+  const userName = memoryUserName(fact);
+  const origin = memoryOriginLabel(fact);
+
   return (
     <button
       type="button"
@@ -82,6 +108,8 @@ export default function FactCard({ fact, onClick }: FactCardProps) {
       <div className="mt-2 flex items-center gap-3 text-xs text-zinc-500">
         <span>{relativeTime(fact.created_at)}</span>
         <span>{Math.round(fact.confidence * 100)}% conf</span>
+        {userName && <ProvChip label="user" value={userName} />}
+        {origin && <ProvChip label="origin" value={origin} />}
         {(fact.usefulness_rated_count ?? 0) > 0 && <span>{signalBreakdown(fact)}</span>}
         {fact.score != null && <span>score {fact.score.toFixed(3)}</span>}
         {fact.workstream_key && <ProvChip label="ws" value={fact.workstream_key} />}
@@ -94,6 +122,47 @@ export default function FactCard({ fact, onClick }: FactCardProps) {
       </div>
     </button>
   );
+}
+
+export function memoryUserName(fact: Fact): string | null {
+  return nonEmpty(fact.user_name)
+    ?? identityLabel(fact.origin?.user)
+    ?? nonEmpty(fact.metadata?.actor_label)
+    ?? identityLabel(fact.last_operation_origin?.user);
+}
+
+export function memoryOriginAgentLabel(fact: Fact): string | null {
+  return identityLabel(fact.origin?.agent);
+}
+
+export function memoryOriginLabel(fact: Fact): string | null {
+  return operationLabel(fact.origin) ?? nonEmpty(fact.source);
+}
+
+export function memoryLastOperationUserName(fact: Fact): string | null {
+  return identityLabel(fact.last_operation_origin?.user);
+}
+
+export function memoryLastOperationLabel(fact: Fact): string | null {
+  return operationLabel(fact.last_operation_origin);
+}
+
+function operationLabel(origin: OperationOrigin | null | undefined): string | null {
+  const surface = nonEmpty(origin?.interface) ?? nonEmpty(origin?.agent?.type);
+  const target = nonEmpty(origin?.operation?.subsystem) ?? nonEmpty(origin?.operation?.tool);
+  const action = nonEmpty(origin?.operation?.action);
+  const parts = [surface, target, action].filter((part): part is string => Boolean(part));
+  return parts.length > 0 ? parts.join("/") : null;
+}
+
+function identityLabel(identity: OriginIdentity | null | undefined): string | null {
+  return nonEmpty(identity?.name) ?? nonEmpty(identity?.id);
+}
+
+function nonEmpty(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 function signalBreakdown(fact: Fact): string {

--- a/packages/ui/app/src/pages/Dashboard.tsx
+++ b/packages/ui/app/src/pages/Dashboard.tsx
@@ -109,7 +109,7 @@ export default function Dashboard() {
       {/* Stats row */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
         <StatCard label="Active Facts" value={active} />
-        <StatCard label="Total Stored" value={total} sub={`${superseded} superseded`} />
+        <StatCard label="Total Stored" value={total} sub={superseded > 0 ? `${superseded} superseded` : undefined} />
         <StatCard label="Categories" value={BROWSABLE_CATEGORY_OPTIONS.length} />
         <StatCard label="Subtypes" value={activeSubtypeCount} sub={`${subtypeTotal.toLocaleString()} typed memories`} />
       </div>
@@ -134,6 +134,7 @@ export default function Dashboard() {
           <h3 className="text-sm font-medium text-zinc-400 mb-4">Facts by Kind</h3>
           <div className="space-y-3">
             {Object.entries(byKind)
+              .filter(([, count]) => count > 0)
               .sort(([, a], [, b]) => b - a)
               .map(([kind, count]) => (
                 <div

--- a/packages/ui/app/src/pages/Memory.tsx
+++ b/packages/ui/app/src/pages/Memory.tsx
@@ -267,7 +267,7 @@ export default function Memory() {
               <Database size={14} />
               {stats.active.toLocaleString()} active
             </span>
-            <span>{stats.superseded.toLocaleString()} superseded</span>
+            {stats.superseded > 0 && <span>{stats.superseded.toLocaleString()} superseded</span>}
           </div>
         )}
       </div>

--- a/packages/ui/app/src/pages/MemoryFact.tsx
+++ b/packages/ui/app/src/pages/MemoryFact.tsx
@@ -8,6 +8,13 @@ import { BROWSABLE_CATEGORY_OPTIONS, DOMAIN_OPTIONS, ontologyLabel } from "../li
 import Badge from "../components/Badge";
 import { EntityChip } from "../components/EntityChip";
 import type { Fact } from "../components/FactCard";
+import {
+  memoryLastOperationLabel,
+  memoryLastOperationUserName,
+  memoryOriginAgentLabel,
+  memoryOriginLabel,
+  memoryUserName,
+} from "../components/FactCard";
 
 export default function MemoryFact() {
   const { id } = useParams<{ id: string }>();
@@ -119,6 +126,8 @@ export default function MemoryFact() {
   const domainOptions = DOMAIN_OPTIONS.some((d) => d.value === editDomain) || !editDomain
     ? DOMAIN_OPTIONS
     : [{ value: editDomain, label: `Legacy: ${editDomain}` }, ...DOMAIN_OPTIONS];
+  const userName = memoryUserName(fact);
+  const origin = memoryOriginLabel(fact);
 
   return (
     <div>
@@ -228,6 +237,8 @@ export default function MemoryFact() {
               {fact.kind && <Badge label={`Kind: ${ontologyLabel(fact.kind)}`} color={KIND_COLORS[fact.kind]} size="md" />}
               {fact.memory_subtype && <Badge label={`Type: ${ontologyLabel(fact.memory_subtype)}`} color={CATEGORY_COLORS[fact.category]} size="md" />}
               {fact.domain && <Badge label={`Domain: ${ontologyLabel(fact.domain)}`} color={fact.domain === "personal_productivity" ? "green" : "zinc"} size="md" />}
+              {userName && <Badge label={`User: ${userName}`} color="blue" size="md" />}
+              {origin && <Badge label={`Origin: ${origin}`} color="indigo" size="md" />}
               {fact.source && <Badge label={`Source: ${ontologyLabel(fact.source)}`} size="md" />}
               {fact.actor_id && <Badge label={`Actor: ${fact.actor_id}`} color="zinc" size="md" />}
             </>
@@ -316,7 +327,20 @@ export default function MemoryFact() {
 }
 
 function ProvenanceSection({ fact }: { fact: Fact }) {
-  const fields: { label: string; value: string; render?: JSX.Element }[] = [];
+  const fields: { label: string; value: string; mono?: boolean; render?: JSX.Element }[] = [];
+  const userName = memoryUserName(fact);
+  const origin = memoryOriginLabel(fact);
+  const agent = memoryOriginAgentLabel(fact);
+  const lastOperation = memoryLastOperationLabel(fact);
+  const lastOperationUser = memoryLastOperationUserName(fact);
+
+  if (userName) fields.push({ label: "User", value: userName, mono: false });
+  if (origin) fields.push({ label: "Origin", value: origin });
+  if (agent) fields.push({ label: "Agent", value: agent, mono: false });
+  if (lastOperation) fields.push({ label: "Last operation", value: lastOperation });
+  if (lastOperationUser && lastOperationUser !== userName) {
+    fields.push({ label: "Last user", value: lastOperationUser, mono: false });
+  }
   if (fact.workstream_key) fields.push({ label: "Workstream", value: fact.workstream_key });
   if (fact.task_key) fields.push({ label: "Task", value: fact.task_key });
   if (fact.repo) {
@@ -349,7 +373,11 @@ function ProvenanceSection({ fact }: { fact: Fact }) {
         {fields.map((f) => (
           <div key={f.label}>
             <p className="text-xs text-zinc-500">{f.label}</p>
-            {f.render ?? <p className="text-zinc-300 font-mono text-xs break-all">{f.value}</p>}
+            {f.render ?? (
+              <p className={`text-zinc-300 text-xs break-all ${f.mono === false ? "" : "font-mono"}`}>
+                {f.value}
+              </p>
+            )}
           </div>
         ))}
       </div>

--- a/packages/ui/src/lib/qdrant.test.ts
+++ b/packages/ui/src/lib/qdrant.test.ts
@@ -112,6 +112,39 @@ describe("ui/lib/qdrant", () => {
         { key: "created_at", range: { lte: "2024-12-31" } },
       ]);
     });
+
+    it("excludes telemetry by default while preserving explicit telemetry requests", () => {
+      const defaultFilter = buildFilter({ excludeTelemetry: true });
+      assert.deepEqual(defaultFilter.must_not, [
+        { key: "kind", match: { value: "telemetry" } },
+      ]);
+
+      const telemetryKind = buildFilter({ kind: "telemetry", excludeTelemetry: true });
+      assert.equal(telemetryKind.must_not, undefined);
+
+      const telemetrySubtype = buildFilter({ memorySubtype: "recall_event", excludeTelemetry: true });
+      assert.equal(telemetrySubtype.must_not, undefined);
+    });
+
+    it("excludes system lifecycle metadata by default while preserving explicit system requests", () => {
+      const defaultFilter = buildFilter({ excludeSystem: true });
+      assert.deepEqual(defaultFilter.must_not, [
+        { key: "category", match: { value: "system" } },
+        { key: "memory_subtype", match: { any: ["session_index", "episode", "workstream"] } },
+      ]);
+
+      const systemCategory = buildFilter({ category: "system", excludeSystem: true });
+      assert.equal(systemCategory.must_not, undefined);
+
+      const sessionIndexSubtype = buildFilter({ memorySubtype: "session_index", excludeSystem: true });
+      assert.equal(sessionIndexSubtype.must_not, undefined);
+
+      const summaryKind = buildFilter({ kind: "summary", excludeSystem: true });
+      assert.deepEqual(summaryKind.must_not, [
+        { key: "category", match: { value: "system" } },
+        { key: "memory_subtype", match: { any: ["session_index", "episode", "workstream"] } },
+      ]);
+    });
   });
 
   describe("QdrantClient", () => {

--- a/packages/ui/src/lib/qdrant.ts
+++ b/packages/ui/src/lib/qdrant.ts
@@ -125,6 +125,19 @@ const MEMORY_SUBTYPE_FILTER_ALIASES: Record<string, FilterCondition[]> = {
   ],
 };
 
+const TELEMETRY_SUBTYPES = new Set([
+  "recall_event",
+  "feedback_event",
+  "outcome_event",
+  "aggregate_rollup",
+]);
+
+const SYSTEM_SUBTYPES = new Set([
+  "session_index",
+  "episode",
+  "workstream",
+]);
+
 const categoryFilterConditions = (categories: string[]): FilterCondition[] => {
   return categories.map((category) => ({ key: "category", match: categoryFilterValue(category) }));
 };
@@ -233,6 +246,8 @@ export function buildFilter(opts: {
   until?: string;
   excludeSuperseded?: boolean;
   excludeEntityType?: boolean;
+  excludeTelemetry?: boolean;
+  excludeSystem?: boolean;
 }): QdrantFilter {
   const must: FilterCondition[] = [];
   const should: FilterCondition[] = [];
@@ -279,6 +294,21 @@ export function buildFilter(opts: {
   // Phase 5a entity_type sidecar points are not user-facing facts; opt-in to exclude.
   if (opts.excludeEntityType === true && opts.kind !== "entity_type") {
     must_not.push({ key: "kind", match: { value: "entity_type" } });
+  }
+  const explicitlyRequestsTelemetry = opts.kind === "telemetry"
+    || (opts.memorySubtype !== undefined && TELEMETRY_SUBTYPES.has(opts.memorySubtype))
+    || (opts.memorySubtypes ?? []).some((subtype) => TELEMETRY_SUBTYPES.has(subtype));
+  if (opts.excludeTelemetry === true && !explicitlyRequestsTelemetry) {
+    must_not.push({ key: "kind", match: { value: "telemetry" } });
+  }
+  const explicitlyRequestsSystem = opts.category === "system"
+    || (opts.categories ?? []).includes("system")
+    || (opts.memorySubtype !== undefined && SYSTEM_SUBTYPES.has(opts.memorySubtype))
+    || (opts.memorySubtypes ?? []).some((subtype) => SYSTEM_SUBTYPES.has(subtype))
+    || explicitlyRequestsTelemetry;
+  if (opts.excludeSystem === true && !explicitlyRequestsSystem) {
+    must_not.push({ key: "category", match: { value: "system" } });
+    must_not.push({ key: "memory_subtype", match: { any: Array.from(SYSTEM_SUBTYPES) } });
   }
   const filter: QdrantFilter = { must };
   if (should.length > 0) filter.should = should;

--- a/packages/ui/src/routes/memory.test.ts
+++ b/packages/ui/src/routes/memory.test.ts
@@ -230,14 +230,15 @@ describe("ui/routes/memory", () => {
       const search = log.calls.find((c) => c.path.endsWith("/points/search"));
       assert.ok(search);
       assert.equal(search!.body.limit, 5);
-      assert.deepEqual(search!.body.filter.must[0], {
+      assert.deepEqual(search!.body.filter.must[0], { is_null: { key: "superseded_by" } });
+      assert.deepEqual(search!.body.filter.must[1], {
         should: [
           { key: "origin.agent.type", match: { any: ["system", "daemon"] } },
           { key: "origin.interface", match: { any: ["system", "daemon"] } },
           { key: "source", match: { any: ["system", "daemon"] } },
         ],
       });
-      assert.deepEqual(search!.body.filter.must[1], {
+      assert.deepEqual(search!.body.filter.must[2], {
         should: [
           { key: "origin.user.id", match: { value: "agent-1" } },
           { key: "origin.agent.id", match: { value: "agent-1" } },
@@ -253,6 +254,12 @@ describe("ui/routes/memory", () => {
           key: "memory_subtype",
           match: { value: "codebase_map" },
         },
+      ]);
+      assert.deepEqual(search!.body.filter.must_not, [
+        { key: "kind", match: { value: "entity_type" } },
+        { key: "kind", match: { value: "telemetry" } },
+        { key: "category", match: { value: "system" } },
+        { key: "memory_subtype", match: { any: ["session_index", "episode", "workstream"] } },
       ]);
     });
 
@@ -327,6 +334,78 @@ describe("ui/routes/memory", () => {
 
       const scroll = log.calls.find((c) => c.path.endsWith("/points/scroll"));
       assert.deepEqual(scroll!.body.order_by, { key: "created_at", direction: "desc" });
+      assert.deepEqual(scroll!.body.filter.must, [
+        { is_null: { key: "superseded_by" } },
+      ]);
+      assert.deepEqual(scroll!.body.filter.must_not, [
+        { key: "kind", match: { value: "entity_type" } },
+        { key: "kind", match: { value: "telemetry" } },
+        { key: "category", match: { value: "system" } },
+        { key: "memory_subtype", match: { any: ["session_index", "episode", "workstream"] } },
+      ]);
+    });
+
+    it("allows explicit superseded archive browse requests", async () => {
+      const log = installMock({
+        qdrantHandler: (c) => {
+          if (c.path.endsWith("/points/count")) return { result: { count: 1 } };
+          return { result: { points: [sampleFact({ superseded_by: "replacement-id" })], next_page_offset: null } };
+        },
+      });
+      const app = buildApp();
+
+      const res = await app.fetch(new Request("http://localhost/api/memory/browse?include_superseded=true"));
+
+      assert.equal(res.status, 200);
+      const scroll = log.calls.find((c) => c.path.endsWith("/points/scroll"));
+      assert.deepEqual(scroll!.body.filter.must, []);
+    });
+
+    it("allows explicit telemetry browse requests", async () => {
+      const log = installMock({
+        qdrantHandler: (c) => {
+          if (c.path.endsWith("/points/count")) return { result: { count: 1 } };
+          return {
+            result: {
+              points: [sampleFact({ kind: "telemetry", memory_subtype: "recall_event" })],
+              next_page_offset: null,
+            },
+          };
+        },
+      });
+      const app = buildApp();
+
+      const res = await app.fetch(new Request("http://localhost/api/memory/browse?kind=telemetry"));
+
+      assert.equal(res.status, 200);
+      const scroll = log.calls.find((c) => c.path.endsWith("/points/scroll"));
+      assert.deepEqual(scroll!.body.filter.must_not, [
+        { key: "kind", match: { value: "entity_type" } },
+      ]);
+    });
+
+    it("allows explicit system lifecycle browse requests", async () => {
+      const log = installMock({
+        qdrantHandler: (c) => {
+          if (c.path.endsWith("/points/count")) return { result: { count: 1 } };
+          return {
+            result: {
+              points: [sampleFact({ category: "system", kind: "summary", memory_subtype: "session_index" })],
+              next_page_offset: null,
+            },
+          };
+        },
+      });
+      const app = buildApp();
+
+      const res = await app.fetch(new Request("http://localhost/api/memory/browse?memory_subtype=session_index"));
+
+      assert.equal(res.status, 200);
+      const scroll = log.calls.find((c) => c.path.endsWith("/points/scroll"));
+      assert.deepEqual(scroll!.body.filter.must_not, [
+        { key: "kind", match: { value: "entity_type" } },
+        { key: "kind", match: { value: "telemetry" } },
+      ]);
     });
 
     it("computes usefulness fields for browse results", async () => {
@@ -435,7 +514,8 @@ describe("ui/routes/memory", () => {
       await app.fetch(new Request("http://localhost/api/memory/browse?category=engineering"));
       const scroll = log.calls.find((c) => c.path.endsWith("/points/scroll"));
       assert.ok(scroll);
-      assert.deepEqual(scroll!.body.filter.must[0], {
+      assert.deepEqual(scroll!.body.filter.must[0], { is_null: { key: "superseded_by" } });
+      assert.deepEqual(scroll!.body.filter.must[1], {
         key: "category",
         match: { any: ["engineering", "codebase", "infrastructure", "operations", "decisions", "observations"] },
       });
@@ -450,7 +530,9 @@ describe("ui/routes/memory", () => {
       await app.fetch(new Request("http://localhost/api/memory/browse?memory_subtype=convention"));
       const scroll = log.calls.find((c) => c.path.endsWith("/points/scroll"));
       assert.ok(scroll);
-      assert.deepEqual(scroll!.body.filter.must, []);
+      assert.deepEqual(scroll!.body.filter.must, [
+        { is_null: { key: "superseded_by" } },
+      ]);
       assert.deepEqual(scroll!.body.filter.should, [
         { key: "memory_subtype", match: { value: "convention" } },
         { key: "kind", match: { value: "distilled" } },
@@ -467,6 +549,7 @@ describe("ui/routes/memory", () => {
       const scroll = log.calls.find((c) => c.path.endsWith("/points/scroll"));
       assert.ok(scroll);
       assert.deepEqual(scroll!.body.filter.must, [
+        { is_null: { key: "superseded_by" } },
         { key: "entities", match: { value: "bikky" } },
       ]);
       assert.deepEqual(scroll!.body.filter.should, [
@@ -918,17 +1001,16 @@ describe("ui/routes/memory", () => {
 
   describe("GET /stats", () => {
     it("returns total/active/superseded counts and ontology breakdowns", async () => {
-      let pointsCount = 100;
       installMock({
         qdrantHandler: (c) => {
-          if (c.path === "/collections/test") {
-            return { result: { points_count: pointsCount, vectors_count: pointsCount } };
-          }
           if (c.path.endsWith("/points/count")) {
-            // Return a different count per filter to exercise the merge logic
             const must = c.body?.filter?.must ?? [];
+            if (must.some((cond: any) => cond.key === "category" && cond.match?.any?.includes("engineering"))) return { result: { count: 10 } };
+            if (must.some((cond: any) => cond.key === "kind" && cond.match?.value === "fact")) return { result: { count: 10 } };
+            if (must.some((cond: any) => cond.key === "memory_subtype" && cond.match?.value === "codebase_map")) return { result: { count: 10 } };
+            if (must.length === 1 && must.some((cond: any) => cond.is_null?.key === "superseded_by")) return { result: { count: 80 } };
             if (must.length === 0) return { result: { count: 90 } };
-            return { result: { count: 10 } };
+            return { result: { count: 0 } };
           }
           return { result: {} };
         },
@@ -945,12 +1027,38 @@ describe("ui/routes/memory", () => {
         byKind: Record<string, number>;
         bySubtype: Record<string, number>;
       };
-      assert.equal(body.total, 100);
-      assert.equal(body.active, 90);
-      assert.equal(body.superseded, 10);
+      assert.equal(body.total, 80);
+      assert.equal(body.active, 80);
+      assert.equal(body.superseded, 0);
       assert.equal(body.byCategory.engineering, 10);
       assert.equal(body.byKind.fact, 10);
+      assert.equal(body.byKind.telemetry, undefined);
       assert.equal(body.bySubtype.codebase_map, 10);
+      assert.equal(body.bySubtype.session_index, undefined);
+      assert.equal(body.bySubtype.aggregate_rollup, undefined);
+    });
+
+    it("allows explicit superseded archive stats requests", async () => {
+      installMock({
+        qdrantHandler: (c) => {
+          if (c.path.endsWith("/points/count")) {
+            const must = c.body?.filter?.must ?? [];
+            if (must.length === 1 && must.some((cond: any) => cond.is_null?.key === "superseded_by")) return { result: { count: 80 } };
+            if (must.length === 0) return { result: { count: 90 } };
+            return { result: { count: 0 } };
+          }
+          return { result: {} };
+        },
+      });
+      const app = buildApp();
+
+      const res = await app.fetch(new Request("http://localhost/api/memory/stats?include_superseded=true"));
+
+      assert.equal(res.status, 200);
+      const body = await res.json() as { total: number; active: number; superseded: number };
+      assert.equal(body.total, 90);
+      assert.equal(body.active, 80);
+      assert.equal(body.superseded, 10);
     });
 
     it("scopes category and subtype counts to source and kind filters", async () => {
@@ -989,6 +1097,7 @@ describe("ui/routes/memory", () => {
       );
       assert.ok(engineeringCount);
       assert.deepEqual(engineeringCount!.body.filter.must, [
+        { is_null: { key: "superseded_by" } },
         { key: "category", match: { any: ["engineering", "codebase", "infrastructure", "operations", "decisions", "observations"] } },
         { key: "kind", match: { value: "fact" } },
         {
@@ -999,12 +1108,19 @@ describe("ui/routes/memory", () => {
           ],
         },
       ]);
+      assert.deepEqual(engineeringCount!.body.filter.must_not, [
+        { key: "kind", match: { value: "entity_type" } },
+        { key: "kind", match: { value: "telemetry" } },
+        { key: "category", match: { value: "system" } },
+        { key: "memory_subtype", match: { any: ["session_index", "episode", "workstream"] } },
+      ]);
 
       const subtypeCount = countCalls.find((c) =>
         (c.body?.filter?.must ?? []).some((cond: any) => cond.key === "memory_subtype" && cond.match?.value === "codebase_map"),
       );
       assert.ok(subtypeCount);
       assert.deepEqual(subtypeCount!.body.filter.must, [
+        { is_null: { key: "superseded_by" } },
         { key: "kind", match: { value: "fact" } },
         { key: "memory_subtype", match: { value: "codebase_map" } },
         {
@@ -1014,6 +1130,12 @@ describe("ui/routes/memory", () => {
             { key: "source", match: { any: ["system", "daemon"] } },
           ],
         },
+      ]);
+      assert.deepEqual(subtypeCount!.body.filter.must_not, [
+        { key: "kind", match: { value: "entity_type" } },
+        { key: "kind", match: { value: "telemetry" } },
+        { key: "category", match: { value: "system" } },
+        { key: "memory_subtype", match: { any: ["session_index", "episode", "workstream"] } },
       ]);
     });
 
@@ -1051,7 +1173,14 @@ describe("ui/routes/memory", () => {
         .find((c) => (c.body?.filter?.should ?? []).some((cond: any) => cond.key === "memory_subtype" && cond.match?.value === "convention"));
       assert.ok(conventionCount);
       assert.deepEqual(conventionCount!.body.filter.must, [
+        { is_null: { key: "superseded_by" } },
         { key: "kind", match: { value: "distilled" } },
+      ]);
+      assert.deepEqual(conventionCount!.body.filter.must_not, [
+        { key: "kind", match: { value: "entity_type" } },
+        { key: "kind", match: { value: "telemetry" } },
+        { key: "category", match: { value: "system" } },
+        { key: "memory_subtype", match: { any: ["session_index", "episode", "workstream"] } },
       ]);
       assert.deepEqual(conventionCount!.body.filter.should, [
         { key: "memory_subtype", match: { value: "convention" } },

--- a/packages/ui/src/routes/memory.ts
+++ b/packages/ui/src/routes/memory.ts
@@ -155,6 +155,36 @@ const KEYWORD_SEARCH_PAGE_SIZE = 100;
 const KEYWORD_SEARCH_SCAN_LIMIT = 5_000;
 const USEFULNESS_BROWSE_SCAN_LIMIT = 5_000;
 
+const userFacingFilterDefaults = {
+  excludeSuperseded: true,
+  excludeEntityType: true,
+  excludeTelemetry: true,
+  excludeSystem: true,
+} as const;
+
+const userFacingFilterOptions = (c: Context) => ({
+  ...userFacingFilterDefaults,
+  excludeSuperseded: c.req.query("include_superseded") !== "true",
+});
+
+const TELEMETRY_MEMORY_SUBTYPE_VALUES = new Set([
+  "recall_event",
+  "feedback_event",
+  "outcome_event",
+  "aggregate_rollup",
+]);
+
+const SYSTEM_MEMORY_SUBTYPE_VALUES = new Set([
+  "session_index",
+  "episode",
+  "workstream",
+]);
+
+const INTERNAL_MEMORY_SUBTYPE_VALUES = new Set([
+  ...TELEMETRY_MEMORY_SUBTYPE_VALUES,
+  ...SYSTEM_MEMORY_SUBTYPE_VALUES,
+]);
+
 const keywordValueText = (value: unknown): string[] => {
   if (value === undefined || value === null || value === "") return [];
   if (Array.isArray(value)) return value.flatMap(keywordValueText);
@@ -239,7 +269,7 @@ memoryRoutes.get("/search", async (c) => {
     entity: c.req.query("entity"),
     source: c.req.query("source"),
     actorId: c.req.query("actor_id"),
-    excludeEntityType: true,
+    ...userFacingFilterOptions(c),
   });
 
   const limit = Math.min(parseInt(c.req.query("limit") || "20", 10), 100);
@@ -293,7 +323,7 @@ memoryRoutes.get("/browse", async (c) => {
     actorId: c.req.query("actor_id"),
     since: c.req.query("since"),
     until: c.req.query("until"),
-    excludeEntityType: true,
+    ...userFacingFilterOptions(c),
   });
 
   const limit = Math.min(parseInt(c.req.query("limit") || "20", 10), 100);
@@ -929,8 +959,9 @@ memoryRoutes.get("/stats", async (c) => {
   const kind = c.req.query("kind") || undefined;
   const source = c.req.query("source") || undefined;
   const statsFilter = { kind, source };
+  const includeSuperseded = c.req.query("include_superseded") === "true";
   const destQuery = c.req.query("destination") || "_default";
-  const cacheKey = `stats:dest=${destQuery}:kind=${kind ?? ""}:source=${source ?? ""}`;
+  const cacheKey = `stats:dest=${destQuery}:kind=${kind ?? ""}:source=${source ?? ""}:include_superseded=${includeSuperseded ? "true" : "false"}`;
   if (!refresh) {
     const hit = cacheGet<unknown>(cacheKey);
     if (hit) return c.json(hit);
@@ -943,14 +974,21 @@ memoryRoutes.get("/stats", async (c) => {
     const safeCount = async (filter?: QdrantFilter) => {
       try { return await qdrant.count(filter); } catch { return 0; }
     };
-    const [info, catCounts, kindCounts, subtypeCounts, allCount] = await Promise.all([
-      qdrant.collectionInfo(),
-      Promise.all(CATEGORY_VALUES.map(async (cat) => [cat, await safeCount(buildFilter({ ...statsFilter, category: cat }))] as const)),
-      Promise.all(KIND_VALUES.map(async (k) => [k, await safeCount(buildFilter({ source, kind: k }))] as const)),
-      Promise.all(MEMORY_SUBTYPE_VALUES.map(async (subtype) => [subtype, await safeCount(buildFilter({ ...statsFilter, memorySubtype: subtype }))] as const)),
-      safeCount(buildFilter(statsFilter)),
+    const filterOptions = userFacingFilterOptions(c);
+    const baseStatsFilter = { ...statsFilter, ...filterOptions };
+    const visibleCategoryValues = CATEGORY_VALUES.filter((cat) => cat !== "system");
+    const visibleKindValues = kind === "telemetry" ? KIND_VALUES : KIND_VALUES.filter((k) => k !== "telemetry");
+    const visibleSubtypeValues = kind === "telemetry"
+      ? MEMORY_SUBTYPE_VALUES.filter((subtype) => TELEMETRY_MEMORY_SUBTYPE_VALUES.has(subtype))
+      : MEMORY_SUBTYPE_VALUES.filter((subtype) => !INTERNAL_MEMORY_SUBTYPE_VALUES.has(subtype));
+    const [catCounts, kindCounts, subtypeCounts, totalCount, activeCount] = await Promise.all([
+      Promise.all(visibleCategoryValues.map(async (cat) => [cat, await safeCount(buildFilter({ ...baseStatsFilter, category: cat }))] as const)),
+      Promise.all(visibleKindValues.map(async (k) => [k, await safeCount(buildFilter({ source, kind: k, ...filterOptions }))] as const)),
+      Promise.all(visibleSubtypeValues.map(async (subtype) => [subtype, await safeCount(buildFilter({ ...baseStatsFilter, memorySubtype: subtype }))] as const)),
+      safeCount(buildFilter(baseStatsFilter)),
+      safeCount(buildFilter({ ...baseStatsFilter, excludeSuperseded: true })),
     ]);
-    return { info, catCounts, kindCounts, subtypeCounts, allCount };
+    return { catCounts, kindCounts, subtypeCounts, totalCount, activeCount };
   }));
 
   // Sum across destinations
@@ -959,8 +997,8 @@ memoryRoutes.get("/stats", async (c) => {
     for (const list of lists) for (const [k, v] of list) out[k] = (out[k] ?? 0) + v;
     return out;
   };
-  const total = perDest.reduce((s, r) => s + r.info.points_count, 0);
-  const active = perDest.reduce((s, r) => s + r.allCount, 0);
+  const total = perDest.reduce((s, r) => s + r.totalCount, 0);
+  const active = perDest.reduce((s, r) => s + r.activeCount, 0);
   const payload = {
     total,
     active,

--- a/src/daemon/quality-rollups.test.ts
+++ b/src/daemon/quality-rollups.test.ts
@@ -277,6 +277,11 @@ describe("daemon/quality-rollups", () => {
 
     const result = await aggregateMemoryQualitySignals({
       ...CONFIG_DEFAULTS,
+      identity: {
+        ...CONFIG_DEFAULTS.identity,
+        user_id: "git:saber:60dc9feaec8b",
+        user_name: "Saber",
+      },
       daemon: {
         ...CONFIG_DEFAULTS.daemon,
         memory_quality_rollups_max_scopes_per_run: 10,
@@ -288,9 +293,11 @@ describe("daemon/quality-rollups", () => {
     assert.equal(result.rollups_upserted > 0, true);
     assert.equal(upserts.length, result.rollups_upserted);
 
-    const firstPayload = ((upserts[0]?.points as Array<{ payload: Record<string, unknown> }>)[0]?.payload);
+    const firstPayload = upsertPayloads(upserts)[0];
     assert.equal(firstPayload?.kind, "telemetry");
     assert.equal(firstPayload?.memory_subtype, "aggregate_rollup");
+    assert.equal(firstPayload?.origin?.user?.name, "Saber");
+    assert.equal(firstPayload?.origin?.user?.source, "config");
     assert.equal(firstPayload?.rollup_type, "latest");
     assert.equal(firstPayload?.active_fact_count, 1);
   });
@@ -519,7 +526,7 @@ const depsWithScrollResponses = (
 
 const upsertPayloads = (
   upserts: Array<Record<string, unknown>>,
-): Array<Record<string, unknown> & { origin?: { metadata?: Record<string, unknown> } }> => upserts.flatMap((upsert) =>
+): Array<Record<string, unknown> & { origin?: { metadata?: Record<string, unknown>; user?: { name?: string; source?: string } } }> => upserts.flatMap((upsert) =>
   ((upsert.points as Array<{ payload: Record<string, unknown> }> | undefined) ?? [])
-    .map((point) => point.payload as Record<string, unknown> & { origin?: { metadata?: Record<string, unknown> } }),
+    .map((point) => point.payload as Record<string, unknown> & { origin?: { metadata?: Record<string, unknown>; user?: { name?: string; source?: string } } }),
 );

--- a/src/daemon/quality-rollups.ts
+++ b/src/daemon/quality-rollups.ts
@@ -396,7 +396,7 @@ const rollupId = (rollup: QualityRollup): string => stableUuid(
   `aggregate_rollup:${ROLLUP_TYPE}:${rollup.destination}:${rollup.scope_type}:${rollup.scope_value}`,
 );
 
-const rollupPayload = (rollup: QualityRollup): Record<string, unknown> => {
+const rollupPayload = (config: BikkyConfig, rollup: QualityRollup): Record<string, unknown> => {
   const content = rollupContent(rollup);
   return {
     content,
@@ -407,6 +407,7 @@ const rollupPayload = (rollup: QualityRollup): Record<string, unknown> => {
     layer: layerForMemorySubtype("aggregate_rollup") ?? "workspace",
     entities: rollup.scope_type === "entity" ? [rollup.scope_value.toLowerCase()] : [],
     origin: buildOperationOrigin({
+      config,
       interface: "daemon",
       action: "aggregate",
       subsystem: "memory_quality_rollups",
@@ -447,11 +448,12 @@ const rollupPayload = (rollup: QualityRollup): Record<string, unknown> => {
 };
 
 const upsertRollup = async (
+  config: BikkyConfig,
   deps: QualityRollupDeps,
   destination: Destination,
   rollup: QualityRollup,
 ): Promise<void> => {
-  const payload = rollupPayload(rollup);
+  const payload = rollupPayload(config, rollup);
   const vector = await deps.embed(String(payload.content));
   await deps.qdrantRequest("PUT", `/collections/${destination.collection}/points`, {
     points: [{ id: rollupId(rollup), vector, payload }],
@@ -484,7 +486,7 @@ export const aggregateMemoryQualitySignals = async (
     const selectedRollups = rollups.slice(0, maxScopes);
     scopesCapped ||= rollups.length > selectedRollups.length;
     for (const rollup of selectedRollups) {
-      await upsertRollup(deps, destination, rollup);
+      await upsertRollup(config, deps, destination, rollup);
       rollupsUpserted++;
     }
   }

--- a/tasks/004-origin-metadata/execution-log.md
+++ b/tasks/004-origin-metadata/execution-log.md
@@ -4,7 +4,7 @@
 
 | Phase | Step | State | Next | Blockers |
 |-------|------|-------|------|----------|
-| implement | Package memory UI filtering/provenance follow-up | in-progress | Stage and commit verified changes, then open PR for issue #150 | None |
+| implement | PR #151 opened for issue #150 | waiting-for-ci | Wait for GitHub checks, then request explicit approval before merging PR #151 into main | None |
 
 ## Implementation Progress
 
@@ -28,3 +28,4 @@
 - 2026-05-11 18:33 AEST — Follow-up requested to merge local Memory dashboard/list filtering, provenance display, and quality-rollup identity fixes. Created issue #150 for the focused PR.
 - 2026-05-11 18:38 AEST — Local verification passed: root `npm test`, UI `npm test`, and UI `npm run build`.
 - 2026-05-11 18:39 AEST — Code review found no material correctness, security, or logic issues in the local changes.
+- 2026-05-11 18:42 AEST — Created branch `feat/memory-dashboard-provenance`, committed `166e48d`, pushed it, and opened PR #151.

--- a/tasks/004-origin-metadata/execution-log.md
+++ b/tasks/004-origin-metadata/execution-log.md
@@ -1,0 +1,30 @@
+# Execution Log: origin-metadata
+
+## Status
+
+| Phase | Step | State | Next | Blockers |
+|-------|------|-------|------|----------|
+| implement | Package memory UI filtering/provenance follow-up | in-progress | Stage and commit verified changes, then open PR for issue #150 | None |
+
+## Implementation Progress
+
+- [x] Restore task artifacts and update GitHub issue #127 with the final origin-first design
+- [x] Inspect current provenance, config, MCP, daemon, UI, and read serialization code
+- [x] Implement canonical origin types/helpers and config identity provisioning
+- [x] Wire MCP writes/mutations/read output
+- [x] Wire daemon writes and direct upserts
+- [x] Wire UI/API writes and types
+- [x] Update docs and tests
+- [x] Run full validation and prepare PR
+- [ ] Package follow-up Memory dashboard filtering/provenance changes into a PR for issue #150
+
+## Timeline
+
+- 2026-05-06 12:14 AEST — Implementation started on `feat/origin-metadata`; final design treats `origin` as canonical provenance and uses `config`, `shell`, `git`, `env`, or `hostname` identity sources.
+- 2026-05-06 12:18 AEST — Restored `tasks/004-origin-metadata/` RPI artifacts on the implementation branch.
+- 2026-05-06 12:45 AEST — Added canonical origin helpers/tests, config identity provisioning, MCP origin-first writes and mutation attribution, daemon/UI origin wiring, legacy read/filter compatibility, and docs for origin identity.
+- 2026-05-06 12:55 AEST — Core check/test and UI typecheck/test passed after cleaning stale `dist/` artifacts; final package/UI build validation remains.
+- 2026-05-06 13:05 AEST — UI typecheck/test/build, core check/test, and package verification passed with origin metadata wiring in place.
+- 2026-05-11 18:33 AEST — Follow-up requested to merge local Memory dashboard/list filtering, provenance display, and quality-rollup identity fixes. Created issue #150 for the focused PR.
+- 2026-05-11 18:38 AEST — Local verification passed: root `npm test`, UI `npm test`, and UI `npm run build`.
+- 2026-05-11 18:39 AEST — Code review found no material correctness, security, or logic issues in the local changes.

--- a/tasks/004-origin-metadata/plan.md
+++ b/tasks/004-origin-metadata/plan.md
@@ -1,0 +1,107 @@
+# Plan: Origin Metadata
+
+## Problem
+
+Bikky provenance is split across `source`, `actor_id`, `actor_label`, and generic metadata. That makes it hard to answer who the configured user was, which automated agent/surface acted, and which operation created or mutated a memory. The new design should make `origin` the canonical provenance object.
+
+## Canonical shape
+
+```ts
+interface OriginIdentity {
+  type: "user" | "coding_agent" | "daemon" | "ui" | "api" | "cli" | "docs" | "system" | "unknown";
+  id: string | null;
+  name: string | null;
+  source: "config" | "shell" | "git" | "env" | "hostname";
+}
+
+interface OperationOrigin {
+  schema_version: 1;
+  user: OriginIdentity | null;
+  agent: OriginIdentity;
+  interface: "mcp" | "daemon" | "ui" | "api" | "cli" | "system";
+  operation: {
+    action: "create" | "update" | "delete" | "verify" | "forget" | "review" | "correct" | "reinforce" | "supersede" | "feedback";
+    tool?: string;
+    route?: string;
+    subsystem?: string;
+    outcome?: string;
+  };
+  metadata?: Record<string, string | number | boolean | null>;
+}
+```
+
+Memory classification fields such as `kind` and `memory_subtype` remain outside `origin`.
+
+## Implementation plan
+
+1. Add provenance types/helpers.
+   - Create `src/provenance/origin.ts`.
+   - Reuse email-like ID normalization from `src/provenance/actor.ts`.
+   - Resolve user identity from config/env/git/shell/hostname, with hostname fallback.
+   - Resolve agent identity from MCP/daemon/UI/API/CLI/system context.
+   - Bound metadata to primitive values and safe string lengths.
+
+2. Extend config and setup.
+   - Add `identity.user_id` / `identity.user_name` to `src/config.ts`.
+   - Keep legacy `actor_id` / `actor_label` only if needed for reading old config, not as the public write model.
+   - Update setup/install/start path to provision missing user identity once without overwriting configured values.
+
+3. Wire MCP.
+   - Remove/deprecate public `actor_id` write input where feasible.
+   - Do not add MCP `origin` or `user` override input.
+   - Add `origin` to creation paths and `last_operation_origin` to mutation paths.
+   - Update structured/text read output.
+
+4. Wire daemon.
+   - Add daemon origin defaults to central `storeFact()`.
+   - Add origins to direct daemon upserts for session index, episode summary, workstream summary, and entity typing.
+
+5. Wire UI/API.
+   - Add origin generation to create/update/delete routes.
+   - Update UI Qdrant payload types.
+
+6. Update tests and docs.
+   - Add origin helper/config tests.
+   - Update MCP, daemon, UI, and serialization tests.
+   - Update README/config/API docs for canonical origin semantics and hostname fallback.
+
+7. Validate.
+   - Run `npm run check`.
+   - Run `npm test`.
+   - Run `cd packages/ui && npm run typecheck && npm test && npm run build`.
+   - Run `npm run verify:package`.
+
+## Acceptance criteria
+
+- New writes store canonical `origin`.
+- Mutation-only operations preserve creation `origin` and set `last_operation_origin`.
+- MCP callers cannot spoof `origin.user`.
+- Identity source values are limited to `config`, `shell`, `git`, `env`, and `hostname`.
+- Hostname is used when all other identity detection fails.
+- `kind` and `memory_subtype` remain outside `origin`.
+- Tests cover helper resolution, write paths, mutation paths, daemon origins, UI/API origins, and read serialization.
+
+## Follow-up plan: issue #150
+
+1. Package the local Memory dashboard/list filtering changes.
+   - Keep default browse/search/stats scoped to current user-facing memories.
+   - Preserve explicit diagnostic access for telemetry, system lifecycle records, and superseded records.
+
+2. Package the local provenance display changes.
+   - Show configured user/origin on memory cards.
+   - Show user, origin, agent, and last-operation provenance on the memory detail page.
+   - Keep legacy fallbacks for records that only have `user_name`, `metadata.actor_label`, `source`, or `actor_id`.
+
+3. Package the quality-rollup identity fix.
+   - Pass `BikkyConfig` into quality-rollup origin generation so config identity is used.
+   - Keep regression coverage for configured identity.
+
+4. Verify before commit.
+   - Run root `npm test`.
+   - Run `cd packages/ui && npm test`.
+   - Run `cd packages/ui && npm run build`.
+
+5. Open and merge a focused PR.
+   - Branch from `main`.
+   - Reference `Closes #150` in the PR.
+   - Wait for GitHub checks before merging into `main`.

--- a/tasks/004-origin-metadata/research.md
+++ b/tasks/004-origin-metadata/research.md
@@ -1,0 +1,57 @@
+# Research: Origin Metadata
+
+## Current model
+
+- Bikky currently stores provenance across multiple fields:
+  - `source` is a coarse enum (`agent`, `system`, `user`, `docs`).
+  - `actor_id` is a top-level indexed payload field.
+  - `actor_label` and `actor_source` are stored in generic metadata by MCP helpers.
+- `src/provenance/actor.ts` resolves an actor from explicit MCP input, env, config, or Git fallback. This is useful prior art for normalization, but the explicit MCP override should not become the human user source of truth.
+- There is no canonical object that says which configured human user, which automated actor, which surface, and which operation produced or mutated a memory.
+
+## Final design direction
+
+- Breaking changes are acceptable.
+- `origin` becomes the canonical provenance object for new writes.
+- `origin.user` is the configured/provisioned human identity. MCP callers do not provide it.
+- `origin.agent` is inferred by the runtime surface: coding agent, daemon, UI/API, CLI, docs importer, system, or unknown.
+- `origin.interface` records the entry surface.
+- `origin.operation` records create/update/delete/verify/forget/review/correct/reinforce/supersede/feedback semantics plus tool/route/subsystem/outcome details.
+- Identity sources to implement: `config`, `shell`, `git`, `env`, `hostname`. Do not implement `runtime`, `legacy`, or `default`; hostname is the fallback when automated detection fails.
+- Keep memory classification fields such as `kind` and `memory_subtype` outside `origin`.
+
+## Write surfaces to inspect/wire
+
+- MCP:
+  - `src/mcp/tools.ts`
+  - `src/mcp/types.ts`
+  - `src/mcp/helpers.ts`
+- Daemon:
+  - `src/daemon/qdrant.ts`
+  - `src/daemon/extraction.ts`
+  - `src/daemon/session-index.ts`
+  - `src/daemon/episode-summary.ts`
+  - `src/daemon/workstream-summary.ts`
+  - `src/daemon/entity-typing.ts`
+- UI/API:
+  - `packages/ui/src/routes/memory.ts`
+  - `packages/ui/src/lib/qdrant.ts`
+- Config/install:
+  - `src/config.ts`
+  - `src/install.ts`
+  - `src/lifecycle.ts`
+  - `src/provenance/actor.ts`
+
+## Risks and considerations
+
+- Existing Qdrant records may still have top-level `source` / `actor_id`; read paths may need a compatibility adapter, but new writes should be origin-first.
+- Tests need to cover identity fallback order, hostname fallback, MCP no-spoofing behavior, mutation `last_operation_origin`, daemon origins, and UI/API origins.
+- Existing indexes/filters may reference `source` and `actor_id`; replacing those may require search/filter updates or an intentional compatibility bridge.
+
+## Follow-up research: Memory UI filtering and provenance display
+
+- Issue #150 tracks the follow-up PR for the local dashboard/list filtering and provenance display changes.
+- The default Memory UI should show current user-facing memories only. Internal telemetry (`kind=telemetry`), system lifecycle records (`session_index`, `episode`, `workstream`), entity sidecars, and superseded/archive records are useful diagnostics but should not appear by default.
+- `packages/ui/src/routes/memory.ts` is the central route layer for browse/search/stats defaults; `packages/ui/src/lib/qdrant.ts` is the central Qdrant filter builder.
+- The React list/detail surfaces share the `Fact` type in `packages/ui/app/src/components/FactCard.tsx`; provenance display helpers can live there and be reused by `MemoryFact.tsx`.
+- Daemon quality rollup telemetry writes through `src/daemon/quality-rollups.ts`; it must pass loaded `BikkyConfig` into `buildOperationOrigin` so configured identity wins over Git fallback.


### PR DESCRIPTION
## Summary

- Hide internal memory records from default Memory dashboard/list/search views: telemetry, system lifecycle records, entity sidecars, and superseded/archive records.
- Preserve explicit diagnostics for telemetry/system records and superseded archives.
- Show configured user/origin provenance in memory cards and detail pages with legacy fallbacks.
- Ensure daemon quality-rollup telemetry uses configured identity when building origin metadata.

Closes #150

## Verification

- `npm test`
- `cd packages/ui && npm test`
- `cd packages/ui && npm run build`
