### PR TITLE
Remove Human memory category

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The most valuable things you and your agents learn — why a config value exists
 bikky gives your agent memory tools and runs a small background service after `bikky setup`. You keep working normally; bikky captures useful facts, organizes them, recalls them in future sessions, and keeps the store tidy over time.
 
 - **Capture** — Facts are extracted automatically from session transcripts; no manual docs to write.
-- **Classify** — Memories are grouped as **engineering**, **product**, **human**, or **system** so they stay easy to browse and filter.
+- **Classify** — Memories are grouped as **engineering**, **product**, or **system** so they stay easy to browse and filter.
 - **Recall** — Every new session, yours or a teammate's, recalls from the same store via semantic search.
 - **Curate** — bikky merges duplicates, fades stale facts, resolves contradictions, distills recurring patterns, and builds an entity graph over time.
 - **Compound** — Session 50 is dramatically better than session 1 because memory accumulates.
@@ -34,9 +34,8 @@ bikky gives your agent memory tools and runs a small background service after `b
 
 Subtypes keep recall precise without making setup harder:
 
-- **Engineering** — codebase maps, architecture decisions, infra topology, access patterns, operational procedures, troubleshooting gotchas, and conventions.
+- **Engineering** — codebase maps, architecture decisions, infra topology, access patterns, operational procedures, troubleshooting gotchas, conventions, preferences, person/ownership context, working agreements, and durable activity events.
 - **Product** — domain rules, product decisions, requirements, user workflows, roadmap items, success metrics, and market insights.
-- **Human** — preferences, person profiles, ownership notes, working agreements, and activity events.
 - **System** — session indexes, episodes, workstreams, and feedback signals.
 
 ---

--- a/packages/ui/app/e2e/memory-filters.spec.ts
+++ b/packages/ui/app/e2e/memory-filters.spec.ts
@@ -27,9 +27,8 @@ interface MockMemoryApiOptions {
 }
 
 const categoryCounts = {
-  engineering: 4,
+  engineering: 6,
   product: 3,
-  human: 2,
 };
 
 const subtypeCounts = {
@@ -169,7 +168,7 @@ test("Memory restores URL filter state and clears individual active filters", as
   const expectedUntil = new Date("2026-01-09T23:59:59").toISOString();
 
   await page.goto(
-    "/memory?category=product,human&memory_subtype=product_decision&entity=bikky-ui&usefulness=positive&since=2026-01-02&until=2026-01-09&sort=oldest",
+    "/memory?category=product,engineering&memory_subtype=product_decision&entity=bikky-ui&usefulness=positive&since=2026-01-02&until=2026-01-09&sort=oldest",
   );
 
   await expect(page.getByRole("combobox", { name: "Sort memories" })).toHaveValue("oldest");
@@ -178,7 +177,7 @@ test("Memory restores URL filter state and clears individual active filters", as
   await expect(page.getByLabel("From date")).toHaveValue("2026-01-02");
   await expect(page.getByLabel("Until date")).toHaveValue("2026-01-09");
   await expectRequest(captured, "/api/memory/browse", {
-    category: "product,human",
+    category: "product,engineering",
     memory_subtype: "product_decision",
     entity: "bikky-ui",
     usefulness: "positive",
@@ -190,7 +189,7 @@ test("Memory restores URL filter state and clears individual active filters", as
 
   await page.getByRole("button", { name: "Clear Category filter Product (3)" }).click();
   await expectRequest(captured, "/api/memory/browse", {
-    category: "human",
+    category: "engineering",
     memory_subtype: "product_decision",
     entity: "bikky-ui",
     usefulness: "positive",
@@ -202,7 +201,7 @@ test("Memory restores URL filter state and clears individual active filters", as
 
   await page.getByRole("button", { name: "Clear Subtype filter Product decision (2)" }).click();
   await expectRequest(captured, "/api/memory/browse", {
-    category: "human",
+    category: "engineering",
     memory_subtype: null,
     entity: "bikky-ui",
     usefulness: "positive",
@@ -214,7 +213,7 @@ test("Memory restores URL filter state and clears individual active filters", as
 
   await page.getByRole("button", { name: "Clear Entity filter bikky-ui" }).click();
   await expectRequest(captured, "/api/memory/browse", {
-    category: "human",
+    category: "engineering",
     memory_subtype: null,
     entity: null,
     usefulness: "positive",
@@ -226,7 +225,7 @@ test("Memory restores URL filter state and clears individual active filters", as
 
   await page.getByRole("button", { name: "Clear From filter 2026-01-02" }).click();
   await expectRequest(captured, "/api/memory/browse", {
-    category: "human",
+    category: "engineering",
     memory_subtype: null,
     entity: null,
     usefulness: "positive",
@@ -299,11 +298,11 @@ test("Memory shows empty and error states", async ({ page }) => {
   });
 
   failBrowse = true;
-  await page.goto("/memory?category=human");
+  await page.goto("/memory?category=engineering");
 
   await expect(page.getByText("Qdrant is unavailable")).toBeVisible();
   await expectRequest(captured, "/api/memory/browse", {
-    category: "human",
+    category: "engineering",
     destination: "all",
   });
 });

--- a/packages/ui/app/src/lib/format.ts
+++ b/packages/ui/app/src/lib/format.ts
@@ -21,7 +21,6 @@ export function truncate(str: string, max: number): string {
 export const CATEGORY_COLORS: Record<string, string> = {
   engineering: "blue",
   product: "indigo",
-  human: "pink",
   system: "amber",
   // Legacy facts may still carry pre-ontology category values.
   codebase: "blue",
@@ -30,11 +29,12 @@ export const CATEGORY_COLORS: Record<string, string> = {
   decisions: "purple",
   product_domain: "indigo",
   observations: "amber",
-  preferences: "green",
+  human: "blue",
+  preferences: "blue",
   projects: "cyan",
-  people: "pink",
+  people: "blue",
   observation: "amber",
-  team: "pink",
+  team: "blue",
 };
 
 export const KIND_COLORS: Record<string, string> = {

--- a/packages/ui/app/src/lib/ontology.ts
+++ b/packages/ui/app/src/lib/ontology.ts
@@ -11,9 +11,8 @@ export interface MemorySubtypeOption extends OntologyOption {
 }
 
 export const CATEGORY_OPTIONS: OntologyOption[] = [
-  { value: "engineering", label: "Engineering", description: "Codebase maps, architecture decisions, infrastructure topology, access, operations, troubleshooting, and conventions." },
+  { value: "engineering", label: "Engineering", description: "Codebase maps, architecture decisions, infrastructure topology, access, operations, troubleshooting, conventions, preferences, ownership, working agreements, and durable activity events." },
   { value: "product", label: "Product", description: "Domain rules, product decisions, requirements, user workflows, roadmap, success metrics, and market insight." },
-  { value: "human", label: "Human", description: "Preferences, people, ownership, working agreements, and durable actor-action activity events." },
   { value: "system", label: "System", description: "Bikky lifecycle memory: sessions, episodes, workstreams, recall/feedback/outcome telemetry, and rollups." },
 ];
 
@@ -145,7 +144,7 @@ export const MEMORY_SUBTYPE_OPTIONS: MemorySubtypeOption[] = [
     value: "person_profile",
     label: "Person profile",
     kind: "fact",
-    category: "human",
+    category: "engineering",
     description: "Durable role, expertise, team, or person context.",
     example: "Use for explicit people context that helps future collaboration.",
   },
@@ -153,7 +152,7 @@ export const MEMORY_SUBTYPE_OPTIONS: MemorySubtypeOption[] = [
     value: "ownership_note",
     label: "Ownership note",
     kind: "fact",
-    category: "human",
+    category: "engineering",
     description: "Owner, approver, escalation path, or accountability.",
     example: "Use for who owns or approves a project, component, or decision.",
   },
@@ -161,7 +160,7 @@ export const MEMORY_SUBTYPE_OPTIONS: MemorySubtypeOption[] = [
     value: "working_agreement",
     label: "Working agreement",
     kind: "fact",
-    category: "human",
+    category: "engineering",
     description: "Collaboration norm, operating rule, or approval expectation.",
     example: "Use for durable ways of working.",
   },
@@ -169,7 +168,7 @@ export const MEMORY_SUBTYPE_OPTIONS: MemorySubtypeOption[] = [
     value: "activity_event",
     label: "Activity event",
     kind: "fact",
-    category: "human",
+    category: "engineering",
     description: "Explicit actor-action-object event with durable project value.",
     example: "Use for state-changing actions like approvals, merges, releases, assignments, or decisions.",
   },
@@ -185,7 +184,7 @@ export const MEMORY_SUBTYPE_OPTIONS: MemorySubtypeOption[] = [
     value: "preference",
     label: "Preference",
     kind: "fact",
-    category: "human",
+    category: "engineering",
     description: "A user, team, or workspace preference about style, tooling, defaults, or workflow.",
     example: "Use for durable preferences that should shape future agent behavior.",
   },

--- a/packages/ui/app/src/pages/Graph.tsx
+++ b/packages/ui/app/src/pages/Graph.tsx
@@ -70,7 +70,6 @@ interface SharedResponse {
 const CATEGORY_HEX: Record<string, string> = {
   engineering: "#3b82f6",
   product: "#6366f1",
-  human: "#ec4899",
   system: "#f59e0b",
   // Legacy facts may still carry pre-ontology category values.
   codebase: "#3b82f6",
@@ -80,10 +79,11 @@ const CATEGORY_HEX: Record<string, string> = {
   product_domain: "#6366f1",
   observations: "#f59e0b",
   observation: "#f59e0b",
-  preferences: "#22c55e",
+  human: "#3b82f6",
+  preferences: "#3b82f6",
   projects: "#06b6d4",
-  people: "#ec4899",
-  team: "#ec4899",
+  people: "#3b82f6",
+  team: "#3b82f6",
 };
 
 const GRAPH_MAX_NODES = 75;
@@ -92,11 +92,10 @@ const GRAPH_SERVER_MIN_WEIGHT = 1;
 const MAX_SIMULATION_TICKS = 500;
 const SIMULATION_WARMUP_TICKS = 60;
 
-// Canonical four-category ontology shown in the legend.
+// Canonical category ontology shown in the legend.
 const LEGEND_CATEGORIES: Array<{ key: string; label: string }> = [
   { key: "engineering", label: "Engineering" },
   { key: "product", label: "Product" },
-  { key: "human", label: "Human" },
   { key: "system", label: "System" },
 ];
 

--- a/packages/ui/src/lib/qdrant.test.ts
+++ b/packages/ui/src/lib/qdrant.test.ts
@@ -72,7 +72,7 @@ describe("ui/lib/qdrant", () => {
     it("maps canonical category filters to legacy stored categories", () => {
       const f = buildFilter({ category: "engineering" });
       assert.deepEqual(f.must, [
-        { key: "category", match: { any: ["engineering", "codebase", "infrastructure", "operations", "decisions", "observations"] } },
+        { key: "category", match: { any: ["engineering", "codebase", "infrastructure", "operations", "decisions", "observations", "human", "people", "preferences", "team"] } },
       ]);
     });
 
@@ -92,7 +92,7 @@ describe("ui/lib/qdrant", () => {
       });
       assert.deepEqual(f.must, []);
       assert.deepEqual(f.should, [
-        { key: "category", match: { any: ["engineering", "codebase", "infrastructure", "operations", "decisions", "observations"] } },
+        { key: "category", match: { any: ["engineering", "codebase", "infrastructure", "operations", "decisions", "observations", "human", "people", "preferences", "team"] } },
         { key: "category", match: { any: ["product", "product_domain", "projects"] } },
         { key: "memory_subtype", match: { value: "codebase_map" } },
         { key: "memory_subtype", match: { value: "convention" } },

--- a/packages/ui/src/lib/qdrant.ts
+++ b/packages/ui/src/lib/qdrant.ts
@@ -99,9 +99,8 @@ const SOURCE_FILTER_ALIASES: Record<string, string[]> = {
 };
 
 const CATEGORY_FILTER_ALIASES: Record<string, string[]> = {
-  engineering: ["engineering", "codebase", "infrastructure", "operations", "decisions", "observations"],
+  engineering: ["engineering", "codebase", "infrastructure", "operations", "decisions", "observations", "human", "people", "preferences", "team"],
   product: ["product", "product_domain", "projects"],
-  human: ["human", "people", "preferences", "team"],
   system: ["system"],
 };
 

--- a/packages/ui/src/routes/memory.test.ts
+++ b/packages/ui/src/routes/memory.test.ts
@@ -248,7 +248,7 @@ describe("ui/routes/memory", () => {
       assert.deepEqual(search!.body.filter.should, [
         {
           key: "category",
-          match: { any: ["engineering", "codebase", "infrastructure", "operations", "decisions", "observations"] },
+          match: { any: ["engineering", "codebase", "infrastructure", "operations", "decisions", "observations", "human", "people", "preferences", "team"] },
         },
         {
           key: "memory_subtype",
@@ -517,7 +517,7 @@ describe("ui/routes/memory", () => {
       assert.deepEqual(scroll!.body.filter.must[0], { is_null: { key: "superseded_by" } });
       assert.deepEqual(scroll!.body.filter.must[1], {
         key: "category",
-        match: { any: ["engineering", "codebase", "infrastructure", "operations", "decisions", "observations"] },
+        match: { any: ["engineering", "codebase", "infrastructure", "operations", "decisions", "observations", "human", "people", "preferences", "team"] },
       });
     });
 
@@ -553,7 +553,7 @@ describe("ui/routes/memory", () => {
         { key: "entities", match: { value: "bikky" } },
       ]);
       assert.deepEqual(scroll!.body.filter.should, [
-        { key: "category", match: { any: ["engineering", "codebase", "infrastructure", "operations", "decisions", "observations"] } },
+        { key: "category", match: { any: ["engineering", "codebase", "infrastructure", "operations", "decisions", "observations", "human", "people", "preferences", "team"] } },
         { key: "category", match: { any: ["product", "product_domain", "projects"] } },
         { key: "memory_subtype", match: { value: "codebase_map" } },
         { key: "memory_subtype", match: { value: "convention" } },
@@ -937,7 +937,7 @@ describe("ui/routes/memory", () => {
             points: [
               sampleFact({ entities: ["a", "b"], category: "engineering" }),
               sampleFact({ entities: ["a", "c"], category: "product" }),
-              sampleFact({ entities: ["a", "d"], category: "human" }),
+              sampleFact({ entities: ["a", "d"], category: "engineering" }),
             ],
             next_page_offset: null,
           },
@@ -1098,7 +1098,7 @@ describe("ui/routes/memory", () => {
       assert.ok(engineeringCount);
       assert.deepEqual(engineeringCount!.body.filter.must, [
         { is_null: { key: "superseded_by" } },
-        { key: "category", match: { any: ["engineering", "codebase", "infrastructure", "operations", "decisions", "observations"] } },
+        { key: "category", match: { any: ["engineering", "codebase", "infrastructure", "operations", "decisions", "observations", "human", "people", "preferences", "team"] } },
         { key: "kind", match: { value: "fact" } },
         {
           should: [

--- a/packages/ui/src/routes/memory.ts
+++ b/packages/ui/src/routes/memory.ts
@@ -43,7 +43,6 @@ function clientFor(dest: { qdrant_url: string; qdrant_api_key: string | null; co
 const CATEGORY_VALUES = [
   "engineering",
   "product",
-  "human",
   "system",
 ] as const;
 

--- a/src/daemon/capture-policy.test.ts
+++ b/src/daemon/capture-policy.test.ts
@@ -44,7 +44,6 @@ describe("daemon/capture-policy", () => {
   it("maps categories to deterministic default fact subtypes", () => {
     assert.strictEqual(subtypeForCategory("engineering"), "codebase_map");
     assert.strictEqual(subtypeForCategory("product"), "domain_rule");
-    assert.strictEqual(subtypeForCategory("human"), "preference");
     assert.strictEqual(subtypeForCategory("system"), "codebase_map");
   });
 

--- a/src/daemon/capture-policy.ts
+++ b/src/daemon/capture-policy.ts
@@ -114,7 +114,6 @@ export const CAPTURE_KIND_SUBTYPES = {
 export const FACT_CATEGORY_TO_SUBTYPE: Record<Category, MemorySubtype> = {
   engineering: "codebase_map",
   product: "domain_rule",
-  human: "preference",
   system: "codebase_map",
 };
 

--- a/src/daemon/consolidation.ts
+++ b/src/daemon/consolidation.ts
@@ -483,7 +483,6 @@ const formatHealthReport = (report: HealthReport | null): string => {
 const CATEGORY_TO_HEADING: Record<string, (typeof ALLOWED_BRIEF_HEADINGS)[number]> = {
   engineering: "Engineering",
   product: "Product",
-  human: "Human",
   system: "System",
   // Legacy stored categories remain readable before any data migration.
   codebase: "Engineering",
@@ -494,9 +493,10 @@ const CATEGORY_TO_HEADING: Record<string, (typeof ALLOWED_BRIEF_HEADINGS)[number
   projects: "System",
   observation: "Engineering",
   observations: "Engineering",
-  preferences: "Human",
-  people: "Human",
-  team: "Human",
+  human: "Engineering",
+  preferences: "Engineering",
+  people: "Engineering",
+  team: "Engineering",
 };
 
 const generateMemoryBrief = async (_config: BikkyConfig): Promise<boolean> => {

--- a/src/daemon/extraction.test.ts
+++ b/src/daemon/extraction.test.ts
@@ -171,7 +171,8 @@ describe("daemon/extraction prompt", () => {
     assert.ok(!DEFAULT_EXTRACTION_PROMPT.includes("work or personal"));
     assert.ok(!DEFAULT_EXTRACTION_PROMPT.includes("Telegram"));
     assert.ok(!DEFAULT_EXTRACTION_PROMPT.includes("WhatsApp"));
-    assert.ok(DEFAULT_EXTRACTION_PROMPT.includes("engineering | product | human | system"));
+    assert.ok(DEFAULT_EXTRACTION_PROMPT.includes("engineering | product | system"));
+    assert.ok(!DEFAULT_EXTRACTION_PROMPT.includes("engineering | product | human | system"));
     assert.ok(DEFAULT_EXTRACTION_PROMPT.includes("product_decision"));
     assert.ok(DEFAULT_EXTRACTION_PROMPT.includes("activity_event"));
   });
@@ -189,8 +190,8 @@ describe("normalizeExtractedFact", () => {
     });
 
     assert.ok(fact);
-    assert.strictEqual(fact.category, "human");
-    assert.strictEqual(fact.memory_subtype, "preference");
+    assert.strictEqual(fact.category, "engineering");
+    assert.strictEqual(fact.memory_subtype, "person_profile");
     assert.deepStrictEqual(fact.entities, ["node", "npm-test"]);
   });
 
@@ -253,7 +254,7 @@ describe("normalizeExtractedFact", () => {
     });
 
     assert.ok(fact);
-    assert.strictEqual(fact.category, "human");
+    assert.strictEqual(fact.category, "engineering");
     assert.strictEqual(fact.memory_subtype, "activity_event");
     assert.strictEqual(fact.action_actor, "Saber");
     assert.strictEqual(fact.action_type, "merged");

--- a/src/daemon/extraction.ts
+++ b/src/daemon/extraction.ts
@@ -78,7 +78,7 @@ Every fact must pass at least one gate:
 
 ## Ontology
 - domain is the activity profile. For coding-agent captures use "software_engineering".
-- category is subject matter: engineering | product | human | system.
+- category is subject matter: engineering | product | system.
 - kind is object shape. For this prompt, emit only kind="fact".
 - memory_subtype must be one of:
   codebase_map | architecture_decision | infra_topology | access_pattern | operational_procedure | domain_rule | product_decision | product_requirement | user_workflow | roadmap_item | success_metric | market_insight | troubleshooting_gotcha | preference | person_profile | ownership_note | working_agreement | activity_event.
@@ -308,14 +308,14 @@ export const factQualitySignals = (fact: ExtractedFact): FactQualitySignals => {
   const isPreferenceLike = subtype === "preference" || subtype === "domain_rule" || subtype === "working_agreement";
   const isDecisionLike = subtype === "architecture_decision" || subtype === "product_decision" || subtype === "troubleshooting_gotcha";
   const isProductLike = subtype === "product_requirement" || subtype === "user_workflow" || subtype === "roadmap_item" || subtype === "success_metric" || subtype === "market_insight";
-  const isHumanLike = subtype === "person_profile" || subtype === "ownership_note" || subtype === "activity_event";
-  const shortUseful = wordCount >= 7 && wordCount <= 22 && (isPreferenceLike || isDecisionLike || isProductLike || isHumanLike) && (entities.length > 0 || durableAnchor);
+  const isCollaborationLike = subtype === "person_profile" || subtype === "ownership_note" || subtype === "activity_event";
+  const shortUseful = wordCount >= 7 && wordCount <= 22 && (isPreferenceLike || isDecisionLike || isProductLike || isCollaborationLike) && (entities.length > 0 || durableAnchor);
 
   let score = 0.25;
   if (wordCount >= 8) score += 0.1;
   if (wordCount >= 14) score += 0.1;
   if (durableAnchor) score += 0.25;
-  if (isPreferenceLike || isDecisionLike || isProductLike || isHumanLike) score += 0.15;
+  if (isPreferenceLike || isDecisionLike || isProductLike || isCollaborationLike) score += 0.15;
   if ((fact.confidence ?? 0) >= 0.75) score += 0.1;
   if ((fact.importance ?? 0) >= 0.7) score += 0.1;
   if (statusOnly) score -= 0.4;
@@ -343,7 +343,11 @@ const subtypeForRawCategoryHint = (rawCategory: string | null, category: string)
   if (hint.includes("infra")) return "infra_topology";
   if (hint.includes("operation") || hint.includes("runbook")) return "operational_procedure";
   if (hint.includes("decision")) return "architecture_decision";
-  if (hint.includes("people") || hint.includes("preference") || hint.includes("owner")) return "preference";
+  if (hint.includes("preference")) return "preference";
+  if (hint.includes("owner")) return "ownership_note";
+  if (hint.includes("agreement")) return "working_agreement";
+  if (hint.includes("activity") || hint.includes("actor")) return "activity_event";
+  if (hint.includes("people") || hint.includes("person") || hint.includes("team")) return "person_profile";
   if (hint.includes("product") || hint.includes("domain")) return "domain_rule";
   return subtypeForCategory(normalizeCategory(category));
 };

--- a/src/daemon/quality-rollups.test.ts
+++ b/src/daemon/quality-rollups.test.ts
@@ -108,7 +108,8 @@ describe("daemon/quality-rollups", () => {
         fact("fact-2", {
           repo: "bikky-dev/bikky",
           entities: ["bikky"],
-          last_reinforced_at: "2026-03-01T00:00:00.000Z",
+          confidence: 1,
+          last_reinforced_at: "2026-04-01T00:00:00.000Z",
         }),
       ],
       events: [

--- a/src/daemon/relations.ts
+++ b/src/daemon/relations.ts
@@ -365,7 +365,7 @@ const storeRelation = async (
 
   const id = await qdrant.storeFact({
     content,
-    category: "human",
+    category: "engineering",
     domain: DEFAULT_CAPTURE_CONTEXT.domain,
     kind: "relation",
     entities: [fromEntity, toEntity],

--- a/src/daemon/staleness.ts
+++ b/src/daemon/staleness.ts
@@ -33,7 +33,7 @@ const defaultDeps: StaleDeps = {
  */
 export const scanStaleFacts = async (config: BikkyConfig, deps: StaleDeps = defaultDeps): Promise<void> => {
   const threshold = config.daemon.staleness_threshold_days || 30;
-  const categories = ["engineering", "product", "human", "system"];
+  const categories = ["engineering", "product", "system"];
   const limit = 3;
 
   if (!deps.isReady()) {

--- a/src/mcp/helpers.test.ts
+++ b/src/mcp/helpers.test.ts
@@ -240,7 +240,7 @@ describe("computeEffectiveConfidence", () => {
     assert.ok(effective >= 0.45 && effective <= 0.55, `Expected ~0.5, got ${effective}`);
   });
 
-  it("different categories have different decay rates", () => {
+  it("different category and domain profiles have different decay rates", () => {
     const dayOffset = 86400000 * 90; // 90 days
     const pastDate = new Date(Date.now() - dayOffset).toISOString();
 
@@ -251,20 +251,21 @@ describe("computeEffectiveConfidence", () => {
       last_verified_at: undefined,
     });
 
-    const humanPayload = makePayload({
-      category: "human",
+    const engineeringPersonalPayload = makePayload({
+      category: "engineering",
+      domain: "personal_productivity",
       confidence: 0.9,
       last_reinforced_at: pastDate,
       last_verified_at: undefined,
     });
 
     const systemEffective = computeEffectiveConfidence(systemPayload);
-    const humanEffective = computeEffectiveConfidence(humanPayload);
+    const engineeringPersonalEffective = computeEffectiveConfidence(engineeringPersonalPayload);
 
-    // human context decays slower than system lifecycle context.
+    // Personal productivity preferences now live under Engineering and decay slower than system lifecycle context.
     assert.ok(
-      humanEffective > systemEffective,
-      `human (${humanEffective}) should decay slower than system (${systemEffective})`,
+      engineeringPersonalEffective > systemEffective,
+      `engineering personal productivity (${engineeringPersonalEffective}) should decay slower than system (${systemEffective})`,
     );
   });
 });

--- a/src/mcp/taxonomy.test.ts
+++ b/src/mcp/taxonomy.test.ts
@@ -47,7 +47,6 @@ describe("ontology values", () => {
     assert.deepStrictEqual(values, [
       "engineering",
       "product",
-      "human",
       "system",
     ]);
   });
@@ -157,7 +156,11 @@ describe("memory subtypes", () => {
     assert.strictEqual(defaultMemorySubtypeForKind("relation"), null);
     assert.strictEqual(categoryForMemorySubtype("architecture_decision"), "engineering");
     assert.strictEqual(categoryForMemorySubtype("product_decision"), "product");
-    assert.strictEqual(categoryForMemorySubtype("preference"), "human");
+    assert.strictEqual(categoryForMemorySubtype("preference"), "engineering");
+    assert.strictEqual(categoryForMemorySubtype("person_profile"), "engineering");
+    assert.strictEqual(categoryForMemorySubtype("ownership_note"), "engineering");
+    assert.strictEqual(categoryForMemorySubtype("working_agreement"), "engineering");
+    assert.strictEqual(categoryForMemorySubtype("activity_event"), "engineering");
     assert.strictEqual(categoryForMemorySubtype("session_index"), "system");
     assert.strictEqual(layerForMemorySubtype("workstream"), "workstream");
     assert.strictEqual(layerForMemorySubtype("episode"), "episode");
@@ -173,8 +176,9 @@ describe("normalization", () => {
     assert.strictEqual(normalizeCategory("Infrastructure"), "engineering");
     assert.strictEqual(normalizeCategory("infra-stuff"), "engineering");
     assert.strictEqual(normalizeCategory("product decision"), "product");
-    assert.strictEqual(normalizeCategory("owner"), "human");
-    assert.strictEqual(normalizeCategory("preferences"), "human");
+    assert.strictEqual(normalizeCategory("owner"), "engineering");
+    assert.strictEqual(normalizeCategory("preferences"), "engineering");
+    assert.strictEqual(normalizeCategory("human"), "engineering");
     assert.strictEqual(normalizeCategory("workstream"), "system");
     assert.strictEqual(normalizeCategory("something_random"), "engineering");
   });
@@ -214,10 +218,10 @@ describe("decay policy", () => {
   it("maps legacy category aliases into the four-category ontology", () => {
     assert.strictEqual(normalizeCategory("codebase"), "engineering");
     assert.strictEqual(normalizeCategory("product_domain"), "product");
-    assert.strictEqual(normalizeCategory("people"), "human");
+    assert.strictEqual(normalizeCategory("people"), "engineering");
     assert.strictEqual(normalizeCategory("observations"), "engineering");
     assert.strictEqual(getDecayHalfLife({ category: "observation", domain: "work" }), 120);
-    assert.strictEqual(getDecayHalfLife({ category: "team", domain: "personal" }), 180);
+    assert.strictEqual(getDecayHalfLife({ category: "team", domain: "personal" }), 120);
   });
 
   it("does not decay relation or telemetry objects", () => {

--- a/src/mcp/taxonomy.ts
+++ b/src/mcp/taxonomy.ts
@@ -26,14 +26,6 @@ export const CATEGORIES = {
       "Activation should be measured by whether agents successfully reuse recalled memory.",
     ],
   },
-  human: {
-    description:
-      "Human context: explicit preferences, people and roles, ownership, working agreements, and durable actor-action activity events.",
-    examples: [
-      "Saber prefers concise implementation plans before code changes.",
-      "Alex approved PR #85 for merge.",
-    ],
-  },
   system: {
     description:
       "System context: Bikky-owned lifecycle memory, session indexes, episodes, workstreams, recall/feedback/outcome telemetry, and aggregate rollups.",
@@ -59,7 +51,6 @@ export const DOMAINS = {
     defaultCategories: [
       "engineering",
       "product",
-      "human",
       "system",
     ] as const,
   },
@@ -68,7 +59,7 @@ export const DOMAINS = {
       "Product direction, positioning, roadmap tradeoffs, customer problems, metrics, and market learning.",
     defaultCategories: [
       "product",
-      "human",
+      "engineering",
       "system",
     ] as const,
   },
@@ -77,7 +68,7 @@ export const DOMAINS = {
       "Business process, vendors, finance, legal/admin operations, recurring procedures, and ownership.",
     defaultCategories: [
       "product",
-      "human",
+      "engineering",
       "system",
     ] as const,
   },
@@ -94,7 +85,7 @@ export const DOMAINS = {
     description:
       "Individual productivity, habits, planning preferences, reminders, and personal operating context.",
     defaultCategories: [
-      "human",
+      "engineering",
       "product",
       "system",
     ] as const,
@@ -230,11 +221,11 @@ export const MEMORY_SUBTYPE_DEFAULT_CATEGORY = {
   success_metric: "product",
   market_insight: "product",
   troubleshooting_gotcha: "engineering",
-  preference: "human",
-  person_profile: "human",
-  ownership_note: "human",
-  working_agreement: "human",
-  activity_event: "human",
+  preference: "engineering",
+  person_profile: "engineering",
+  ownership_note: "engineering",
+  working_agreement: "engineering",
+  activity_event: "engineering",
   session_index: "system",
   episode: "system",
   workstream: "system",
@@ -311,20 +302,19 @@ export const DECAY_HALF_LIFE: Record<string, number> = {
   // Software-engineering defaults.
   "engineering.software_engineering": 120,
   "product.software_engineering": 120,
-  "human.software_engineering": 180,
   "system.software_engineering": 45,
 
   // Other domain profiles.
+  "engineering.product_strategy": 180,
   "product.product_strategy": 180,
-  "human.product_strategy": 180,
   "system.product_strategy": 60,
+  "engineering.business_operations": 180,
   "product.business_operations": 120,
-  "human.business_operations": 180,
   "system.business_operations": 90,
   "product.research": 120,
   "engineering.research": 120,
   "system.research": 90,
-  "human.personal_productivity": 180,
+  "engineering.personal_productivity": 180,
   "product.personal_productivity": 90,
   "system.personal_productivity": 45,
 
@@ -433,17 +423,6 @@ export function normalizeCategory(category: string | null | undefined): Category
     normalized === "projects"
   ) return "product";
   if (
-    normalized.includes("human") ||
-    normalized.includes("people") ||
-    normalized.includes("person") ||
-    normalized.includes("owner") ||
-    normalized.includes("team") ||
-    normalized.includes("preference") ||
-    normalized.includes("agreement") ||
-    normalized.includes("activity") ||
-    normalized.includes("actor")
-  ) return "human";
-  if (
     normalized.includes("system") ||
     normalized.includes("session") ||
     normalized.includes("episode") ||
@@ -462,7 +441,16 @@ export function normalizeCategory(category: string | null | undefined): Category
     normalized.includes("code") ||
     normalized.includes("architecture") ||
     normalized.includes("troubleshoot") ||
-    normalized.includes("observation")
+    normalized.includes("observation") ||
+    normalized.includes("human") ||
+    normalized.includes("people") ||
+    normalized.includes("person") ||
+    normalized.includes("owner") ||
+    normalized.includes("team") ||
+    normalized.includes("preference") ||
+    normalized.includes("agreement") ||
+    normalized.includes("activity") ||
+    normalized.includes("actor")
   ) return "engineering";
   return DEFAULT_CATEGORY;
 }
@@ -615,15 +603,6 @@ export function getDecayHalfLife(input: {
     rawCategory.includes("market") ||
     rawCategory.includes("customer") ||
     rawCategory === "projects" ||
-    rawCategory.includes("human") ||
-    rawCategory.includes("people") ||
-    rawCategory.includes("person") ||
-    rawCategory.includes("owner") ||
-    rawCategory.includes("team") ||
-    rawCategory.includes("preference") ||
-    rawCategory.includes("agreement") ||
-    rawCategory.includes("activity") ||
-    rawCategory.includes("actor") ||
     rawCategory.includes("system") ||
     rawCategory.includes("session") ||
     rawCategory.includes("episode") ||
@@ -640,7 +619,16 @@ export function getDecayHalfLife(input: {
     rawCategory.includes("code") ||
     rawCategory.includes("architecture") ||
     rawCategory.includes("troubleshoot") ||
-    rawCategory.includes("observation");
+    rawCategory.includes("observation") ||
+    rawCategory.includes("human") ||
+    rawCategory.includes("people") ||
+    rawCategory.includes("person") ||
+    rawCategory.includes("owner") ||
+    rawCategory.includes("team") ||
+    rawCategory.includes("preference") ||
+    rawCategory.includes("agreement") ||
+    rawCategory.includes("activity") ||
+    rawCategory.includes("actor");
   if (categoryWasProvided && !categoryIsKnown) {
     return DECAY_DEFAULT_HALF_LIFE;
   }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -424,9 +424,8 @@ function buildMemoryNudge(): string | null {
   // session typically produces. The agent picks the best fit.
   return `🧠 Memory nudge: No memory_store calls in ${mins} minutes. ` +
     "Reflect on what's worth persisting:\n" +
-    "  • engineering — codebase maps, architecture, infra, ops, troubleshooting?\n" +
+    "  • engineering — codebase maps, architecture, infra, ops, troubleshooting, preferences, ownership, working agreements, activity events?\n" +
     "  • product — requirements, decisions, workflows, roadmap, metrics, market insight?\n" +
-    "  • human — preferences, owners, working agreements, durable activity events?\n" +
     "  • system — session, episode, workstream, or quality-rollup memory?\n" +
     "If yes, call memory_store now so future sessions inherit the knowledge.";
 }
@@ -2392,7 +2391,7 @@ export function registerTools(mcp: McpServer): void {
         try {
           const staleThreshold = new Date(Date.now() - STALENESS_DAYS * 86400000).toISOString();
           const staleFilter: QdrantFilter = { must: [] };
-          staleFilter.must.push({ key: "category", match: { any: ["engineering", "product", "human", "system"] } });
+          staleFilter.must.push({ key: "category", match: { any: ["engineering", "product", "system"] } });
           staleFilter.should = [
             { key: "last_reinforced_at", range: { lte: staleThreshold } },
             { is_null: { key: "last_reinforced_at" } },
@@ -2431,10 +2430,9 @@ export function registerTools(mcp: McpServer): void {
 
       sections.push(
         "🔍 Reflect: think about the LAST 10 minutes of work and answer in your head:\n" +
-        "  1. Did you touch engineering context: code, infra, ops, access, troubleshooting, or conventions?\n" +
+        "  1. Did you touch engineering context: code, infra, ops, access, troubleshooting, conventions, preferences, ownership, working agreements, or durable activity events?\n" +
         "  2. Did you capture product context: a requirement, decision, workflow, roadmap item, metric, or market insight?\n" +
-        "  3. Did you learn human context: a preference, owner, working agreement, person profile, or durable activity event?\n" +
-        "  4. Did the work produce system context: session, episode, workstream, recall, feedback, outcome, or rollup state?\n" +
+        "  3. Did the work produce system context: session, episode, workstream, recall, feedback, outcome, or rollup state?\n" +
         "If any answer is yes, call memory_store now — one atomic fact per item, with category/domain/entities.",
       );
 

--- a/src/prompts/brief.ts
+++ b/src/prompts/brief.ts
@@ -15,7 +15,6 @@ export const BRIEF_PROMPT_DESCRIPTOR: PromptDescriptor = {
 const ALLOWED_HEADINGS = [
   "Engineering",
   "Product",
-  "Human",
   "System",
 ] as const;
 

--- a/src/prompts/extraction.ts
+++ b/src/prompts/extraction.ts
@@ -21,13 +21,18 @@ export const EXTRACTION_PROMPT_DESCRIPTOR: PromptDescriptor = {
 const SUBTYPE_REASONING = `## Subtype reasoning (think step-by-step BEFORE picking memory_subtype)
 For each candidate fact, walk these four top-level categories first, then pick the most concrete memory_subtype:
 
-  ENGINEERING — how the software is built and operated:
+  ENGINEERING — how the software is built and operated, including collaboration preferences:
     codebase_map      → file paths, symbols, modules, repo structure
     architecture_decision → engineering/system design choice with rationale
     infra_topology    → clusters, services, queues, datastores, regions
     access_pattern    → roles, permissions, auth flows, approval gates
     operational_procedure  → runbook / deploy / rollout / maintenance / incident steps
     troubleshooting_gotcha → stable failure mode, debugging quirk, surprising behaviour
+    preference             → explicit style, tooling, or interaction preference
+    person_profile         → durable role, expertise, person/team context
+    ownership_note         → owner, approver, escalation path, accountability
+    working_agreement      → collaboration norm or operating rule
+    activity_event         → explicit actor-action-object event with durable project value
     convention             → produced by distillation, not this extraction prompt
 
   PRODUCT — what the product should be and how it succeeds:
@@ -38,13 +43,6 @@ For each candidate fact, walk these four top-level categories first, then pick t
     roadmap_item           → planned/deferred work, priority, release theme
     success_metric         → KPI, adoption/retention/quality metric, evaluation target
     market_insight         → audience, customer/community feedback, competitor/GTM insight
-
-  HUMAN — durable people, preferences, and collaboration context:
-    preference             → explicit style, tooling, or interaction preference
-    person_profile         → durable role, expertise, person/team context
-    ownership_note         → owner, approver, escalation path, accountability
-    working_agreement      → collaboration norm or operating rule
-    activity_event         → explicit actor-action-object event with durable project value
 
 Disambiguation rules (apply in order; first match wins):
   R1. If the fact describes a *failure* or *workaround* → troubleshooting_gotcha (NOT operational_procedure).
@@ -72,7 +70,7 @@ Example 2 — codebase vs infra:
 Example 3 — domain_rule vs preference:
   TEXT: "I prefer kebab-case branch names; it's just my style."
   → memory_subtype: preference (R6: 'I prefer' + 'my style')
-  → subtype_reason: "Personal style → Human → R6 wins → preference."
+  → subtype_reason: "Personal style → Engineering → R6 wins → preference."
 
 Example 4 — product vs engineering decision:
   TEXT: "We decided the memory page should show categories and subtype chips directly because a sub-tab layer made the ontology feel confusing."
@@ -82,7 +80,7 @@ Example 4 — product vs engineering decision:
 Example 5 — durable activity event:
   TEXT: "Saber merged PR #85 after approving the subtype UX copy changes."
   → memory_subtype: activity_event (R7: actor + durable state-changing action + object)
-  → subtype_reason: "Actor-action-object event tied to a PR → Human → R7 wins → activity_event."`;
+  → subtype_reason: "Actor-action-object event tied to a PR → Engineering → R7 wins → activity_event."`;
 
 const SELF_JUDGMENT = `## Self-judgment (think step-by-step BEFORE emitting each fact)
 
@@ -237,7 +235,7 @@ If nothing passes the quality gate, return: {"facts": []}`;
 const buildSystem = (): string => {
   return [
     "<role>",
-    "You are Bikky's knowledge-extraction agent for open-source coding agents. You read session transcripts and emit durable Engineering, Product, Human, and System-aligned facts that help a future agent continue useful work.",
+    "You are Bikky's knowledge-extraction agent for open-source coding agents. You read session transcripts and emit durable Engineering, Product, and System-aligned facts that help a future agent continue useful work.",
     "</role>",
     "",
     "<task>",

--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -118,8 +118,8 @@ test("renderPrompt: distill renders with summaries", () => {
 
 test("renderPrompt: contradiction renders", () => {
   const out = renderPrompt("contradiction", {
-    newFact: { content: "user lives in Berlin", category: "human" },
-    candidates: [{ id: "f1", content: "user lives in Paris", category: "human", score: 0.91 }],
+    newFact: { content: "user lives in Berlin", category: "engineering" },
+    candidates: [{ id: "f1", content: "user lives in Paris", category: "engineering", score: 0.91 }],
   });
   assert.match(out.promptName, /^contradiction@/);
   assert.ok(out.messages[1].content.includes("Berlin"));

--- a/tasks/008-remove-human-category/artifacts/backfill-human-category.mjs
+++ b/tasks/008-remove-human-category/artifacts/backfill-human-category.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const LEGACY_CATEGORIES = ["human", "preferences", "people", "team"];
+const MIGRATION_ID = "008-remove-human-category";
+const SCROLL_LIMIT = 256;
+const APPLY_CHUNK_SIZE = 100;
+
+const args = new Set(process.argv.slice(2));
+const apply = args.has("--apply");
+const configPath = valueArg("--config") ?? process.env.BIKKY_CONFIG ?? join(homedir(), ".bikky", "config.json");
+const destinationFilter = valueArg("--destination");
+
+function valueArg(name) {
+  const argv = process.argv.slice(2);
+  const index = argv.indexOf(name);
+  if (index === -1) return null;
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+  return value;
+}
+
+function destinationsFromConfig(config) {
+  const destinations = Array.isArray(config.destinations) && config.destinations.length > 0
+    ? config.destinations
+    : [{
+        name: "default",
+        qdrant_url: config.qdrant_url,
+        qdrant_api_key: config.qdrant_api_key,
+        collection: config.collection ?? "bikky",
+      }];
+
+  return destinations
+    .map((destination) => ({
+      name: destination.name ?? "default",
+      qdrantUrl: String(destination.qdrant_url ?? "").replace(/\/+$/, ""),
+      qdrantApiKey: destination.qdrant_api_key ?? null,
+      collection: destination.collection ?? config.collection ?? "bikky",
+    }))
+    .filter((destination) => destination.qdrantUrl.length > 0)
+    .filter((destination) => !destinationFilter || destination.name === destinationFilter);
+}
+
+async function qdrantRequest(destination, method, path, body) {
+  const headers = { "Content-Type": "application/json" };
+  if (destination.qdrantApiKey) headers["api-key"] = destination.qdrantApiKey;
+  const response = await fetch(`${destination.qdrantUrl}/collections/${destination.collection}${path}`, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`${destination.name}/${destination.collection} ${method} ${path} failed (${response.status}): ${text.slice(0, 300)}`);
+  }
+  return response.json();
+}
+
+async function scrollLegacyCategory(destination, category) {
+  const points = [];
+  let offset = null;
+  do {
+    const body = {
+      filter: { must: [{ key: "category", match: { value: category } }] },
+      limit: SCROLL_LIMIT,
+      with_payload: ["category", "memory_subtype", "superseded_by"],
+    };
+    if (offset) body.offset = offset;
+    const response = await qdrantRequest(destination, "POST", "/points/scroll", body);
+    points.push(...(response.result?.points ?? []));
+    offset = response.result?.next_page_offset ?? null;
+  } while (offset);
+  return points;
+}
+
+async function setPayload(destination, ids, payload) {
+  for (let i = 0; i < ids.length; i += APPLY_CHUNK_SIZE) {
+    const chunk = ids.slice(i, i + APPLY_CHUNK_SIZE);
+    await qdrantRequest(destination, "POST", "/points/payload", {
+      points: chunk,
+      payload,
+    });
+  }
+}
+
+const config = JSON.parse(await readFile(configPath, "utf8"));
+const destinations = destinationsFromConfig(config);
+if (destinations.length === 0) {
+  throw new Error(destinationFilter
+    ? `No configured destination named ${destinationFilter}`
+    : "No configured Qdrant destinations found");
+}
+
+console.log(`${apply ? "APPLY" : "DRY RUN"} ${MIGRATION_ID}`);
+console.log(`config=${configPath}`);
+
+let total = 0;
+for (const destination of destinations) {
+  const byCategory = new Map();
+  const bySubtype = new Map();
+
+  for (const category of LEGACY_CATEGORIES) {
+    const points = await scrollLegacyCategory(destination, category);
+    if (points.length === 0) continue;
+    byCategory.set(category, points);
+    total += points.length;
+    for (const point of points) {
+      const subtype = point.payload?.memory_subtype ?? "(missing)";
+      bySubtype.set(subtype, (bySubtype.get(subtype) ?? 0) + 1);
+    }
+  }
+
+  const destinationTotal = Array.from(byCategory.values()).reduce((sum, points) => sum + points.length, 0);
+  console.log(`${destination.name}/${destination.collection}: ${destinationTotal} point(s)`);
+  for (const [category, points] of byCategory.entries()) {
+    console.log(`  category=${category}: ${points.length}`);
+  }
+  if (bySubtype.size > 0) {
+    console.log(`  subtypes: ${Array.from(bySubtype.entries()).map(([subtype, count]) => `${subtype}=${count}`).join(", ")}`);
+  }
+
+  if (!apply || destinationTotal === 0) continue;
+
+  const migratedAt = new Date().toISOString();
+  for (const [category, points] of byCategory.entries()) {
+    await setPayload(destination, points.map((point) => point.id), {
+      category: "engineering",
+      taxonomy_migration: MIGRATION_ID,
+      taxonomy_previous_category: category,
+      taxonomy_migrated_at: migratedAt,
+    });
+  }
+  console.log(`  applied: category=engineering`);
+}
+
+if (!apply) {
+  console.log(`Dry run only. Re-run with --apply after explicit approval to update ${total} point(s).`);
+}

--- a/tasks/008-remove-human-category/execution-log.md
+++ b/tasks/008-remove-human-category/execution-log.md
@@ -1,0 +1,28 @@
+## Status
+
+| Phase | Status | Next step | Blockers |
+| --- | --- | --- | --- |
+| implement | in-progress | Apply code, docs, tests, and dry-run backfill script changes on `feat/remove-human-category-167` | Data backfill apply still requires separate user approval |
+
+## Implementation Progress
+
+- [x] Research existing taxonomy surfaces
+- [x] Write plan and get approval
+- [x] Create GitHub issue
+- [ ] Implement approved code/docs/tests changes
+- [ ] Prepare and approve data backfill
+- [ ] Verify, commit, and open PR
+
+## Timeline
+
+- 2026-05-12 19:18 AEST — User requested moving `Preferences` to `Engineering` and removing the `Human` category from code, logic, documentation, and existing data.
+- 2026-05-12 19:20 AEST — User confirmed scope includes a data migration/backfill for existing memories.
+- 2026-05-12 19:21 AEST — Created task folder `tasks/008-remove-human-category/` and started research.
+- 2026-05-12 19:25 AEST — User confirmed all former Human subtypes should move to Engineering.
+- 2026-05-12 19:28 AEST — Counted configured Qdrant data read-only: `perso/bikky` has 155 `human` records; `work/bikky` has 157 `human` records.
+- 2026-05-12 19:32 AEST — Wrote research and implementation plan.
+- 2026-05-12 19:34 AEST — User approved implementation plan.
+- 2026-05-12 19:35 AEST — Created GitHub issue #167 and branch `feat/remove-human-category-167`.
+- 2026-05-12 19:44 AEST — Implemented taxonomy, daemon, UI, docs, tests, and dry-run backfill script changes.
+- 2026-05-12 19:47 AEST — Verification passed: `npm test`, `cd packages/ui && npm test`, `cd packages/ui && npm run test:e2e`, `cd packages/ui && npm run build`, `npm run check`.
+- 2026-05-12 19:48 AEST — Backfill dry-run reported 312 target points: 155 in `perso/bikky`, 157 in `work/bikky`; no data mutations performed.

--- a/tasks/008-remove-human-category/execution-log.md
+++ b/tasks/008-remove-human-category/execution-log.md
@@ -26,3 +26,4 @@
 - 2026-05-12 19:44 AEST — Implemented taxonomy, daemon, UI, docs, tests, and dry-run backfill script changes.
 - 2026-05-12 19:47 AEST — Verification passed: `npm test`, `cd packages/ui && npm test`, `cd packages/ui && npm run test:e2e`, `cd packages/ui && npm run build`, `npm run check`.
 - 2026-05-12 19:48 AEST — Backfill dry-run reported 312 target points: 155 in `perso/bikky`, 157 in `work/bikky`; no data mutations performed.
+- 2026-05-12 19:54 AEST — User approved Qdrant backfill apply. Applied migration to 312 target points, then verified a follow-up dry-run found 0 remaining target points.

--- a/tasks/008-remove-human-category/execution-log.md
+++ b/tasks/008-remove-human-category/execution-log.md
@@ -27,3 +27,4 @@
 - 2026-05-12 19:47 AEST — Verification passed: `npm test`, `cd packages/ui && npm test`, `cd packages/ui && npm run test:e2e`, `cd packages/ui && npm run build`, `npm run check`.
 - 2026-05-12 19:48 AEST — Backfill dry-run reported 312 target points: 155 in `perso/bikky`, 157 in `work/bikky`; no data mutations performed.
 - 2026-05-12 19:54 AEST — User approved Qdrant backfill apply. Applied migration to 312 target points, then verified a follow-up dry-run found 0 remaining target points.
+- 2026-05-12 19:59 AEST — Legacy running MCP tooling created 2 additional `activity_event` points with `category=human` while recording the outcome. Re-ran the approved backfill guard, migrated those 2 points to Engineering, and verified the final dry-run found 0 remaining target points.

--- a/tasks/008-remove-human-category/plan.md
+++ b/tasks/008-remove-human-category/plan.md
@@ -1,0 +1,59 @@
+# Plan: remove Human category
+
+## Problem
+
+The memory ontology currently exposes `human` as a first-class category. The requested taxonomy change is to remove that category completely, move `Preferences` to `Engineering`, and reclassify all former Human subtypes as Engineering in code, UI, docs, tests, and existing stored records.
+
+## Proposed changes
+
+1. Update the canonical taxonomy in `src/mcp/taxonomy.ts`.
+   - Remove `human` from `CATEGORIES`.
+   - Remove `human` from every domain `defaultCategories`.
+   - Map `preference`, `person_profile`, `ownership_note`, `working_agreement`, and `activity_event` to `engineering`.
+   - Replace `human.*` decay policy entries with `engineering.*` equivalents or rely on engineering defaults where appropriate.
+   - Change legacy alias normalization so `human`, `people`, `person`, `owner`, `team`, `preference`, `agreement`, `activity`, and `actor` normalize to `engineering`.
+
+2. Update daemon and prompt logic.
+   - `src/daemon/capture-policy.ts`: remove the `human` default category mapping.
+   - `src/daemon/extraction.ts`: make fallback hints for people/preferences/owners resolve to Engineering-backed subtypes.
+   - `src/prompts/extraction.ts` and daemon default prompt text: remove Human as a top-level category and describe preferences/people/ownership/agreements/activity events under Engineering.
+   - `src/prompts/brief.ts` and `src/daemon/consolidation.ts`: remove the Human heading/category and map legacy human-like categories to Engineering.
+   - `src/daemon/staleness.ts` and `src/mcp/tools.ts`: remove `human` from category filters and heartbeat copy.
+   - `src/daemon/relations.ts`: store inferred relation objects under Engineering instead of Human.
+
+3. Update UI/API ontology and filters.
+   - `packages/ui/src/routes/memory.ts`: remove `human` from category stats/options.
+   - `packages/ui/src/lib/qdrant.ts`: route human-like legacy aliases to Engineering filters or remove the Human filter alias.
+   - `packages/ui/app/src/lib/ontology.ts`: remove Human category option and put former Human subtypes under Engineering.
+   - `packages/ui/app/src/lib/format.ts` and `packages/ui/app/src/pages/Graph.tsx`: remove canonical Human colors/legend and map legacy human-like categories to Engineering colors.
+   - Update Playwright tests to use Engineering/Product only.
+
+4. Update tests.
+   - Core tests: `src/mcp/taxonomy.test.ts`, `src/daemon/capture-policy.test.ts`, `src/daemon/extraction.test.ts`, `src/mcp/helpers.test.ts`, `src/render.test.ts`.
+   - UI route and E2E tests: `packages/ui/src/routes/memory.test.ts`, `packages/ui/app/e2e/memory-filters.spec.ts`.
+
+5. Update docs.
+   - `README.md`: replace the four-category explanation with Engineering/Product/System and mention preferences under Engineering.
+   - Update any category-specific docs found during implementation.
+   - Leave non-category uses of "human" alone, such as "human-readable", origin identity, or review lifecycle wording.
+
+6. Add a dry-run-first backfill script.
+   - Create `tasks/008-remove-human-category/artifacts/backfill-human-category.mjs`.
+   - Default mode: dry-run, no mutations.
+   - Apply mode: requires `--apply` and updates matching Qdrant points to `category: "engineering"` for configured destinations.
+   - Include audit metadata such as `migration: "008-remove-human-category"` and the previous category.
+
+7. Verification.
+   - Run root checks: `npm test`.
+   - Run UI checks: `cd packages/ui && npm test && npm run test:e2e && npm run build`.
+   - Run the backfill script in dry-run mode and verify it reports the expected current counts.
+   - After explicit user approval, run `--apply`, then re-run read-only counts to verify no `category=human` remains in configured destinations.
+
+## Scope lock
+
+- In scope: taxonomy/category logic, prompts, UI category presentation, tests, docs, and a safe Qdrant category backfill.
+- Out of scope: unrelated provenance wording, broad refactors, changing domain names such as `personal_productivity`, changing source/provenance concepts, or removing ordinary non-category uses of the word "human".
+
+## Approval needed before implementation
+
+Approve this plan to start implementation. A separate explicit approval will still be required before running the data-mutating Qdrant backfill with `--apply`.

--- a/tasks/008-remove-human-category/research.md
+++ b/tasks/008-remove-human-category/research.md
@@ -1,0 +1,86 @@
+# Research: remove Human category
+
+## User intent
+
+Remove `human` as a supported memory category everywhere. Move all former `human` subtypes to `engineering`, including `preference`, `person_profile`, `ownership_note`, `working_agreement`, and `activity_event`. Include an existing-data backfill/migration.
+
+## Current taxonomy model
+
+- Canonical categories live in `src/mcp/taxonomy.ts` as `engineering`, `product`, `human`, and `system`.
+- `Category` is derived from `keyof typeof CATEGORIES`, so removing `human` updates MCP schema enum values, category descriptions, prompt rendering, and validation.
+- `MEMORY_SUBTYPE_DEFAULT_CATEGORY` currently maps:
+  - `preference` -> `human`
+  - `person_profile` -> `human`
+  - `ownership_note` -> `human`
+  - `working_agreement` -> `human`
+  - `activity_event` -> `human`
+- `normalizeCategory()` currently maps aliases such as `human`, `people`, `person`, `owner`, `team`, `preference`, `agreement`, `activity`, and `actor` to `human`.
+- `DECAY_HALF_LIFE` includes `human.*` policies; tests rely on human decaying slower than system.
+
+## Code and logic surfaces
+
+- Core taxonomy and MCP schema:
+  - `src/mcp/taxonomy.ts`
+  - `src/mcp/taxonomy.test.ts`
+  - `src/mcp/tools.ts`
+- Daemon capture/extraction:
+  - `src/daemon/capture-policy.ts`
+  - `src/daemon/capture-policy.test.ts`
+  - `src/daemon/extraction.ts`
+  - `src/daemon/extraction.test.ts`
+  - `src/prompts/extraction.ts`
+  - `src/prompts/brief.ts`
+  - `src/daemon/staleness.ts`
+  - `src/daemon/consolidation.ts`
+  - `src/daemon/relations.ts`
+- UI API and frontend:
+  - `packages/ui/src/routes/memory.ts`
+  - `packages/ui/src/lib/qdrant.ts`
+  - `packages/ui/app/src/lib/ontology.ts`
+  - `packages/ui/app/src/lib/format.ts`
+  - `packages/ui/app/src/pages/Graph.tsx`
+  - `packages/ui/app/e2e/memory-filters.spec.ts`
+  - related route/frontend tests
+- Docs:
+  - `README.md`
+  - potentially `docs/configuration.md` only where it discusses ontology/category language; ordinary phrases such as "human-readable" or origin user identity are not category references and can remain.
+
+## Existing data impact
+
+Read-only counts from configured Qdrant destinations:
+
+| Destination | Collection | `human` total | `human` active | `preference` subtype | legacy `preferences` category | legacy `people`/`team` categories |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| `perso` | `bikky` | 155 | 145 | 3 | 0 | 0 |
+| `work` | `bikky` | 157 | 146 | 2 | 0 | 0 |
+
+Subtype breakdown for `category=human`:
+
+| Destination | `preference` | `person_profile` | `ownership_note` | `working_agreement` | `activity_event` | missing subtype |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `perso` | 3 | 0 | 4 | 8 | 137 | 3 |
+| `work` | 2 | 0 | 2 | 8 | 144 | 1 |
+
+The backfill should update at least all `category=human` records to `category=engineering`. It should also handle legacy category aliases defensively (`preferences`, `people`, `team`) even though the current count is zero.
+
+The dry-run script found 312 total target records:
+
+- `perso/bikky`: 155 points.
+- `work/bikky`: 157 points.
+
+## Constraints and risks
+
+- Removing `human` from the canonical category enum will break tests and any callers still passing `category: "human"`. That is intended, but alias normalization should preserve compatibility by mapping old human-like category inputs to `engineering`.
+- Existing Qdrant data must be mutated only after explicit user approval. The migration must support dry-run first.
+- It is not necessary or desirable to remove every plain-English use of "human"; terms like "human-readable", "human identity", or "human-confirmed" are not the category and should remain unless directly tied to ontology/category docs.
+- Existing untracked task folder `tasks/007-notion-memory-plan-update/` predates this work and should not be modified or reverted.
+
+## Proposed migration/backfill behavior
+
+- Add an idempotent migration script that:
+  - reads configured destinations from `~/.bikky/config.json`;
+  - scrolls for records whose `category` is `human`, `preferences`, `people`, or `team`;
+  - groups matching point IDs by destination;
+  - prints a dry-run summary by destination/category/subtype;
+  - with an explicit `--apply`, calls Qdrant `points/payload` to set `category: "engineering"` and update an audit metadata marker.
+- Do not run `--apply` until the user approves the exact operation and target destinations.


### PR DESCRIPTION
## Summary
- remove Human as a canonical memory category across taxonomy, daemon prompts, UI filters, graph/list formatting, docs, and tests
- move former Human subtypes (preferences, person profile, ownership notes, working agreements, activity events) under Engineering
- add dry-run-first Qdrant backfill script for existing legacy Human-category records

## Data backfill
- dry-run found 312 target points: 155 in `perso/bikky`, 157 in `work/bikky`
- after explicit approval, applied the backfill to set target point categories to `engineering` with previous-category migration metadata
- follow-up dry-run found 0 remaining target points
- a later guard pass caught 2 additional legacy-category points emitted by the still-running old MCP process, migrated them too, and the final dry-run again found 0 remaining target points

## Validation
- npm test
- npm run check
- cd packages/ui && npm test
- cd packages/ui && npm run test:e2e
- cd packages/ui && npm run build
- node tasks/008-remove-human-category/artifacts/backfill-human-category.mjs (dry-run before and after apply)

Fixes #167