### PR TITLE
docs: fix configuration coherence

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ cat > ~/.bikky/config.json <<'JSON'
   "embedding": {
     "provider": "openai",
     "model": "text-embedding-3-small",
-    "dimensions": 1536,
+    "dimensions": 1024,
     "api_key": "sk-..."
   },
   "llm": {
@@ -105,7 +105,7 @@ bikky supports four common setup shapes. Pick based on where you want Qdrant to 
 | **LLM**                 | One provider                   | Portkey · OpenAI · Ollama · Bedrock                                                     |
 | **Docker** *(optional)* | Only if you run Qdrant locally | Docker Desktop, OrbStack, colima, etc.                                                   |
 
-Both `embedding.provider` and `llm.provider` accept the same values: `ollama`, `openai`, `bedrock`, or `portkey`. **Portkey is the easiest cloud option** — one API key, any upstream provider, with built-in routing/fallbacks. Bikky's canonical embedding dimension is **1024**, portable across every modern provider.
+Both `embedding.provider` and `llm.provider` accept the same values: `ollama`, `openai`, `bedrock`, or `portkey`. **Portkey is the easiest cloud option** — one API key, any upstream provider, with built-in routing/fallbacks. Bikky's canonical embedding dimension is **1024**, portable across every modern provider. Some providers expose larger native dimensions (for example OpenAI `text-embedding-3-small` can return 1536), but the docs use 1024 so you can switch providers later without rebuilding every collection.
 
 > ⚠️ **Qdrant Cloud free tier does not include automatic backups.** Deleted collections cannot be recovered. If your memory data is valuable, use a paid Qdrant Cloud plan (which includes daily backups), run Qdrant locally with your own backup strategy, or periodically export snapshots via the [Qdrant snapshots API](https://qdrant.tech/documentation/concepts/snapshots/).
 
@@ -196,9 +196,9 @@ bikky-ui              # opens http://localhost:1422
 <p align="center"><i>Dashboard — memory stats, category breakdown, and recent facts at a glance</i></p>
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/bikky-dev/bikky/main/docs/screenshots/memory.png" alt="Memory browser — search, filter, and browse all stored facts" width="720" />
+  <img src="https://raw.githubusercontent.com/bikky-dev/bikky/main/docs/screenshots/memory.png" alt="Memory browser — search, filter, and browse current user-facing memories" width="720" />
 </p>
-<p align="center"><i>Memory browser — search, filter by category/kind/origin, and browse all stored facts</i></p>
+<p align="center"><i>Memory browser — search, filter by category, subtype, entity, usefulness, date, and sort order</i></p>
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/bikky-dev/bikky/main/docs/screenshots/graph.png" alt="Entity graph — interactive visualization of entity relationships" width="720" />
@@ -206,6 +206,10 @@ bikky-ui              # opens http://localhost:1422
 <p align="center"><i>Entity graph — interactive visualization of how concepts, people, and services relate</i></p>
 
 The UI reads from your existing `~/.bikky/config.json` (or `BIKKY_HOME/config.json`) — no extra configuration required.
+
+By default, the dashboard, memory list, and search results show current user-facing memories only. Internal telemetry, system lifecycle summaries (`session_index`, `episode`, `workstream`), entity sidecars, and superseded archive records are hidden from the main views so counts match what you normally mean by "memories." Diagnostic API queries can still request those records explicitly, including superseded records with `include_superseded=true`.
+
+Memory cards and detail pages also surface provenance from canonical `origin` metadata: the configured user, origin surface/operation, agent, last operation, repo, branch, workstream, task, session, and episode when present. Older records that only have legacy `source`, `actor_id`, or `metadata.actor_label` still display useful fallback labels.
 
 ## CLI
 

--- a/docs/config/hosted-qdrant-local-models.md
+++ b/docs/config/hosted-qdrant-local-models.md
@@ -8,6 +8,7 @@ Use this path when you want memory shared across machines, but you still want em
 - A Qdrant API key.
 - Ollama installed locally.
 - The default embedding model pulled with `ollama pull qwen3-embedding:0.6b`.
+- The default LLM model pulled with `ollama pull qwen2.5:7b`.
 
 ## Config
 

--- a/docs/config/local.md
+++ b/docs/config/local.md
@@ -9,6 +9,7 @@ This setup is best for private/free testing rather than long-term team use. Extr
 - Qdrant running locally, usually with Docker.
 - Ollama installed locally.
 - The default embedding model pulled with `ollama pull qwen3-embedding:0.6b`.
+- The default LLM model pulled with `ollama pull qwen2.5:7b`.
 
 ## Config
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ cat > ~/.bikky/config.json <<'JSON'
   "embedding": {
     "provider": "openai",
     "model": "text-embedding-3-small",
-    "dimensions": 1536,
+    "dimensions": 1024,
     "api_key": "sk-..."
   },
   "llm": {
@@ -24,7 +24,7 @@ JSON
 bikky status
 ```
 
-Config lives at `~/.bikky/config.json`, or at `BIKKY_HOME/config.json` when `BIKKY_HOME` is set. Environment variables override the config file.
+Config lives at `~/.bikky/config.json`, or at `BIKKY_HOME/config.json` when `BIKKY_HOME` is set. Environment variables can supply or override most scalar settings. Provider API key env vars such as `OPENAI_API_KEY` and `PORTKEY_API_KEY` are fallback values when the matching `api_key` field is omitted from config; remove the config value when you want key rotation through the environment.
 
 ## Origin identity
 
@@ -64,7 +64,7 @@ Best for performance and teams. Qdrant Cloud stores vectors, and hosted embeddin
   "embedding": {
     "provider": "openai",
     "model": "text-embedding-3-small",
-    "dimensions": 1536,
+    "dimensions": 1024,
     "api_key": "sk-..."
   },
   "llm": {
@@ -88,7 +88,7 @@ Best for local vector storage with hosted extraction and embedding quality.
   "embedding": {
     "provider": "openai",
     "model": "text-embedding-3-small",
-    "dimensions": 1536,
+    "dimensions": 1024,
     "api_key": "sk-..."
   },
   "llm": {
@@ -99,7 +99,7 @@ Best for local vector storage with hosted extraction and embedding quality.
 }
 ```
 
-`qdrant_api_key` is optional. Leave it empty or omit it for local or unauthenticated self-hosted Qdrant. Prefer env vars for hosted model auth? Omit `api_key` above and set `OPENAI_API_KEY` instead.
+`qdrant_api_key` is optional. Leave it empty or omit it for local or unauthenticated self-hosted Qdrant. Prefer env vars for hosted model auth? Omit `api_key` above and set `OPENAI_API_KEY` or `PORTKEY_API_KEY` for the selected provider instead.
 
 ### Local and free
 
@@ -148,15 +148,17 @@ export QDRANT_API_KEY="..."  # only needed for Qdrant Cloud or authenticated sel
 
 Useful basics:
 
-| Env var          | Config field     | Notes                                                                       |
-| ---------------- | ---------------- | --------------------------------------------------------------------------- |
-| `QDRANT_URL`     | `qdrant_url`     | Required unless set in config                                               |
-| `QDRANT_API_KEY` | `qdrant_api_key` | Optional for local/unauthenticated Qdrant; usually needed for Qdrant Cloud  |
-| `BIKKY_HOME`     | —                | Moves the config/log/state directory from `~/.bikky`                        |
-| `BIKKY_USER_ID`  | `identity.user_id` | Explicit human user id for origin provisioning                            |
-| `BIKKY_USER_NAME` | `identity.user_name` | Human-readable human user name for origin provisioning                  |
-| `BIKKY_AGENT_ID` | —                | Optional local automated-agent id stored in `origin.agent`                  |
-| `BIKKY_AGENT_NAME` | —              | Optional local automated-agent label stored in `origin.agent`               |
+| Env var            | Config field          | Notes                                                                                   |
+| ------------------ | --------------------- | --------------------------------------------------------------------------------------- |
+| `QDRANT_URL`       | `qdrant_url`          | Required unless set in config                                                           |
+| `QDRANT_API_KEY`   | `qdrant_api_key`      | Optional for local/unauthenticated Qdrant; usually needed for Qdrant Cloud              |
+| `OPENAI_API_KEY`   | `embedding.api_key` / `llm.api_key` | Fallback key for `openai` when `api_key` is omitted from config              |
+| `PORTKEY_API_KEY`  | `embedding.api_key` / `llm.api_key` | Fallback key for `portkey` when `api_key` is omitted from config             |
+| `BIKKY_HOME`       | —                     | Moves the config/log/state directory from `~/.bikky`                                    |
+| `BIKKY_USER_ID`    | `identity.user_id`    | Explicit human user id for origin provisioning                                          |
+| `BIKKY_USER_NAME`  | `identity.user_name`  | Human-readable human user name for origin provisioning                                  |
+| `BIKKY_AGENT_ID`   | —                     | Optional local automated-agent id stored in `origin.agent`                              |
+| `BIKKY_AGENT_NAME` | —                     | Optional local automated-agent label stored in `origin.agent`                           |
 
 ## Provider options
 
@@ -167,7 +169,7 @@ Use these exact values in `embedding.provider` and `llm.provider`. Both fields a
 | `ollama`       | Yes                  | Yes           | Local and free defaults              | None                              |
 | `openai`       | Yes                  | Yes           | Simple hosted models                 | `OPENAI_API_KEY` or `api_key`     |
 | `bedrock`      | Yes                  | Yes           | AWS-managed models                   | AWS credentials or IAM role       |
-| `portkey`      | Yes                  | Yes           | Gateway/routing over other providers | Portkey API key                   |
+| `portkey`      | Yes                  | Yes           | Gateway/routing over other providers | `PORTKEY_API_KEY` or `api_key`    |
 
 ## Advanced configuration
 
@@ -193,7 +195,7 @@ These sections are optional references for custom providers, tuning, scoping, an
 | `embedding.model`      | `EMBEDDING_MODEL`      | `qwen3-embedding:0.6b`   | Embedding model name                            |
 | `embedding.dimensions` | `EMBEDDING_DIMENSIONS` | `1024`                   | Must match the selected model output            |
 | `embedding.base_url`   | `EMBEDDING_BASE_URL`   | `http://localhost:11434` | Used by local or OpenAI-compatible providers    |
-| `embedding.api_key`    | `OPENAI_API_KEY`       | —                        | Provider API key; can also be set in config     |
+| `embedding.api_key`    | `OPENAI_API_KEY` / `PORTKEY_API_KEY` | —             | Provider API key; env vars are fallback when omitted from config |
 
 Common model dimensions:
 
@@ -205,7 +207,7 @@ Common model dimensions:
 | `openai`  | `text-embedding-3-large`         | `3072`     |
 | `bedrock` | `amazon.titan-embed-text-v2:0`   | `1024`     |
 
-If you change the embedding model, make sure `embedding.dimensions` matches the model output.
+bikky's examples use `1024` because that is the portable default across supported providers. OpenAI 3-series embedding models can return their larger native dimensions above, but they also support shorter outputs; if you change `embedding.dimensions`, make sure the selected model and every Qdrant collection use the same dimension.
 
 #### LLM
 
@@ -216,7 +218,7 @@ The LLM is used by background maintenance features. Ollama is the default.
 | `llm.provider`     | `LLM_PROVIDER`                       | `ollama`                 | One of `ollama`, `openai`, `bedrock`, `portkey` |
 | `llm.model`        | `LLM_MODEL`                          | `qwen2.5:7b`             | LLM model name                               |
 | `llm.base_url`     | `LLM_BASE_URL`                       | `http://localhost:11434` | Used by local or OpenAI-compatible providers |
-| `llm.api_key`      | `OPENAI_API_KEY`                     | —                        | Provider API key; can also be set in config  |
+| `llm.api_key`      | `OPENAI_API_KEY` / `PORTKEY_API_KEY` | —                        | Provider API key; env vars are fallback when omitted from config |
 | `llm.extra.region` | `AWS_BEDROCK_REGION` / `AWS_REGION`  | `us-east-1`              | AWS Bedrock region                           |
 
 #### Timeouts and retries
@@ -243,7 +245,7 @@ Retries use jittered exponential backoff for transient errors, rate limits, and 
   "embedding": {
     "provider": "portkey",
     "model": "@openai/text-embedding-3-small",
-    "dimensions": 1536,
+    "dimensions": 1024,
     "api_key": "pk-..."
   },
   "llm": {
@@ -298,7 +300,7 @@ MCP clients can override this per call with `search_scope`. The value accepts `"
   "embedding": {
     "provider": "openai",
     "model": "text-embedding-3-small",
-    "dimensions": 1536
+    "dimensions": 1024
   },
   "llm": {
     "provider": "openai",

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -8,6 +8,10 @@ npx bikky-ui
 
 The UI reads the same `~/.bikky/config.json` as the `bikky` CLI and opens a local dashboard at <http://localhost:1422>.
 
+The Memory dashboard, list, and search views default to current user-facing memories. Internal telemetry, system lifecycle summaries, entity sidecars, and superseded archive records stay available for diagnostics but are hidden from the main views by default.
+
+Memory cards and detail pages show provenance when it is available: configured user, origin surface/operation, agent, last operation, repo, branch, workstream, task, session, and episode. Older records still fall back to legacy `source`, `actor_id`, and actor-label metadata.
+
 For setup, configuration, and security details, see the main bikky repository:
 
 - [README](https://github.com/bikky-dev/bikky#readme)


### PR DESCRIPTION
## Summary

- Standardize README/config examples on the canonical 1024-dimensional embedding default and explain provider-native alternatives.
- Add the missing Ollama LLM model pull to local-model setup guides.
- Clarify provider API-key environment fallback behavior and document `PORTKEY_API_KEY` centrally.
- Update Memory UI docs to match current filters, default user-facing filtering, diagnostics, and provenance display.

Refs #152

## Verification

- Parsed all `json` fenced blocks in changed Markdown files with `JSON.parse`.
- Checked for stale `"dimensions": 1536`, `category/kind/origin`, and `all stored facts` phrases.
