### PR TITLE
test: add Memory Playwright edge cases

### DIFF
--- a/packages/ui/app/e2e/memory-filters.spec.ts
+++ b/packages/ui/app/e2e/memory-filters.spec.ts
@@ -5,6 +5,27 @@ interface CapturedRequest {
   url: URL;
 }
 
+interface BrowseResponse {
+  results: ReturnType<typeof memoryFact>[];
+  count: number;
+  nextOffset: number | null;
+}
+
+interface SearchResponse {
+  results: ReturnType<typeof memoryFact>[];
+  count: number;
+}
+
+interface MockErrorResponse {
+  status: number;
+  error: string;
+}
+
+interface MockMemoryApiOptions {
+  browse?: (url: URL) => BrowseResponse | MockErrorResponse;
+  search?: (url: URL) => SearchResponse | MockErrorResponse;
+}
+
 const categoryCounts = {
   engineering: 4,
   product: 3,
@@ -140,7 +161,158 @@ test("Memory filters are forwarded to browse and search API requests", async ({ 
   });
 });
 
-async function mockMemoryApi(page: Page, captured: CapturedRequest[]) {
+test("Memory restores URL filter state and clears individual active filters", async ({ page }) => {
+  const captured: CapturedRequest[] = [];
+  await mockMemoryApi(page, captured);
+
+  const expectedSince = new Date("2026-01-02").toISOString();
+  const expectedUntil = new Date("2026-01-09T23:59:59").toISOString();
+
+  await page.goto(
+    "/memory?category=product,human&memory_subtype=product_decision&entity=bikky-ui&usefulness=positive&since=2026-01-02&until=2026-01-09&sort=oldest",
+  );
+
+  await expect(page.getByRole("combobox", { name: "Sort memories" })).toHaveValue("oldest");
+  await expect(page.getByRole("combobox", { name: "Usefulness filter" })).toHaveValue("positive");
+  await expect(page.getByRole("textbox", { name: "Entity filter" })).toHaveValue("bikky-ui");
+  await expect(page.getByLabel("From date")).toHaveValue("2026-01-02");
+  await expect(page.getByLabel("Until date")).toHaveValue("2026-01-09");
+  await expectRequest(captured, "/api/memory/browse", {
+    category: "product,human",
+    memory_subtype: "product_decision",
+    entity: "bikky-ui",
+    usefulness: "positive",
+    since: expectedSince,
+    until: expectedUntil,
+    sort: "oldest",
+    destination: "all",
+  });
+
+  await page.getByRole("button", { name: "Clear Category filter Product (3)" }).click();
+  await expectRequest(captured, "/api/memory/browse", {
+    category: "human",
+    memory_subtype: "product_decision",
+    entity: "bikky-ui",
+    usefulness: "positive",
+    since: expectedSince,
+    until: expectedUntil,
+    sort: "oldest",
+    destination: "all",
+  });
+
+  await page.getByRole("button", { name: "Clear Subtype filter Product decision (2)" }).click();
+  await expectRequest(captured, "/api/memory/browse", {
+    category: "human",
+    memory_subtype: null,
+    entity: "bikky-ui",
+    usefulness: "positive",
+    since: expectedSince,
+    until: expectedUntil,
+    sort: "oldest",
+    destination: "all",
+  });
+
+  await page.getByRole("button", { name: "Clear Entity filter bikky-ui" }).click();
+  await expectRequest(captured, "/api/memory/browse", {
+    category: "human",
+    memory_subtype: null,
+    entity: null,
+    usefulness: "positive",
+    since: expectedSince,
+    until: expectedUntil,
+    sort: "oldest",
+    destination: "all",
+  });
+
+  await page.getByRole("button", { name: "Clear From filter 2026-01-02" }).click();
+  await expectRequest(captured, "/api/memory/browse", {
+    category: "human",
+    memory_subtype: null,
+    entity: null,
+    usefulness: "positive",
+    since: null,
+    until: expectedUntil,
+    sort: "oldest",
+    destination: "all",
+  });
+
+  await page.getByRole("button", { name: "Clear all" }).click();
+  await expectRequest(captured, "/api/memory/browse", {
+    category: null,
+    memory_subtype: null,
+    entity: null,
+    usefulness: null,
+    since: null,
+    until: null,
+    sort: "oldest",
+    destination: "all",
+  });
+});
+
+test("Memory browse appends results when loading more", async ({ page }) => {
+  const captured: CapturedRequest[] = [];
+  await mockMemoryApi(page, captured, {
+    browse: (url) => {
+      const offset = url.searchParams.get("offset");
+      return {
+        results: [memoryFact(offset === "20" ? "browse-page-2" : "browse-page-1", url)],
+        count: 2,
+        nextOffset: offset === "20" ? null : 20,
+      };
+    },
+  });
+
+  await page.goto("/memory?sort=newest");
+
+  await expect(page.getByText("Mock browse-page-1 memory for /api/memory/browse")).toBeVisible();
+  await expect(page.getByText("Showing 1 of 2 facts")).toBeVisible();
+
+  await page.getByRole("button", { name: "Load more" }).click();
+
+  await expectRequest(captured, "/api/memory/browse", {
+    offset: "20",
+    limit: "20",
+    sort: "newest",
+    destination: "all",
+  });
+  await expect(page.getByText("Mock browse-page-1 memory for /api/memory/browse")).toBeVisible();
+  await expect(page.getByText("Mock browse-page-2 memory for /api/memory/browse")).toBeVisible();
+  await expect(page.getByText("Showing 2 of 2 facts")).toBeVisible();
+});
+
+test("Memory shows empty and error states", async ({ page }) => {
+  const captured: CapturedRequest[] = [];
+  let failBrowse = false;
+  await mockMemoryApi(page, captured, {
+    browse: (url) => {
+      if (failBrowse) return { status: 503, error: "Qdrant is unavailable" };
+      return { results: [], count: 0, nextOffset: null };
+    },
+  });
+
+  await page.goto("/memory?category=product");
+  await expect(page.getByText("No facts found")).toBeVisible();
+  await expect(page.getByText("Try adjusting your search or filters")).toBeVisible();
+  await expectRequest(captured, "/api/memory/browse", {
+    category: "product",
+    destination: "all",
+  });
+
+  failBrowse = true;
+  await page.goto("/memory?category=human");
+
+  await expect(page.getByText("Qdrant is unavailable")).toBeVisible();
+  await expectRequest(captured, "/api/memory/browse", {
+    category: "human",
+    destination: "all",
+  });
+});
+
+async function mockMemoryApi(
+  page: Page,
+  captured: CapturedRequest[],
+  options: MockMemoryApiOptions = {},
+) {
   await page.route("**/api/**", async (route) => {
     const url = new URL(route.request().url());
     captured.push({ path: url.pathname, url });
@@ -176,26 +348,28 @@ async function mockMemoryApi(page: Page, captured: CapturedRequest[]) {
     }
 
     if (url.pathname === "/api/memory/search") {
+      const response = options.search?.(url) ?? {
+        results: [memoryFact("search-result", url)],
+        count: 1,
+      };
       await route.fulfill({
-        status: 200,
+        status: "status" in response ? response.status : 200,
         contentType: "application/json",
-        body: JSON.stringify({
-          results: [memoryFact("search-result", url)],
-          count: 1,
-        }),
+        body: JSON.stringify(responseBody(response)),
       });
       return;
     }
 
     if (url.pathname === "/api/memory/browse") {
+      const response = options.browse?.(url) ?? {
+        results: [memoryFact("browse-result", url)],
+        count: 1,
+        nextOffset: null,
+      };
       await route.fulfill({
-        status: 200,
+        status: "status" in response ? response.status : 200,
         contentType: "application/json",
-        body: JSON.stringify({
-          results: [memoryFact("browse-result", url)],
-          count: 1,
-          nextOffset: null,
-        }),
+        body: JSON.stringify(responseBody(response)),
       });
       return;
     }
@@ -208,15 +382,20 @@ async function mockMemoryApi(page: Page, captured: CapturedRequest[]) {
   });
 }
 
+function responseBody(response: BrowseResponse | SearchResponse | MockErrorResponse) {
+  return "status" in response ? { error: response.error } : response;
+}
+
 function memoryFact(id: string, requestUrl: URL) {
+  const entity = requestUrl.searchParams.get("entity");
   return {
     id,
-    content: `Mock memory for ${requestUrl.pathname}`,
+    content: `Mock ${id} memory for ${requestUrl.pathname}`,
     category: requestUrl.searchParams.get("category")?.split(",")[0] || "engineering",
     domain: "software_engineering",
     kind: "fact",
     memory_subtype: requestUrl.searchParams.get("memory_subtype"),
-    entities: requestUrl.searchParams.get("entity") ? [requestUrl.searchParams.get("entity")] : ["bikky-ui"],
+    entities: entity ? [entity] : ["bikky-ui"],
     confidence: 0.91,
     created_at: "2026-01-10T00:00:00.000Z",
     updated_at: "2026-01-10T00:00:00.000Z",

--- a/packages/ui/app/src/pages/Memory.tsx
+++ b/packages/ui/app/src/pages/Memory.tsx
@@ -527,7 +527,7 @@ function ActiveFilterChip({ filter }: { filter: ActiveFilter }) {
         type="button"
         onClick={filter.onClear}
         className="text-zinc-500 hover:text-zinc-200"
-        aria-label={`Clear ${filter.label} filter`}
+        aria-label={`Clear ${filter.label} filter ${filter.value}`}
       >
         ×
       </button>

--- a/tasks/006-memory-playwright-edge-cases/execution-log.md
+++ b/tasks/006-memory-playwright-edge-cases/execution-log.md
@@ -1,0 +1,32 @@
+# Execution Log: memory-playwright-edge-cases
+
+## Status
+
+| Phase | Step | State | Next | Blockers |
+|-------|------|-------|------|----------|
+| review | Memory Playwright edge cases | ready-to-merge | Await explicit merge approval for PR #166 | None |
+
+## Implementation Progress
+
+- [x] Confirm scope: additional Memory UI Playwright edge-case tests
+- [x] Decide to create a new follow-up task instead of extending task 005
+- [x] Research current UI/test behavior
+- [x] Write plan
+- [x] Get plan approval
+- [x] Create GitHub issue
+- [x] Implement tests and any small exposed Memory UI fixes
+- [x] Verify locally
+- [x] Commit and open PR
+
+## Timeline
+
+- 2026-05-11 20:53 AEST — User requested more Playwright tests.
+- 2026-05-11 20:55 AEST — Scope confirmed as Memory UI edge cases: URL-preloaded filter state, clearing individual/combined filters, load-more pagination, and empty/error states.
+- 2026-05-11 20:58 AEST — Created follow-up task `006-memory-playwright-edge-cases`.
+- 2026-05-11 21:03 AEST — Completed research and drafted plan for URL state, chip clearing, pagination, empty, and error Playwright coverage.
+- 2026-05-11 21:05 AEST — User approved plan.
+- 2026-05-11 21:06 AEST — Created GitHub issue #165.
+- 2026-05-11 21:10 AEST — Added Memory Playwright edge-case tests and made active filter clear button labels include the filter value.
+- 2026-05-11 21:14 AEST — Verified `npm run test:e2e`, `npm test`, `npm run build`, and high-threshold production dependency audit in `packages/ui`.
+- 2026-05-11 21:16 AEST — Opened PR #166 for issue #165.
+- 2026-05-11 21:18 AEST — All 6 PR checks passed.

--- a/tasks/006-memory-playwright-edge-cases/plan.md
+++ b/tasks/006-memory-playwright-edge-cases/plan.md
@@ -1,0 +1,44 @@
+# Plan: Memory Playwright Edge Cases
+
+## Problem
+
+The existing Memory Playwright coverage verifies the main filter happy path, but it does not yet cover edge states that commonly regress: URL-restored filters, individual filter clearing, pagination, empty results, and API errors.
+
+## Approach
+
+Add focused tests to the existing Memory Playwright spec using the same mocked API pattern. Keep the default unit-test workflow unchanged.
+
+## Planned changes
+
+1. Update `packages/ui/app/e2e/memory-filters.spec.ts`.
+   - Add a URL-preloaded filter test.
+   - Assert the UI controls and active filter chips reflect URL query params.
+   - Exercise individual active-filter clearing and assert only the cleared parameter is removed from API requests.
+   - Add a load-more pagination test for browse mode.
+   - Add empty and error state tests.
+
+2. Update `packages/ui/app/src/pages/Memory.tsx` only for a small accessibility improvement.
+   - Make active filter chip clear buttons include the filter value in their accessible label, so multiple active filters of the same type are uniquely identifiable.
+   - Preserve visible UI and existing behavior.
+
+3. Create a GitHub issue for this follow-up.
+   - Reference the issue from the PR with `Closes #N`.
+
+4. Verify.
+   - Run `cd packages/ui && npm run test:e2e`.
+   - Run `cd packages/ui && npm test`.
+   - Run `cd packages/ui && npm run build`.
+   - Run `cd packages/ui && npm audit --omit=dev --audit-level=high`.
+
+## Out of scope
+
+- Dashboard or Graph Playwright coverage.
+- Backend route changes.
+- Adding Playwright to default CI unless requested separately.
+- Refactoring Memory page state management beyond the chip accessible-name improvement.
+
+## Acceptance criteria
+
+- Playwright covers Memory URL state, individual clearing, pagination, empty state, and error state.
+- Tests remain deterministic and do not require live Qdrant.
+- Existing UI package tests and build still pass.

--- a/tasks/006-memory-playwright-edge-cases/research.md
+++ b/tasks/006-memory-playwright-edge-cases/research.md
@@ -1,0 +1,80 @@
+# Research: Memory Playwright Edge Cases
+
+## Request
+
+Add more Playwright tests for Memory UI edge cases, building on PR #155.
+
+Confirmed scope:
+
+- URL-preloaded filter state
+- Clearing individual and combined filters
+- Load-more pagination
+- Empty and error states
+- Small Memory UI bug fixes exposed by those tests are in scope
+
+## Current state
+
+- `packages/ui` now has an explicit Playwright harness:
+  - config: `packages/ui/app/playwright.config.ts`
+  - suite directory: `packages/ui/app/e2e/`
+  - command: `cd packages/ui && npm run test:e2e`
+- Existing spec `memory-filters.spec.ts` covers the main filter-happy-path:
+  - category
+  - subtype
+  - entity
+  - usefulness
+  - sort
+  - date range
+  - destination
+  - search
+  - clear-all request behavior
+- Existing test mocks `/api/destinations`, `/api/memory/stats`, `/api/memory/browse`, and `/api/memory/search`, so no live Qdrant or config is required.
+
+## Relevant Memory page behavior
+
+- URL params initialize state for `q`, `category`, `memory_subtype`, `entity`, `sort`, `usefulness`, `since`, and `until`.
+- Active filter chips are rendered for category, subtype, entity, usefulness, since, and until.
+- Individual active filter chips currently share generic accessible names such as `Clear Category filter`; this is testable but less precise if multiple chips of one type exist.
+- `Clear all` clears category/subtype/entity/usefulness/dates but intentionally keeps the search query and sort order.
+- Browse load-more uses `offset=nextOffset` and appends returned results.
+- Search load-more increases `limit` instead of using offset.
+- Empty state renders `No facts found`.
+- API errors render the error message from `apiFetch`.
+
+## Repo guidance
+
+- No repo-level Copilot instructions or `.github/agents` files were present.
+- `CONTRIBUTING.md` requires an issue before non-trivial changes, branch from `main`, local tests before pushing, and a PR that closes the issue.
+- Harness coding standards confirm TypeScript strict-mode expectations; existing project uses Node/npm and ESM, so follow the repo convention rather than migrating package managers.
+- Harness git workflow requires short-lived feature branches, conventional commit messages, PRs for all changes, and explicit approval before merging to `main`.
+
+## Proposed test additions
+
+1. URL state + individual chip clearing
+   - Navigate directly to `/memory` with several query params.
+   - Assert controls and active filter chips reflect the URL state.
+   - Clear individual chips and assert subsequent requests omit only the cleared parameter.
+   - Improve chip clear button accessible names to include the chip value if needed.
+
+2. Browse load-more pagination
+   - Mock first browse response with `nextOffset`.
+   - Click `Load more`.
+   - Assert the next browse request includes `offset`.
+   - Assert appended results and count text update.
+
+3. Empty and error states
+   - Mock an empty browse response and assert the empty state is shown.
+   - Mock a failing browse response and assert the surfaced API error is shown.
+
+## Files likely in scope
+
+- `packages/ui/app/e2e/memory-filters.spec.ts`
+- `packages/ui/app/src/pages/Memory.tsx` only if tests expose accessibility gaps on active filter chips
+- `tasks/006-memory-playwright-edge-cases/*`
+
+## Verification
+
+- `cd packages/ui && npm run test:e2e`
+- `cd packages/ui && npm test`
+- `cd packages/ui && npm run build`
+- `cd packages/ui && npm audit --omit=dev --audit-level=high`


### PR DESCRIPTION
## Summary

- add Memory Playwright coverage for URL-preloaded filters and individual active-filter clearing
- add browse load-more pagination coverage
- add empty and API error state coverage
- make active filter clear buttons include the filter value in their accessible label

Closes #165

## Verification

- `cd packages/ui && npm run test:e2e`
- `cd packages/ui && npm test`
- `cd packages/ui && npm run build`
- `cd packages/ui && npm audit --omit=dev --audit-level=high`