### PR TITLE
test: cover Memory UI filters with Playwright

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -12,6 +12,16 @@ The Memory dashboard, list, and search views default to current user-facing memo
 
 Memory cards and detail pages show provenance when it is available: configured user, origin surface/operation, agent, last operation, repo, branch, workstream, task, session, and episode. Older records still fall back to legacy `source`, `actor_id`, and actor-label metadata.
 
+## Development checks
+
+```bash
+npm test
+npm run build
+npm run test:e2e
+```
+
+`npm run test:e2e` runs the Playwright browser regression suite against mocked API responses, including Memory filter coverage.
+
 For setup, configuration, and security details, see the main bikky repository:
 
 - [README](https://github.com/bikky-dev/bikky#readme)

--- a/packages/ui/app/e2e/memory-filters.spec.ts
+++ b/packages/ui/app/e2e/memory-filters.spec.ts
@@ -1,0 +1,263 @@
+import { expect, test, type Page } from "@playwright/test";
+
+interface CapturedRequest {
+  path: string;
+  url: URL;
+}
+
+const categoryCounts = {
+  engineering: 4,
+  product: 3,
+  human: 2,
+};
+
+const subtypeCounts = {
+  product_decision: 2,
+  product_requirement: 1,
+};
+
+test("Memory filters are forwarded to browse and search API requests", async ({ page }) => {
+  const captured: CapturedRequest[] = [];
+  await mockMemoryApi(page, captured);
+
+  await page.goto("/memory?sort=newest");
+
+  await expectRequest(captured, "/api/memory/browse", {
+    sort: "newest",
+    destination: "all",
+  });
+
+  await page.getByRole("button", { name: "Add category Product" }).click();
+  await expectRequest(captured, "/api/memory/browse", {
+    category: "product",
+    sort: "newest",
+    destination: "all",
+  });
+
+  await page.getByRole("button", { name: "Add subtype Product decision" }).click();
+  await expectRequest(captured, "/api/memory/browse", {
+    category: "product",
+    memory_subtype: "product_decision",
+    sort: "newest",
+    destination: "all",
+  });
+
+  await page.getByRole("textbox", { name: "Entity filter" }).fill("bikky-ui");
+  await expectRequest(captured, "/api/memory/browse", {
+    category: "product",
+    memory_subtype: "product_decision",
+    entity: "bikky-ui",
+    sort: "newest",
+    destination: "all",
+  });
+
+  await page.getByRole("combobox", { name: "Usefulness filter" }).selectOption("positive");
+  await expectRequest(captured, "/api/memory/browse", {
+    category: "product",
+    memory_subtype: "product_decision",
+    entity: "bikky-ui",
+    usefulness: "positive",
+    sort: "newest",
+    destination: "all",
+  });
+
+  await page.getByRole("combobox", { name: "Sort memories" }).selectOption("oldest");
+  await expectRequest(captured, "/api/memory/browse", {
+    category: "product",
+    memory_subtype: "product_decision",
+    entity: "bikky-ui",
+    usefulness: "positive",
+    sort: "oldest",
+    destination: "all",
+  });
+
+  const presetSince = presetSinceDate(6);
+  await page.getByRole("button", { name: "Past 7 days" }).click();
+  await expectRequest(captured, "/api/memory/browse", {
+    category: "product",
+    memory_subtype: "product_decision",
+    entity: "bikky-ui",
+    usefulness: "positive",
+    sort: "oldest",
+    since: new Date(presetSince).toISOString(),
+    until: null,
+    destination: "all",
+  });
+
+  const expectedSince = new Date("2026-01-02").toISOString();
+  const expectedUntil = new Date("2026-01-09T23:59:59").toISOString();
+  await page.getByLabel("From date").fill("2026-01-02");
+  await page.getByLabel("Until date").fill("2026-01-09");
+  await expectRequest(captured, "/api/memory/browse", {
+    category: "product",
+    memory_subtype: "product_decision",
+    entity: "bikky-ui",
+    usefulness: "positive",
+    sort: "oldest",
+    since: expectedSince,
+    until: expectedUntil,
+    destination: "all",
+  });
+
+  await page.getByRole("combobox", { name: "Destination" }).selectOption("bikky");
+  await expectRequest(captured, "/api/memory/browse", {
+    category: "product",
+    memory_subtype: "product_decision",
+    entity: "bikky-ui",
+    usefulness: "positive",
+    sort: "oldest",
+    since: expectedSince,
+    until: expectedUntil,
+    destination: "bikky",
+  });
+
+  await page.getByRole("textbox", { name: "Search memory" }).fill("filter audit");
+  await page.getByRole("button", { name: "Search" }).click();
+  await expectRequest(captured, "/api/memory/search", {
+    q: "filter audit",
+    category: "product",
+    memory_subtype: "product_decision",
+    entity: "bikky-ui",
+    usefulness: "positive",
+    sort: "oldest",
+    since: expectedSince,
+    until: expectedUntil,
+    limit: "20",
+    destination: "bikky",
+  });
+
+  await page.getByRole("button", { name: "Clear all" }).click();
+  await expectRequest(captured, "/api/memory/search", {
+    q: "filter audit",
+    category: null,
+    memory_subtype: null,
+    entity: null,
+    usefulness: null,
+    since: null,
+    until: null,
+    sort: "oldest",
+    destination: "bikky",
+  });
+});
+
+async function mockMemoryApi(page: Page, captured: CapturedRequest[]) {
+  await page.route("**/api/**", async (route) => {
+    const url = new URL(route.request().url());
+    captured.push({ path: url.pathname, url });
+
+    if (url.pathname === "/api/destinations") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          destinations: [
+            { name: "bikky", collection: "bikky", isDefault: true },
+            { name: "work", collection: "work", isDefault: false },
+          ],
+        }),
+      });
+      return;
+    }
+
+    if (url.pathname === "/api/memory/stats") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          total: 9,
+          active: 9,
+          superseded: 0,
+          byCategory: categoryCounts,
+          byKind: { fact: 9 },
+          bySubtype: subtypeCounts,
+        }),
+      });
+      return;
+    }
+
+    if (url.pathname === "/api/memory/search") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          results: [memoryFact("search-result", url)],
+          count: 1,
+        }),
+      });
+      return;
+    }
+
+    if (url.pathname === "/api/memory/browse") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          results: [memoryFact("browse-result", url)],
+          count: 1,
+          nextOffset: null,
+        }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 404,
+      contentType: "application/json",
+      body: JSON.stringify({ error: `Unhandled ${url.pathname}` }),
+    });
+  });
+}
+
+function memoryFact(id: string, requestUrl: URL) {
+  return {
+    id,
+    content: `Mock memory for ${requestUrl.pathname}`,
+    category: requestUrl.searchParams.get("category")?.split(",")[0] || "engineering",
+    domain: "software_engineering",
+    kind: "fact",
+    memory_subtype: requestUrl.searchParams.get("memory_subtype"),
+    entities: requestUrl.searchParams.get("entity") ? [requestUrl.searchParams.get("entity")] : ["bikky-ui"],
+    confidence: 0.91,
+    created_at: "2026-01-10T00:00:00.000Z",
+    updated_at: "2026-01-10T00:00:00.000Z",
+    usefulness_percent: requestUrl.searchParams.get("usefulness") === "positive" ? 100 : null,
+    user_name: "Saber",
+    origin: {
+      user: { name: "Saber" },
+      interface: "ui",
+      operation: { action: "test", subsystem: "memory" },
+    },
+  };
+}
+
+async function expectRequest(
+  captured: CapturedRequest[],
+  path: string,
+  expectedParams: Record<string, string | null>,
+) {
+  await expect
+    .poll(() => {
+      const match = [...captured]
+        .reverse()
+        .find((entry) => entry.path === path && paramsMatch(entry.url, expectedParams));
+      return match?.url.toString() ?? null;
+    })
+    .not.toBeNull();
+}
+
+function paramsMatch(url: URL, expectedParams: Record<string, string | null>): boolean {
+  return Object.entries(expectedParams).every(([key, expected]) => {
+    const actual = url.searchParams.get(key);
+    return expected === null ? actual === null : actual === expected;
+  });
+}
+
+function presetSinceDate(days: number): string {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() - days);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}

--- a/packages/ui/app/playwright.config.ts
+++ b/packages/ui/app/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from "@playwright/test";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  workers: 1,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: "http://127.0.0.1:5173",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: "npm run dev -- --host 127.0.0.1 --port 5173",
+    cwd: packageRoot,
+    url: "http://127.0.0.1:5173/memory",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/packages/ui/app/src/pages/Memory.tsx
+++ b/packages/ui/app/src/pages/Memory.tsx
@@ -66,6 +66,11 @@ function presetSinceDate(days: number): string {
   return `${yyyy}-${mm}-${dd}`;
 }
 
+function setDateRangeParams(params: URLSearchParams, since: string, until: string): void {
+  if (since) params.set("since", new Date(since).toISOString());
+  if (until) params.set("until", new Date(until + "T23:59:59").toISOString());
+}
+
 interface BrowseResponse {
   results: Fact[];
   count: number;
@@ -146,6 +151,7 @@ export default function Memory() {
           if (entity) params.set("entity", entity);
           if (sort) params.set("sort", sort);
           if (usefulness) params.set("usefulness", usefulness);
+          setDateRangeParams(params, since, until);
           params.set("limit", String(append ? results.length + PAGE_SIZE : PAGE_SIZE));
 
           const data = await apiFetch<SearchResponse>(`/api/memory/search?${params}`);
@@ -162,8 +168,7 @@ export default function Memory() {
           if (entity) params.set("entity", entity);
           if (sort) params.set("sort", sort);
           if (usefulness) params.set("usefulness", usefulness);
-          if (since) params.set("since", new Date(since).toISOString());
-          if (until) params.set("until", new Date(until + "T23:59:59").toISOString());
+          setDateRangeParams(params, since, until);
           params.set("limit", String(PAGE_SIZE));
           if (append && offset) params.set("offset", String(offset));
 
@@ -277,6 +282,7 @@ export default function Memory() {
         <div className="relative flex-1">
           <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500" />
           <input
+            aria-label="Search memory"
             type="text"
             placeholder="Search memory…"
             value={query}
@@ -343,6 +349,7 @@ export default function Memory() {
                   type="button"
                   onClick={() => applyCategory(cat.value)}
                   className={pillCls(categories.includes(cat.value))}
+                  aria-label={`${categories.includes(cat.value) ? "Remove" : "Add"} category ${cat.label}`}
                   title={`${categoryCount(cat.value).toLocaleString()} facts`}
                 >
                   {categories.includes(cat.value) ? "Selected" : "Add"}
@@ -358,6 +365,7 @@ export default function Memory() {
                       type="button"
                       onClick={() => applySubtype(subtype.value)}
                       className={pillCls(memorySubtypes.includes(subtype.value))}
+                      aria-label={`${memorySubtypes.includes(subtype.value) ? "Remove" : "Add"} subtype ${subtype.label}`}
                       title={subtype.description}
                     >
                       {subtype.label}
@@ -375,20 +383,39 @@ export default function Memory() {
       <div className="flex flex-wrap items-center gap-2 mb-6">
         <div className="flex items-center gap-1.5">
           <ArrowUpDown size={14} className="text-zinc-500" />
-          <select value={sort} onChange={(e) => setSort(e.target.value)} className={selectCls}>
+          <select
+            aria-label="Sort memories"
+            value={sort}
+            onChange={(e) => setSort(e.target.value)}
+            className={selectCls}
+          >
             {SORT_OPTIONS.map((o) => (
               <option key={o.value} value={o.value}>{o.label}</option>
             ))}
           </select>
         </div>
-        <select value={usefulness} onChange={(e) => setUsefulness(e.target.value)} className={selectCls}>
+        <select
+          aria-label="Usefulness filter"
+          value={usefulness}
+          onChange={(e) => setUsefulness(e.target.value)}
+          className={selectCls}
+        >
           {USEFULNESS_FILTER_OPTIONS.map((option) => (
             <option key={option.value} value={option.value}>{option.label}</option>
           ))}
         </select>
+        <input
+          aria-label="Entity filter"
+          type="text"
+          placeholder="Entity"
+          value={entity}
+          onChange={(e) => setEntity(e.target.value)}
+          className="bg-zinc-900 border border-zinc-700 rounded-md px-2 py-1.5 text-sm text-zinc-300 placeholder-zinc-500 focus:outline-none focus:border-zinc-500"
+        />
         <div className="flex items-center gap-1.5 text-sm text-zinc-400">
           <span>From</span>
           <input
+            aria-label="From date"
             type="date"
             value={since}
             onChange={(e) => setSince(e.target.value)}
@@ -396,6 +423,7 @@ export default function Memory() {
           />
           <span>to</span>
           <input
+            aria-label="Until date"
             type="date"
             value={until}
             onChange={(e) => setUntil(e.target.value)}

--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -17,6 +17,7 @@
         "bikky-ui": "bin/bikky-ui.js"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.1.0",
         "@types/d3-force": "^3.0.10",
         "@types/node": "^25.6.0",
@@ -160,6 +161,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1655,6 +1672,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,6 +37,7 @@
     "dev": "vite --config app/vite.config.ts",
     "typecheck": "tsc --noEmit",
     "test": "tsc && node --test --test-concurrency=1 $(find dist -name '*.test.js') && vitest run --config app/vite.config.ts app/src",
+    "test:e2e": "playwright test --config app/playwright.config.ts",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
@@ -45,6 +46,7 @@
     "open": "^11.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.1.0",
     "@types/d3-force": "^3.0.10",
     "@types/node": "^25.6.0",

--- a/tasks/005-memory-filter-playwright/execution-log.md
+++ b/tasks/005-memory-filter-playwright/execution-log.md
@@ -1,0 +1,28 @@
+# Execution Log: memory-filter-playwright
+
+## Status
+
+| Phase | Step | State | Next | Blockers |
+|-------|------|-------|------|----------|
+| review | Memory filter Playwright coverage | ready-to-merge | Await explicit merge approval | None |
+
+## Implementation Progress
+
+- [x] Confirm user wants all Memory UI filters covered by a Playwright test
+- [x] Inspect existing UI test setup and Memory filter wiring
+- [x] Create GitHub issue
+- [x] Add Playwright E2E test harness for Memory filters
+- [x] Fix filter request parameter gaps exposed by the test
+- [x] Run local verification
+- [x] Open PR
+
+## Timeline
+
+- 2026-05-11 20:10 AEST — User reported Memory UI filters not working and requested testing all filters with a Playwright test.
+- 2026-05-11 20:15 AEST — Research found no existing Playwright E2E suite; `packages/ui` currently uses Node tests plus Vitest for app code.
+- 2026-05-11 20:16 AEST — Research found a likely bug: browse requests include `since`/`until`, but search requests omit those date filters when `q` is present.
+- 2026-05-11 20:18 AEST — Created GitHub issue #154.
+- 2026-05-11 20:25 AEST — Added Playwright config and `npm run test:e2e`, mocked API regression coverage for Memory filters, accessible filter labels, visible entity filter input, and date forwarding for search requests.
+- 2026-05-11 20:26 AEST — Verified `npm run test:e2e`, `npm test`, and `npm run build` in `packages/ui`.
+- 2026-05-11 20:32 AEST — Opened PR #155 and fixed the UI package lockfile for CI npm compatibility.
+- 2026-05-11 20:33 AEST — All 6 PR checks passed.

--- a/tasks/005-memory-filter-playwright/plan.md
+++ b/tasks/005-memory-filter-playwright/plan.md
@@ -1,0 +1,41 @@
+# Plan: Memory Filter Playwright
+
+## Problem
+
+The Memory UI exposes several filters, but there is no browser-level regression test proving that user interactions send the right API query parameters. A likely bug already exists: date range filters are not forwarded on search requests.
+
+## Implementation plan
+
+1. Create a tracking GitHub issue.
+   - Describe the missing filter regression coverage and the search/date forwarding gap.
+
+2. Add Playwright E2E support to `packages/ui`.
+   - Add a direct Playwright test dependency.
+   - Add `app/playwright.config.ts`.
+   - Add a `test:e2e` npm script that runs the Playwright suite explicitly.
+   - Keep default `npm test` unchanged to avoid CI browser setup changes.
+
+3. Make Memory filter controls reliably testable and accessible.
+   - Add `aria-label` attributes to sort, usefulness, entity, and date controls where labels are not otherwise programmatically associated.
+   - Preserve current UI/visual behavior.
+
+4. Fix search request filter forwarding.
+   - Include `since` and `until` query parameters for `/api/memory/search` using the same ISO conversion as browse requests.
+
+5. Add a deterministic Playwright test.
+   - Mock stats, destination, browse, and search API responses.
+   - Exercise category, subtype, entity, usefulness, date range, sort, destination, and search query interactions.
+   - Assert the outgoing API URLs contain the expected filter parameters.
+
+6. Verify.
+   - Run `cd packages/ui && npm test`.
+   - Run `cd packages/ui && npm run build`.
+   - Run `cd packages/ui && npm run test:e2e`.
+
+## Acceptance criteria
+
+- A Playwright E2E test covers every visible Memory filter.
+- Search requests preserve date range filters.
+- The test does not require live Qdrant data.
+- Default unit/build verification still passes.
+- The Playwright suite can be run with an explicit script.

--- a/tasks/005-memory-filter-playwright/research.md
+++ b/tasks/005-memory-filter-playwright/research.md
@@ -1,0 +1,53 @@
+# Research: Memory Filter Playwright
+
+## Request
+
+The user reported that Memory UI filters do not seem to be working and asked to "test all" by implementing a Playwright test.
+
+## Current state
+
+- `packages/ui` has no checked-in Playwright E2E test suite or Playwright config.
+- `packages/ui` runs:
+  - server/lib tests through `node --test`
+  - React/app tests through Vitest
+- A one-off `packages/ui/graph-drag-test.mjs` imports `playwright`, but `playwright` / `@playwright/test` are not direct `packages/ui` dev dependencies.
+- CI currently runs `npm test` for `packages/ui` on Node 20 and Node 22. Adding Playwright to the default CI path would require browser install/setup changes; the focused path is to add an explicit `test:e2e` script first.
+
+## Memory filter wiring
+
+`packages/ui/app/src/pages/Memory.tsx` exposes:
+
+- Search query
+- Category filter
+- Memory subtype filter
+- Entity filter
+- Sort order
+- Usefulness filter
+- `since` / `until` date range
+- Destination selector through the shared API destination store
+
+Browse requests include category, memory subtype, entity, sort, usefulness, `since`, and `until`.
+
+Search requests include category, memory subtype, entity, sort, and usefulness, but currently omit `since` and `until`. That means date filters can silently stop applying when a search query is active.
+
+## Test approach
+
+- Add a Playwright test against the Vite dev server.
+- Mock `/api/*` responses with `page.route()` so the test is deterministic and does not require live Qdrant credentials or seed data.
+- Capture outgoing `/api/memory/browse` and `/api/memory/search` URLs to assert that every UI filter becomes the expected API query parameter.
+- Add stable accessible labels to filter controls where needed so the test interacts like a user rather than through brittle CSS selectors.
+
+## Scope
+
+In scope:
+
+- `packages/ui` Playwright config/script/dependencies
+- Memory page filter accessibility labels
+- Search request date filter forwarding
+- A focused E2E test covering all Memory filters
+
+Out of scope:
+
+- Changing backend filter semantics
+- Changing CI workflows unless explicitly approved
+- Refactoring the Memory page beyond the filter controls needed for reliable testing


### PR DESCRIPTION
## Summary

- add an explicit `npm run test:e2e` Playwright harness for `packages/ui`
- cover Memory search, category, subtype, entity, usefulness, date, sort, destination, and clear-all filter wiring with mocked API responses
- expose stable accessible labels and a visible entity filter input on the Memory page
- forward date range filters on Memory search requests as well as browse requests

Closes #154

## Verification

- `cd packages/ui && npm run test:e2e`
- `cd packages/ui && npm test`
- `cd packages/ui && npm run build`
- `cd packages/ui && npm audit --omit=dev --audit-level=high`