### PR TITLE
Prepare bikky 0.4.5 routing fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 <p align="center"><b>Persistent memory for AI coding agents — built for teams and multi-agent engineering workflows.</b></p>
 
+bikky provides long-term memory for MCP-capable AI coding agents. It exposes memory tools over the Model Context Protocol (MCP), stores facts in Qdrant, and can run a local daemon that extracts durable facts from supported transcript sources. Teams can share memory across tools, repos, and engineers without treating chat history or closed PRs as the source of truth.
+
 <p align="center">
   <img src="https://raw.githubusercontent.com/bikky-dev/bikky/main/docs/diagrams/team-memory.svg" alt="Memory — facts flow from individual sessions into a self-curating knowledge store shared across your team" width="720" />
 </p>
 
 <p align="center"><i>Selected knowledge flows from supported sessions into a store that curates itself over time — deduplicating, distilling, and decaying stale facts — so future sessions can start with more context.</i></p>
-
-bikky provides long-term memory for MCP-capable AI coding agents. It exposes memory tools over the Model Context Protocol (MCP), stores facts in Qdrant, and can run a local daemon that extracts durable facts from supported transcript sources. Teams can share memory across tools, repos, and engineers without treating chat history or closed PRs as the source of truth.
 
 ### Who it's for
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bikky",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bikky",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bikky",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Shared memory for AI coding sessions — MCP server + background daemon",
   "type": "module",
   "license": "AGPL-3.0-or-later",

--- a/src/daemon/qdrant.test.ts
+++ b/src/daemon/qdrant.test.ts
@@ -464,6 +464,75 @@ describe("daemon/qdrant", () => {
       assert.ok(upsertUrls[0]?.startsWith("https://perso-qdrant.example.com:6333/collections/perso-memory/points"));
     });
 
+    it("does not route stored facts by provenance agent text", async () => {
+      const upsertUrls: string[] = [];
+
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const body = init?.body ? JSON.parse(String(init.body)) : null;
+        if (url.includes("/v1/embeddings")) {
+          return new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2, 0.3] }] }), { status: 200 });
+        }
+        if (init?.method === "PUT" && url.includes("/collections/")) {
+          assert.ok(body?.points, "expected Qdrant upsert points");
+          upsertUrls.push(url);
+        }
+        return new Response(JSON.stringify({ result: {} }), { status: 200 });
+      }) as typeof fetch;
+
+      saveConfig({
+        ...CONFIG_DEFAULTS,
+        qdrant_url: null,
+        qdrant_api_key: null,
+        embedding: {
+          ...CONFIG_DEFAULTS.embedding,
+          provider: "ollama",
+          model: "test-model",
+          base_url: "http://embed.test:11434",
+          dimensions: 3,
+        },
+        destinations: [
+          {
+            name: "perso",
+            qdrant_url: "https://perso-qdrant.example.com:6333",
+            qdrant_api_key: null,
+            collection: "perso-memory",
+            match: {
+              content: ["[Bb]ikky"],
+              entity: ["[Bb]ikky"],
+            },
+          },
+          {
+            name: "work",
+            qdrant_url: "https://work-qdrant.example.com:6333",
+            qdrant_api_key: null,
+            collection: "work-memory",
+            default: true,
+          },
+        ],
+      });
+      resetConfig();
+      init();
+
+      await storeFact({
+        content: "mart_alerts table contains dbt_bank enrichment fields.",
+        category: "engineering",
+        entities: ["mart_alerts", "v100_marts"],
+        content_hash: "schema-hash",
+        origin: {
+          schema_version: 1,
+          user: { type: "user", id: "git-saber", name: "Saber", source: "config" },
+          agent: { type: "daemon", id: "daemon:test-host", name: "Bikky daemon on test-host", source: "hostname" },
+          interface: "daemon",
+          operation: { action: "create", subsystem: "extraction" },
+          metadata: { session_id: "uuid:test-session" },
+        },
+      });
+
+      assert.equal(upsertUrls.length, 1);
+      assert.ok(upsertUrls[0]?.startsWith("https://work-qdrant.example.com:6333/collections/work-memory/points"));
+    });
+
     it("keeps dedup follow-up mutations in the matched destination", async () => {
       const mutationUrls: string[] = [];
 

--- a/src/daemon/qdrant.ts
+++ b/src/daemon/qdrant.ts
@@ -292,7 +292,7 @@ const routingInputForFact = (
     content: normalizedContent,
     entities: normalizedEntities,
     metadata,
-    extraContent: [fact.origin, fact.last_operation_origin, fact.relation],
+    extraContent: [fact.relation],
   });
 };
 


### PR DESCRIPTION
## Summary
- prevent daemon provenance/agent text from participating in destination routing
- add regression coverage for non-Bikky facts with a Bikky daemon origin
- move the README top diagram directly above the Who it's for section
- bump root bikky package to 0.4.5

Fixes #170

## Validation
- npm run check
- npm test
- npm run verify:package