### PR TITLE
Release bikky 0.4.6 with memory ignore rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project uses npm package versions for release tracking:
 
 ## Unreleased
 
+## 0.4.6
+
+- Added configurable `ignore` rules for memory writes using the same `cwd`, `entity`, `content`, and `metadata` filters as destination routing.
+- Applied ignore checks before MCP writes, daemon writes, relation sidecars, superseding, telemetry upserts, embedding, deduplication, and Qdrant persistence.
+- Documented ignore configuration and added regression coverage for config validation, routing precedence, MCP write paths, daemon writes, telemetry, and local MCP E2E behavior.
+
 ## 0.4.5
 
 - Fixed destination routing so daemon provenance and agent metadata no longer influence where unrelated facts are stored.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -362,6 +362,39 @@ Matching details:
 - Read/search tools also accept `search_scope`; call `memory_search_scopes` or `get_setup_status` to see available scopes and descriptions.
 - All destinations share one embedding provider, so every destination collection must use the same vector dimensions.
 
+### Ignore rules
+
+Use top-level `ignore` rules when certain memories should not be stored at all. Ignore rules use the same `match` block shape as destination routing (`cwd`, `entity`, `content`, and `metadata` regex arrays), and memory-write `content` matching sees the same flattened memory context used by destination routing.
+
+Ignore rules run before destination resolution, embedding, deduplication, superseding, relation sidecars, telemetry upserts, and Qdrant writes. They also take precedence over explicit `destination` overrides, so an ignored topic cannot be stored by selecting a destination manually.
+
+```jsonc
+{
+  "ignore": [
+    {
+      "name": "personal-topics",
+      "description": "Do not persist personal-topic memories.",
+      "match": {
+        "entity": ["^[Rr]esume$"],
+        "content": ["\\b[Rr]esume\\b"],
+        "metadata": { "repo": ["^private/"] }
+      }
+    }
+  ]
+}
+```
+
+When an MCP write tool is ignored, it returns a structured non-error response such as:
+
+```json
+{
+  "action": "ignored",
+  "status": "ignored",
+  "ignored": true,
+  "rule": "personal-topics"
+}
+```
+
 Migrating from `workspace_id` pre-v0.4:
 
 - Existing top-level `qdrant_url`, `qdrant_api_key`, and `collection` configs still work as a single synthesized destination.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bikky",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bikky",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bikky",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Shared memory for AI coding sessions — MCP server + background daemon",
   "type": "module",
   "license": "AGPL-3.0-or-later",

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -679,6 +679,32 @@ describe("config", () => {
       assert.strictEqual(cfg.search_scopes[0]?.name, "broad");
     });
 
+    it("loads ignore rules with destination-match filters", () => {
+      fs.mkdirSync(BIKKY_DIR, { recursive: true });
+      fs.writeFileSync(
+        CONFIG_PATH,
+        JSON.stringify({
+          ignore: [
+            {
+              name: "private-topics",
+              description: "Do not store private topic memories.",
+              match: {
+                entity: ["^[Rr]esume$"],
+                content: ["\\b[Rr]esume\\b"],
+                metadata: { repo: ["^private/"] },
+              },
+            },
+          ],
+        }),
+      );
+
+      const cfg = loadConfig();
+
+      assert.strictEqual(cfg.ignore.length, 1);
+      assert.strictEqual(cfg.ignore[0]?.name, "private-topics");
+      assert.deepStrictEqual(cfg.ignore[0]?.match.metadata?.repo, ["^private/"]);
+    });
+
     it("env vars override file config", () => {
       fs.mkdirSync(BIKKY_DIR, { recursive: true });
       fs.writeFileSync(
@@ -749,6 +775,21 @@ describe("config", () => {
       assert.ok(issues.some((issue) => issue.path === "daemon.entity_typing_enabled"));
       assert.ok(issues.some((issue) => issue.path === "daemon.memory_quality_rollups_low_confidence_threshold"));
       assert.ok(issues.some((issue) => issue.path === "daemon.memory_quality_rollups_max_scopes_per_run"));
+    });
+
+    it("validates ignore rule regex patterns", () => {
+      const issues = validateConfigObject({
+        ignore: [{
+          name: "broken",
+          match: {
+            content: ["["],
+            metadata: { repo: ["("] },
+          },
+        }],
+      });
+
+      assert.ok(issues.some((issue) => issue.path === "ignore[0].match.content[0]"));
+      assert.ok(issues.some((issue) => issue.path === "ignore[0].match.metadata.repo[0]"));
     });
 
     it("accepts named search scopes as default_search_scope targets", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -162,6 +162,15 @@ export interface Destination {
   match?: DestinationMatch;
 }
 
+export interface IgnoreRule {
+  /** Stable identifier returned in ignored-write responses and logs. */
+  name?: string;
+  /** Human-readable reason/guidance for why the rule exists. */
+  description?: string;
+  /** Match rules using the same semantics as destination routing. */
+  match: DestinationMatch;
+}
+
 export type SearchScopeTarget = "routed" | "all" | string | string[];
 
 export interface SearchScopeDefinition {
@@ -188,6 +197,8 @@ export interface BikkyConfig {
    * default flag → first entry.
    */
   destinations: Destination[];
+  /** Memory write exclusion rules. First matching rule skips persistence. */
+  ignore: IgnoreRule[];
   /**
    * Default read/search scope. "routed" preserves historical behavior
    * (one destination via routing rules); "all" fans out to every destination;
@@ -229,6 +240,7 @@ const DEFAULTS: BikkyConfig = {
   qdrant_api_key: null,
   collection: "bikky",
   destinations: [],
+  ignore: [],
   default_search_scope: "routed",
   search_scopes: [],
   aws_profile: null,
@@ -428,6 +440,12 @@ const destinationFileSchema = z.object({
   match: destinationMatchSchema.optional(),
 }).passthrough();
 
+const ignoreRuleFileSchema = z.object({
+  name: z.string().min(1).optional(),
+  description: z.string().optional(),
+  match: destinationMatchSchema,
+}).passthrough();
+
 const searchScopeTargetSchema = z.union([
   z.string().min(1),
   z.array(z.string().min(1)).min(1),
@@ -444,6 +462,7 @@ const configFileSchema = z.object({
   qdrant_api_key: z.string().nullable().optional(),
   collection: z.string().optional(),
   destinations: z.array(destinationFileSchema).optional(),
+  ignore: z.array(ignoreRuleFileSchema).optional(),
   default_search_scope: searchScopeTargetSchema.optional(),
   search_scopes: z.array(searchScopeDefinitionFileSchema).optional(),
   aws_profile: z.string().nullable().optional(),
@@ -506,6 +525,55 @@ function validateUrlLike(value: unknown, pathName: string, issues: ConfigIssue[]
   }
 }
 
+function validateMatchBlock(match: Record<string, unknown>, base: string, issues: ConfigIssue[]): void {
+  for (const field of ["cwd", "entity", "content"] as const) {
+    const value = match[field];
+    if (value === undefined) continue;
+    if (!Array.isArray(value)) {
+      issues.push({ severity: "error", path: `${base}.${field}`, message: "must be an array of regex strings" });
+      continue;
+    }
+    value.forEach((pattern, pIdx) => {
+      if (typeof pattern !== "string") {
+        issues.push({ severity: "error", path: `${base}.${field}[${pIdx}]`, message: "must be a string" });
+        return;
+      }
+      try { new RegExp(pattern); }
+      catch (e) {
+        issues.push({
+          severity: "error",
+          path: `${base}.${field}[${pIdx}]`,
+          message: `invalid regex: ${e instanceof Error ? e.message : String(e)}`,
+        });
+      }
+    });
+  }
+
+  const metadata = childObject(match, "metadata");
+  if (metadata) {
+    for (const [key, value] of Object.entries(metadata)) {
+      if (!Array.isArray(value)) {
+        issues.push({ severity: "error", path: `${base}.metadata.${key}`, message: "must be an array of regex strings" });
+        continue;
+      }
+      value.forEach((pattern, pIdx) => {
+        if (typeof pattern !== "string") {
+          issues.push({ severity: "error", path: `${base}.metadata.${key}[${pIdx}]`, message: "must be a string" });
+          return;
+        }
+        try { new RegExp(pattern); }
+        catch (e) {
+          issues.push({
+            severity: "error",
+            path: `${base}.metadata.${key}[${pIdx}]`,
+            message: `invalid regex: ${e instanceof Error ? e.message : String(e)}`,
+          });
+        }
+      });
+    }
+  }
+}
+
 export function validateConfigObject(raw: unknown): ConfigIssue[] {
   const parsed = configFileSchema.safeParse(raw);
   const issues: ConfigIssue[] = [];
@@ -565,56 +633,28 @@ export function validateConfigObject(raw: unknown): ConfigIssue[] {
 
       const match = childObject(entry, "match");
       if (match) {
-        for (const field of ["cwd", "entity", "content"] as const) {
-          const value = match[field];
-          if (value === undefined) continue;
-          if (!Array.isArray(value)) {
-            issues.push({ severity: "error", path: `${base}.match.${field}`, message: "must be an array of regex strings" });
-            continue;
-          }
-          value.forEach((pattern, pIdx) => {
-            if (typeof pattern !== "string") {
-              issues.push({ severity: "error", path: `${base}.match.${field}[${pIdx}]`, message: "must be a string" });
-              return;
-            }
-            try { new RegExp(pattern); }
-            catch (e) {
-              issues.push({
-                severity: "error",
-                path: `${base}.match.${field}[${pIdx}]`,
-                message: `invalid regex: ${e instanceof Error ? e.message : String(e)}`,
-              });
-            }
-          });
-        }
-        const metadata = childObject(match, "metadata");
-        if (metadata) {
-          for (const [key, value] of Object.entries(metadata)) {
-            if (!Array.isArray(value)) {
-              issues.push({ severity: "error", path: `${base}.match.metadata.${key}`, message: "must be an array of regex strings" });
-              continue;
-            }
-            value.forEach((pattern, pIdx) => {
-              if (typeof pattern !== "string") {
-                issues.push({ severity: "error", path: `${base}.match.metadata.${key}[${pIdx}]`, message: "must be a string" });
-                return;
-              }
-              try { new RegExp(pattern); }
-              catch (e) {
-                issues.push({
-                  severity: "error",
-                  path: `${base}.match.metadata.${key}[${pIdx}]`,
-                  message: `invalid regex: ${e instanceof Error ? e.message : String(e)}`,
-                });
-              }
-            });
-          }
-        }
+        validateMatchBlock(match, `${base}.match`, issues);
       }
     });
     if (defaultCount > 1) {
       issues.push({ severity: "error", path: "destinations", message: `at most one destination may set 'default: true' (found ${defaultCount})` });
     }
+  }
+
+  if (Array.isArray(raw.ignore)) {
+    raw.ignore.forEach((entry, idx) => {
+      const base = `ignore[${idx}]`;
+      if (!isObject(entry)) {
+        issues.push({ severity: "error", path: base, message: "must be an object" });
+        return;
+      }
+      const match = entry.match;
+      if (!isObject(match)) {
+        issues.push({ severity: "error", path: `${base}.match`, message: "must be an object" });
+        return;
+      }
+      validateMatchBlock(match, `${base}.match`, issues);
+    });
   }
 
   const destinationNames = new Set<string>();

--- a/src/daemon/consolidation.ts
+++ b/src/daemon/consolidation.ts
@@ -184,10 +184,11 @@ const autoDistill = async (
     const promptStamp = `${DISTILL_PROMPT_DESCRIPTOR.id}@${DISTILL_PROMPT_DESCRIPTOR.version}`;
 
     // Store distilled patterns
+    let storedPatterns = 0;
     for (const pattern of patterns) {
       if (!pattern.content) continue;
       const hash = createHash("sha256").update(`distilled:${pattern.content}`).digest("hex");
-      await qdrant.storeFact({
+      const storedId = await qdrant.storeFact({
         content: pattern.content,
         category: normalizeCategory(pattern.category ?? "engineering"),
         domain: normalizeDomain(pattern.domain ?? "software_engineering"),
@@ -211,6 +212,12 @@ const autoDistill = async (
           },
         }),
       }, { destination });
+      if (storedId) storedPatterns++;
+    }
+
+    if (storedPatterns === 0) {
+      logFn("INFO", `Auto-distill: all ${patterns.length} patterns were ignored by config rules`);
+      return { distilled: false };
     }
 
     // Supersede the source summaries
@@ -223,8 +230,8 @@ const autoDistill = async (
       }));
     }
 
-    logFn("INFO", `Auto-distill: consolidated ${batch.length} summaries into ${patterns.length} patterns`);
-    return { distilled: true, count: patterns.length };
+    logFn("INFO", `Auto-distill: consolidated ${batch.length} summaries into ${storedPatterns} patterns`);
+    return { distilled: true, count: storedPatterns };
   } catch (e) {
     logFn("ERROR", `Auto-distill failed: ${(e as Error).message}`);
     return { distilled: false };

--- a/src/daemon/extraction.ts
+++ b/src/daemon/extraction.ts
@@ -551,6 +551,11 @@ const storeFacts = async (
     try {
       const dedup = await qdrant.dedupCheck(sanitizedFact.content, hash, undefined, undefined, routeInput);
 
+      if (dedup.action === "ignore") {
+        logFn("DEBUG", `Extraction: ignoring fact due to config rule '${dedup.ignoreRule ?? "unknown"}': "${sanitizedFact.content.slice(0, 80)}…"`);
+        continue;
+      }
+
       if (dedup.action === "skip") {
         // Reinforce existing fact
         if (dedup.existingId) {
@@ -722,6 +727,7 @@ const storeFacts = async (
 
       if (dedup.action === "supersede" && dedup.existingId) {
         const newId = await qdrant.storeFact(storePayload, routeInput);
+        if (!newId) continue;
         await qdrant.supersedeFact(dedup.existingId, newId, dedup.destination, buildOperationOrigin({
           interface: "daemon",
           action: "supersede",
@@ -735,8 +741,8 @@ const storeFacts = async (
         }));
         stored++;
       } else {
-        await qdrant.storeFact(storePayload, routeInput);
-        stored++;
+        const newId = await qdrant.storeFact(storePayload, routeInput);
+        if (newId) stored++;
       }
     } catch (e) {
       logFn("WARN", `Extraction: failed to store fact: ${(e as Error).message}`);

--- a/src/daemon/qdrant.test.ts
+++ b/src/daemon/qdrant.test.ts
@@ -274,6 +274,80 @@ describe("daemon/qdrant", () => {
   });
 
   describe("storeFact", () => {
+    it("ignores matching stored facts before embedding or Qdrant upsert", async () => {
+      const calls: string[] = [];
+
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        calls.push(url);
+        return new Response(JSON.stringify({ result: {} }), { status: 200 });
+      }) as typeof fetch;
+
+      saveConfig({
+        ...CONFIG_DEFAULTS,
+        qdrant_url: "https://qdrant.example.com:6333",
+        qdrant_api_key: null,
+        collection: "test-ignore",
+        ignore: [
+          { name: "private-topics", match: { content: ["\\b[Rr]esume\\b"], entity: ["^[Rr]esume$"] } },
+        ],
+        embedding: {
+          ...CONFIG_DEFAULTS.embedding,
+          provider: "ollama",
+          model: "test-model",
+          base_url: "http://embed.test:11434",
+          dimensions: 3,
+        },
+      });
+      resetConfig();
+      init();
+
+      const id = await storeFact({
+        content: "Resume notes should be excluded.",
+        category: "engineering",
+        entities: ["resume"],
+        content_hash: "ignore-hash",
+      });
+
+      assert.equal(id, null);
+      assert.deepEqual(calls, []);
+    });
+
+    it("ignores dedup candidates before embedding or Qdrant lookup", async () => {
+      const calls: string[] = [];
+
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        calls.push(url);
+        return new Response(JSON.stringify({ result: {} }), { status: 200 });
+      }) as typeof fetch;
+
+      saveConfig({
+        ...CONFIG_DEFAULTS,
+        qdrant_url: "https://qdrant.example.com:6333",
+        qdrant_api_key: null,
+        collection: "test-ignore",
+        ignore: [
+          { name: "private-topics", match: { content: ["\\b[Gg]arden\\b"] } },
+        ],
+        embedding: {
+          ...CONFIG_DEFAULTS.embedding,
+          provider: "ollama",
+          model: "test-model",
+          base_url: "http://embed.test:11434",
+          dimensions: 3,
+        },
+      });
+      resetConfig();
+      init();
+
+      const result = await dedupCheck("Garden notes should be excluded.", "garden-hash");
+
+      assert.equal(result.action, "ignore");
+      assert.equal(result.ignoreRule, "private-topics");
+      assert.deepEqual(calls, []);
+    });
+
     it("redacts secret content before embedding and Qdrant upsert", async () => {
       const embedInputs: string[] = [];
       const upsertBodies: Record<string, unknown>[] = [];

--- a/src/daemon/qdrant.ts
+++ b/src/daemon/qdrant.ts
@@ -15,7 +15,7 @@ import { embed, initEmbedding, getEmbeddingConfig } from "../llm/index.js";
 import type { InitEmbeddingInput } from "../llm/index.js";
 import { type QdrantLogLevel } from "../lib/qdrant-client.js";
 import { QdrantPool } from "../lib/qdrant-pool.js";
-import { buildResolver, type RoutingInput } from "../routing.js";
+import { buildResolver, findMatchingIgnoreRule, type RoutingInput } from "../routing.js";
 import {
   DEFAULT_DOMAIN,
   QDRANT_INDEXES,
@@ -187,11 +187,12 @@ export interface QdrantScrollFilters {
   orderBy?: { key: "created_at" | "updated_at" | "last_reinforced_at"; direction: "asc" | "desc" };
 }
 
-export type DedupAction = "insert" | "skip" | "supersede";
+export type DedupAction = "insert" | "skip" | "supersede" | "ignore";
 
 export interface DedupResult {
   action: DedupAction;
   destination?: string;
+  ignoreRule?: string;
   existingId?: string;
   existingCount?: number;
   score?: number;
@@ -557,7 +558,7 @@ const scrollFactsAcrossDestinations = async (
 // Write methods
 // ---------------------------------------------------------------------------
 
-const storeFact = async (fact: StoreFact, routeInput?: RoutingInput): Promise<string> => {
+const storeFact = async (fact: StoreFact, routeInput?: RoutingInput): Promise<string | null> => {
   const normalizedKind = normalizeKind(fact.kind);
   const normalizedSubtype = validateMemorySubtype(normalizedKind, fact.memory_subtype);
   const normalizedCategory = normalizedSubtype
@@ -642,7 +643,7 @@ const storeFact = async (fact: StoreFact, routeInput?: RoutingInput): Promise<st
     payload.redaction = redaction;
   }
 
-  const destination = resolveDestination(mergeRoutingInputs(routingInputForFact(
+  const writeInput = mergeRoutingInputs(routingInputForFact(
     fact,
     redactedContent.text,
     payload.entities,
@@ -650,9 +651,15 @@ const storeFact = async (fact: StoreFact, routeInput?: RoutingInput): Promise<st
       category: normalizedCategory,
       domain: normalizedDomain,
       kind: normalizedKind,
-      ...(normalizedSubtype ? { memory_subtype: normalizedSubtype } : {}),
-    },
-  ), routeInput));
+        ...(normalizedSubtype ? { memory_subtype: normalizedSubtype } : {}),
+      },
+  ), routeInput);
+  const ignored = findMatchingIgnoreRule(writeInput, loadConfig().ignore);
+  if (ignored) {
+    logFn("INFO", `Qdrant: ignored fact write due to ignore rule '${ignored.name}' [${normalizedCategory}] ${redactedContent.text.slice(0, 60)}`);
+    return null;
+  }
+  const destination = resolveDestination(writeInput);
   const vector = await embed(redactedContent.text);
 
   await qdrantRequest("PUT", `/collections/${destination.collection}/points`, {
@@ -709,7 +716,13 @@ const dedupCheck = async (
   workspaceId?: string,
   routeInput?: RoutingInput,
 ): Promise<DedupResult> => {
-  const destination = resolveDestination(routeInput ?? { content });
+  const input = mergeRoutingInputs({ content }, routeInput);
+  const ignored = findMatchingIgnoreRule(input, loadConfig().ignore);
+  if (ignored) {
+    logFn("INFO", `Qdrant: ignored dedup/write candidate due to ignore rule '${ignored.name}'`);
+    return { action: "ignore", ignoreRule: ignored.name };
+  }
+  const destination = resolveDestination(input);
   // First: hash-based exact check (fast, no embedding)
   try {
     const must: Record<string, unknown>[] = [

--- a/src/daemon/relations.ts
+++ b/src/daemon/relations.ts
@@ -341,7 +341,7 @@ const storeRelation = async (
   candidate: RelationCandidate,
   destination?: string,
   extras: { evidence?: string; confidence?: number; inVocabulary?: boolean; judgment?: { evidence_strength?: number; durability?: string; directionality_clarity?: string } } = {},
-): Promise<string> => {
+): Promise<string | null> => {
   const hash = createHash("sha256")
     .update(`daemon-relation:${pairKey(fromEntity, toEntity)}:${relationType}`)
     .digest("hex");
@@ -391,6 +391,10 @@ const storeRelation = async (
     },
   }, destination ? { destination } : undefined);
 
+  if (!id) {
+    logFn("INFO", `Relations: ignored ${fromEntity} —[${relationType}]→ ${toEntity} due to ignore rules`);
+    return null;
+  }
   logFn("INFO", `Relations: inferred ${fromEntity} —[${relationType}]→ ${toEntity} (id: ${id})`);
   return id;
 };
@@ -474,12 +478,16 @@ const tick = async (config: BikkyConfig): Promise<void> => {
           .update(`daemon-relation:${pairKey(result.from, result.to)}:${result.type}`)
           .digest("hex");
         const dedup = await qdrant.dedupCheck(result.content, hash, undefined, undefined, { destination });
+        if (dedup.action === "ignore") {
+          logFn("DEBUG", `Relations: ignoring ${candidate.entityA}↔${candidate.entityB} due to config rule '${dedup.ignoreRule ?? "unknown"}'`);
+          continue;
+        }
         if (dedup.action === "skip") {
           logFn("DEBUG", `Relations: skipping duplicate ${candidate.entityA}↔${candidate.entityB}`);
           continue;
         }
 
-        await storeRelation(
+        const storedId = await storeRelation(
           result.from,
           result.to,
           result.type,
@@ -488,7 +496,7 @@ const tick = async (config: BikkyConfig): Promise<void> => {
           destination,
           { evidence: result.evidence, confidence: result.confidence, inVocabulary: result.inVocabulary, judgment: result.judgment },
         );
-        inferred++;
+        if (storedId) inferred++;
       } catch (e: unknown) {
         failures++;
         logFn("WARN", `Relations: failed to infer ${candidate.entityA}↔${candidate.entityB}: ${(e as Error).message}`);

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { DestinationMatch } from "../config.js";
+import type { DestinationMatch, IgnoreRule } from "../config.js";
 
 const TEST_BIKKY_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "bikky-mcp-tools-"));
 process.env.BIKKY_HOME = TEST_BIKKY_HOME;
@@ -51,7 +51,7 @@ function destinationList(value: "routed" | "all" | string[]): string {
   return Array.isArray(value) ? value.join(",") : value;
 }
 
-function configureDestinations(): void {
+function configureDestinations(ignore: IgnoreRule[] = []): void {
   saveConfig({
     ...CONFIG_DEFAULTS,
     embedding: {
@@ -68,6 +68,7 @@ function configureDestinations(): void {
       timeout_ms: 100,
       retries: 0,
     },
+    ignore,
     destinations: [
       {
         name: "perso",
@@ -102,7 +103,7 @@ function configureDestinations(): void {
   rebuildPool();
 }
 
-function configureWorkDefaultDestinations(persoMatch: DestinationMatch): void {
+function configureWorkDefaultDestinations(persoMatch: DestinationMatch, ignore: IgnoreRule[] = []): void {
   saveConfig({
     ...CONFIG_DEFAULTS,
     embedding: {
@@ -119,6 +120,7 @@ function configureWorkDefaultDestinations(persoMatch: DestinationMatch): void {
       timeout_ms: 100,
       retries: 0,
     },
+    ignore,
     destinations: [
       {
         name: "perso",
@@ -413,6 +415,47 @@ describe("mcp/tools", () => {
     assert.equal(upsert.destination, "work");
   });
 
+  it("ignores memory_store before explicit destination overrides or storage calls", async () => {
+    configureDestinations([
+      { name: "private-topics", match: { content: ["\\b[Rr]esume\\b"], entity: ["^[Rr]esume$"] } },
+    ]);
+    const calls = installStorageMock();
+    const handlers = collectTools();
+
+    const result = await handlers.get("memory_store")!({
+      content: "Resume drafting notes should not be stored.",
+      category: "engineering",
+      entities: ["resume"],
+      destination: "work",
+    });
+
+    const body = parseToolJson(result);
+    assert.equal(body.action, "ignored");
+    assert.equal(body.rule, "private-topics");
+    assert.equal(calls.length, 0);
+  });
+
+  it("ignores summary and distilled writes before upsert", async () => {
+    configureDestinations([
+      { name: "private-topics", match: { content: ["garden|eggs"] } },
+    ]);
+    const calls = installStorageMock();
+    const handlers = collectTools();
+
+    const summary = await handlers.get("memory_session_summary")!({
+      content: "Garden planning notes should not be stored.",
+      entities: ["garden"],
+    });
+    const distilled = await handlers.get("memory_distill")!({
+      content: "Eggs inventory belongs outside memory.",
+      entities: ["eggs"],
+    });
+
+    assert.equal(parseToolJson(summary).action, "ignored");
+    assert.equal(parseToolJson(distilled).action, "ignored");
+    assert.equal(calls.length, 0);
+  });
+
   it("routes summary and distilled writes by repo from the full memory context", async () => {
     configureWorkDefaultDestinations({ metadata: { repo: ["^bikky-dev/bikky$"] } });
     const calls = installStorageMock();
@@ -583,6 +626,39 @@ describe("mcp/tools", () => {
     assert.equal((payloadUpdate.body?.payload as Record<string, unknown>).verification_count, 5);
   });
 
+  it("ignores memory_review corrections before embedding, upsert, or supersede", async () => {
+    configureDestinations([
+      { name: "private-corrections", match: { content: ["private correction"] } },
+    ]);
+    const calls = installStorageMock({
+      pointsByDestination: {
+        work: {
+          "work-fact": point("work-fact", {
+            content: "Old work fact",
+            category: "engineering",
+            entities: ["work"],
+            metadata: { repo: "work/repo" },
+          }),
+        },
+      },
+    });
+    const handlers = collectTools();
+
+    const result = await handlers.get("memory_review")!({
+      action: "correct",
+      fact_id: "work-fact",
+      corrected_content: "private correction should not persist",
+    });
+
+    const body = parseToolJson(result);
+    assert.equal(body.action, "ignored");
+    assert.equal(body.rule, "private-corrections");
+    assert.ok(calls.some((call) => call.method === "POST" && call.url.endsWith("/points")));
+    assert.ok(!calls.some((call) => call.url === "http://embed.test/v1/embeddings"));
+    assert.ok(!calls.some((call) => call.method === "PUT" && call.url.endsWith("/points")));
+    assert.ok(!calls.some((call) => call.method === "POST" && call.url.endsWith("/points/payload")));
+  });
+
   it("writes recall telemetry and updates recall counters in the result destination", async () => {
     const calls = installStorageMock({
       searchResults: [
@@ -619,6 +695,31 @@ describe("mcp/tools", () => {
     assert.deepEqual(payload?.returned_fact_ids, ["work-fact"]);
     assert.equal(payload?.result_count, 1);
     assert.equal(payload?.search_scope, "work");
+  });
+
+  it("ignores recall telemetry writes that match ignore rules", async () => {
+    configureDestinations([
+      { name: "private-query", match: { content: ["secret-query"] } },
+    ]);
+    const calls = installStorageMock({
+      searchResultsByDestination: {
+        work: [
+          point("work-fact", {
+            content: "Work fact",
+            entities: ["work"],
+          }),
+        ],
+      },
+    });
+    const handlers = collectTools();
+
+    await handlers.get("memory_recall")!({
+      query: "secret-query",
+      search_scope: "work",
+    });
+
+    assert.ok(calls.some((call) => call.method === "POST" && call.url.endsWith("/points/search")));
+    assert.ok(!calls.some((call) => call.method === "PUT" && call.url.endsWith("/points")));
   });
 
   it("writes recall telemetry and counters separately for each result destination", async () => {
@@ -711,6 +812,34 @@ describe("mcp/tools", () => {
     assert.equal(payload.target_fact_id, "work-fact");
   });
 
+  it("ignores feedback telemetry while still updating the source fact", async () => {
+    configureDestinations([
+      { name: "private-feedback", match: { content: ["private-note"] } },
+    ]);
+    const calls = installStorageMock({
+      pointsByDestination: {
+        work: {
+          "work-fact": point("work-fact", { useful_count: 1 }),
+        },
+      },
+    });
+    const handlers = collectTools();
+
+    const result = await handlers.get("memory_mark_useful")!({
+      fact_id: "work-fact",
+      note: "private-note",
+    });
+
+    const body = parseToolJson(result);
+    assert.equal(body.status, "marked_useful");
+    assert.equal(body.event_ignored, true);
+
+    const payloadUpdate = calls.find((call) => call.method === "POST" && call.url.endsWith("/points/payload"));
+    assert.ok(payloadUpdate);
+    assert.equal((payloadUpdate.body?.payload as Record<string, unknown>).useful_count, 2);
+    assert.ok(!calls.some((call) => call.method === "PUT" && call.url.endsWith("/points")));
+  });
+
   it("writes outcome telemetry in the same destination as the source fact", async () => {
     const calls = installStorageMock({
       pointsByDestination: {
@@ -745,6 +874,36 @@ describe("mcp/tools", () => {
     assert.equal(payload.memory_subtype, "outcome_event");
     assert.equal(payload.target_fact_id, "work-fact");
     assert.equal(payload.outcome, "misleading");
+  });
+
+  it("ignores outcome telemetry while still updating the source fact", async () => {
+    configureDestinations([
+      { name: "private-outcome", match: { content: ["sensitive outcome"] } },
+    ]);
+    const calls = installStorageMock({
+      pointsByDestination: {
+        work: {
+          "work-fact": point("work-fact", { misleading_count: 1 }),
+        },
+      },
+    });
+    const handlers = collectTools();
+
+    const result = await handlers.get("memory_report_outcome")!({
+      fact_id: "work-fact",
+      outcome: "misleading",
+      notes: "sensitive outcome",
+    });
+
+    const body = parseToolJson(result);
+    assert.equal(body.status, "outcome_recorded");
+    assert.equal(body.event_ignored, true);
+    assert.equal(body.misleading_count, 2);
+
+    const payloadUpdate = calls.find((call) => call.method === "POST" && call.url.endsWith("/points/payload"));
+    assert.ok(payloadUpdate);
+    assert.equal((payloadUpdate.body?.payload as Record<string, unknown>).misleading_count, 2);
+    assert.ok(!calls.some((call) => call.method === "PUT" && call.url.endsWith("/points")));
   });
 
   for (const { outcome, field } of [

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -59,7 +59,7 @@ import {
   resolveDest,
   findPointById,
 } from "./api.js";
-import { DestinationNotFoundError, type RoutingInput } from "../routing.js";
+import { DestinationNotFoundError, findMatchingIgnoreRule, type IgnoreMatch, type RoutingInput } from "../routing.js";
 import type { Destination } from "../config.js";
 import { saveConfig, loadConfig, EXTRACTION_HEALTH_PATH } from "../config.js";
 import {
@@ -200,6 +200,53 @@ function resolveDestOrError(input: RoutingInput): { dest: Destination; error?: n
   }
 }
 
+function ignoredWriteResult(tool: string, match: IgnoreMatch): McpToolResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify({
+      action: "ignored",
+      status: "ignored",
+      ignored: true,
+      tool,
+      rule: match.name,
+      rule_index: match.index,
+      description: match.rule.description ?? null,
+      message: `Memory write ignored by config rule '${match.name}'.`,
+    }) }],
+  };
+}
+
+function ignoreWriteOrError(input: RoutingInput, tool: string): { match?: IgnoreMatch; error?: never } | { match?: never; error: McpToolResult } {
+  try {
+    const match = findMatchingIgnoreRule(input, loadConfig().ignore);
+    return match ? { match } : {};
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      error: {
+        content: [{ type: "text", text: JSON.stringify({
+          status: "error",
+          message: `Failed to evaluate ignore rules for ${tool}: ${msg}`,
+        }, null, 2) }],
+        isError: true,
+      },
+    };
+  }
+}
+
+function telemetryIgnored(input: RoutingInput, subtype: string): boolean {
+  try {
+    const match = findMatchingIgnoreRule(input, loadConfig().ignore);
+    if (!match) return false;
+    log("INFO", `Skipped ${subtype} write due to ignore rule '${match.name}'`);
+    return true;
+  } catch (e) {
+    log("WARN", `Failed to evaluate ignore rules for ${subtype}: ${e instanceof Error ? e.message : String(e)}`);
+    // Telemetry can include recall queries or feedback notes, so fail closed
+    // rather than risk persisting content that an ignore rule was meant to block.
+    return true;
+  }
+}
+
 type ScopedPoint = QdrantPoint & {
   _destination: Destination;
   _combinedScore?: number;
@@ -268,6 +315,21 @@ async function recordRecallTelemetry(args: {
     const entities = [...new Set(points.flatMap((point) => point.payload.entities ?? []))].slice(0, 25);
     const eventContent = `Recall returned ${points.length} fact(s) from ${dest.name}: ${args.redactedQuery.text}`;
     const redactedEvent = redactStorageText(eventContent);
+    const eventRoutingInput = buildMemoryRoutingInput({
+      cwd: process.cwd(),
+      content: redactedEvent.text,
+      entities,
+      context: {
+        category: categoryForMemorySubtype("recall_event") ?? "system",
+        domain: "software_engineering",
+        kind: "telemetry",
+        memory_subtype: "recall_event",
+        layer: "memory_object",
+        search_scope: args.searchScope.name,
+        destination: dest.name,
+      },
+    });
+    if (telemetryIgnored(eventRoutingInput, "recall_event")) continue;
     const eventPayload: Record<string, unknown> = {
       content: redactedEvent.text,
       category: categoryForMemorySubtype("recall_event") ?? "system",
@@ -910,7 +972,7 @@ export function registerTools(mcp: McpServer): void {
         type: redactedRelation.type.text,
         to: redactedRelation.to.text,
       } : null;
-      const resolved = resolveDestOrError(memoryWriteRoutingInput({
+      const writeInput = memoryWriteRoutingInput({
         tool: "memory_store",
         destination,
         content: redactedContent.text,
@@ -931,7 +993,11 @@ export function registerTools(mcp: McpServer): void {
           review_status,
           supersedes,
         },
-      }));
+      });
+      const ignored = ignoreWriteOrError(writeInput, "memory_store");
+      if (ignored.error) return ignored.error;
+      if (ignored.match) return ignoredWriteResult("memory_store", ignored.match);
+      const resolved = resolveDestOrError(writeInput);
       if (resolved.error) return resolved.error;
       const dest = resolved.dest;
       const createOrigin = mcpOrigin({
@@ -1841,34 +1907,51 @@ export function registerTools(mcp: McpServer): void {
 
         // Write a telemetry feedback_event row so the signal is also visible
         // to aggregations and review tooling.
-        const eventId = newId();
         const eventContent = note
           ? `Fact ${fact_id} marked useful: ${note}`
           : `Fact ${fact_id} marked useful.`;
         const redactedEvent = redactStorageText(eventContent);
-        const eventPayload: Record<string, unknown> = {
+        let eventId: string | null = null;
+        const eventInput = buildMemoryRoutingInput({
+          cwd: process.cwd(),
           content: redactedEvent.text,
-          category: categoryForMemorySubtype("feedback_event") ?? "system",
-          domain: "software_engineering",
-          kind: "telemetry",
-          memory_subtype: "feedback_event",
-          layer: "memory_object",
           entities: [],
-          origin: feedbackOrigin,
-          confidence: 1.0,
-          importance: 0.3,
-          content_hash: contentHash("feedback_event", `${fact_id}:useful:${now}`),
-          target_fact_id: fact_id,
-          feedback_kind: "useful",
-          created_at: now,
-          updated_at: now,
-        };
-        addRedactionPayload(eventPayload, redactedEvent);
-        try {
-          const eventVector = await embed(redactedEvent.text);
-          await qdrantUpsert(dest, eventId, eventVector, eventPayload);
-        } catch (e) {
-          log("WARN", `Failed to record feedback_event: ${e instanceof Error ? e.message : String(e)}`);
+          context: {
+            category: categoryForMemorySubtype("feedback_event") ?? "system",
+            domain: "software_engineering",
+            kind: "telemetry",
+            memory_subtype: "feedback_event",
+            layer: "memory_object",
+            target_fact_id: fact_id,
+            feedback_kind: "useful",
+          },
+        });
+        if (!telemetryIgnored(eventInput, "feedback_event")) {
+          eventId = newId();
+          const eventPayload: Record<string, unknown> = {
+            content: redactedEvent.text,
+            category: categoryForMemorySubtype("feedback_event") ?? "system",
+            domain: "software_engineering",
+            kind: "telemetry",
+            memory_subtype: "feedback_event",
+            layer: "memory_object",
+            entities: [],
+            origin: feedbackOrigin,
+            confidence: 1.0,
+            importance: 0.3,
+            content_hash: contentHash("feedback_event", `${fact_id}:useful:${now}`),
+            target_fact_id: fact_id,
+            feedback_kind: "useful",
+            created_at: now,
+            updated_at: now,
+          };
+          addRedactionPayload(eventPayload, redactedEvent);
+          try {
+            const eventVector = await embed(redactedEvent.text);
+            await qdrantUpsert(dest, eventId, eventVector, eventPayload);
+          } catch (e) {
+            log("WARN", `Failed to record feedback_event: ${e instanceof Error ? e.message : String(e)}`);
+          }
         }
 
         return {
@@ -1877,7 +1960,7 @@ export function registerTools(mcp: McpServer): void {
             fact_id,
             destination: dest.name,
             useful_count: newCount,
-            event_id: eventId,
+            ...(eventId ? { event_id: eventId } : { event_ignored: true }),
           }) }],
         };
       } catch (e) {
@@ -1927,31 +2010,48 @@ export function registerTools(mcp: McpServer): void {
           last_operation_origin: feedbackOrigin,
         });
 
-        const eventId = newId();
         const eventContent = notes
           ? `Fact ${fact_id} outcome=${outcome}: ${notes}`
           : `Fact ${fact_id} outcome=${outcome}.`;
         const redactedEvent = redactStorageText(eventContent);
-        const eventPayload: Record<string, unknown> = {
+        let eventId: string | null = null;
+        const eventInput = buildMemoryRoutingInput({
+          cwd: process.cwd(),
           content: redactedEvent.text,
-          category: categoryForMemorySubtype("outcome_event") ?? "system",
-          domain: "software_engineering",
-          kind: "telemetry",
-          memory_subtype: "outcome_event",
-          layer: "memory_object",
           entities: [],
-          origin: feedbackOrigin,
-          confidence: 1.0,
-          importance: outcome === "wrong" || outcome === "misleading" ? 0.6 : 0.3,
-          content_hash: contentHash("outcome_event", `${fact_id}:${outcome}:${now}`),
-          target_fact_id: fact_id,
-          outcome,
-          created_at: now,
-          updated_at: now,
-        };
-        addRedactionPayload(eventPayload, redactedEvent);
-        const eventVector = await embed(redactedEvent.text);
-        await qdrantUpsert(dest, eventId, eventVector, eventPayload);
+          context: {
+            category: categoryForMemorySubtype("outcome_event") ?? "system",
+            domain: "software_engineering",
+            kind: "telemetry",
+            memory_subtype: "outcome_event",
+            layer: "memory_object",
+            target_fact_id: fact_id,
+            outcome,
+          },
+        });
+        if (!telemetryIgnored(eventInput, "outcome_event")) {
+          eventId = newId();
+          const eventPayload: Record<string, unknown> = {
+            content: redactedEvent.text,
+            category: categoryForMemorySubtype("outcome_event") ?? "system",
+            domain: "software_engineering",
+            kind: "telemetry",
+            memory_subtype: "outcome_event",
+            layer: "memory_object",
+            entities: [],
+            origin: feedbackOrigin,
+            confidence: 1.0,
+            importance: outcome === "wrong" || outcome === "misleading" ? 0.6 : 0.3,
+            content_hash: contentHash("outcome_event", `${fact_id}:${outcome}:${now}`),
+            target_fact_id: fact_id,
+            outcome,
+            created_at: now,
+            updated_at: now,
+          };
+          addRedactionPayload(eventPayload, redactedEvent);
+          const eventVector = await embed(redactedEvent.text);
+          await qdrantUpsert(dest, eventId, eventVector, eventPayload);
+        }
 
         return {
           content: [{ type: "text", text: JSON.stringify({
@@ -1960,7 +2060,7 @@ export function registerTools(mcp: McpServer): void {
             destination: dest.name,
             outcome,
             [counterField]: counterValue,
-            event_id: eventId,
+            ...(eventId ? { event_id: eventId } : { event_ignored: true }),
           }) }],
         };
       } catch (e) {
@@ -2000,7 +2100,7 @@ export function registerTools(mcp: McpServer): void {
       try {
         const normalizedEntities = (entities ?? []).map((e) => e.trim().toLowerCase()).filter(Boolean);
         const redactedContent = redactStorageText(content);
-        const resolved = resolveDestOrError(memoryWriteRoutingInput({
+        const writeInput = memoryWriteRoutingInput({
           tool: "memory_session_summary",
           destination,
           content: redactedContent.text,
@@ -2016,7 +2116,11 @@ export function registerTools(mcp: McpServer): void {
             task_key,
             repo,
           },
-        }));
+        });
+        const ignored = ignoreWriteOrError(writeInput, "memory_session_summary");
+        if (ignored.error) return ignored.error;
+        if (ignored.match) return ignoredWriteResult("memory_session_summary", ignored.match);
+        const resolved = resolveDestOrError(writeInput);
         if (resolved.error) return resolved.error;
         const dest = resolved.dest;
         const summaryId = newId();
@@ -2104,7 +2208,7 @@ export function registerTools(mcp: McpServer): void {
       try {
         const normalizedEntities = entities.map((e) => e.trim().toLowerCase()).filter(Boolean);
         const redactedContent = redactStorageText(content);
-        const resolved = resolveDestOrError(memoryWriteRoutingInput({
+        const writeInput = memoryWriteRoutingInput({
           tool: "memory_distill",
           destination,
           content: redactedContent.text,
@@ -2119,7 +2223,11 @@ export function registerTools(mcp: McpServer): void {
             repo,
             supersedes,
           },
-        }));
+        });
+        const ignored = ignoreWriteOrError(writeInput, "memory_distill");
+        if (ignored.error) return ignored.error;
+        if (ignored.match) return ignoredWriteResult("memory_distill", ignored.match);
+        const resolved = resolveDestOrError(writeInput);
         if (resolved.error) return resolved.error;
         const dest = resolved.dest;
         const distilledId = newId();
@@ -2315,9 +2423,36 @@ export function registerTools(mcp: McpServer): void {
         const origPayload = point.payload;
         const redactedCorrected = redactStorageText(corrected_content);
 
+        const origCategory = normalizeCategory(origPayload?.category ?? DEFAULT_CATEGORY);
+        const origDomain = normalizeDomain(origPayload?.domain ?? DEFAULT_DOMAIN);
+        const origKind = normalizeKind(origPayload?.kind ?? "fact");
+        const correctedEntities = origPayload?.entities ?? [];
+        const writeInput = memoryWriteRoutingInput({
+          tool: "memory_review",
+          destination: dest.name,
+          content: redactedCorrected.text,
+          entities: correctedEntities,
+          metadata: origPayload?.metadata,
+          context: {
+            category: origCategory,
+            domain: origDomain,
+            kind: origKind,
+            memory_subtype: origPayload?.memory_subtype,
+            layer: origPayload?.layer,
+            episode_id: origPayload?.episode_id,
+            workstream_key: origPayload?.workstream_key,
+            task_key: origPayload?.task_key,
+            repo: origPayload?.repo,
+            branch: origPayload?.branch,
+            corrected_from: fact_id,
+          },
+        });
+        const ignored = ignoreWriteOrError(writeInput, "memory_review");
+        if (ignored.error) return ignored.error;
+        if (ignored.match) return ignoredWriteResult("memory_review", ignored.match);
+
         const vector = await embed(redactedCorrected.text);
         const correctedId = crypto.randomUUID();
-        const origCategory = normalizeCategory(origPayload?.category ?? DEFAULT_CATEGORY);
         const hash = contentHash(origCategory, redactedCorrected.text);
         const correctOrigin = mcpOrigin({
           action: "correct",
@@ -2327,8 +2462,8 @@ export function registerTools(mcp: McpServer): void {
         const correctedPayload: Record<string, unknown> = {
           content: redactedCorrected.text,
           category: origCategory,
-          domain: normalizeDomain(origPayload?.domain ?? DEFAULT_DOMAIN),
-          kind: normalizeKind(origPayload?.kind ?? "fact"),
+          domain: origDomain,
+          kind: origKind,
           ...(origPayload?.memory_subtype ? { memory_subtype: origPayload.memory_subtype } : {}),
           ...(origPayload?.layer ? { layer: origPayload.layer } : {}),
           ...(origPayload?.episode_id ? { episode_id: origPayload.episode_id } : {}),
@@ -2336,7 +2471,7 @@ export function registerTools(mcp: McpServer): void {
           ...(origPayload?.task_key ? { task_key: origPayload.task_key } : {}),
           ...(origPayload?.repo ? { repo: origPayload.repo } : {}),
           ...(origPayload?.branch ? { branch: origPayload.branch } : {}),
-          entities: origPayload?.entities ?? [],
+          entities: correctedEntities,
           origin: correctOrigin,
           confidence: 0.95,
           importance: origPayload?.importance ?? 0.5,

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import {
   resolveDestination,
   buildResolver,
+  findMatchingIgnoreRule,
+  routingInputMatches,
   DestinationNotFoundError,
   NoDestinationsConfiguredError,
 } from "./routing.js";
@@ -109,5 +111,49 @@ describe("routing.buildResolver", () => {
   it("closure throws on empty destinations", () => {
     const resolve = buildResolver([]);
     assert.throws(() => resolve({}), NoDestinationsConfiguredError);
+  });
+});
+
+describe("routing ignore rules", () => {
+  it("uses destination match semantics for ignore rules", () => {
+    assert.equal(
+      routingInputMatches(
+        {
+          cwd: ["/private"],
+          entity: ["^secret-"],
+          content: ["password"],
+          metadata: { repo: ["^private/"] },
+        },
+        {
+          cwd: "/work",
+          entities: ["project"],
+          content: "safe note",
+          metadata: { repo: "private/notes" },
+        },
+      ),
+      true,
+    );
+  });
+
+  it("returns the first matching ignore rule in array order", () => {
+    const match = findMatchingIgnoreRule(
+      { content: "resume update", entities: ["resume"] },
+      [
+        { name: "first", match: { content: ["resume"] } },
+        { name: "second", match: { entity: ["resume"] } },
+      ],
+    );
+
+    assert.equal(match?.name, "first");
+    assert.equal(match?.index, 0);
+  });
+
+  it("does not let destination overrides affect ignore matching", () => {
+    const match = findMatchingIgnoreRule(
+      { destination: "work", content: "garden notes" },
+      [{ name: "private-topics", match: { content: ["garden"] } }],
+    );
+
+    assert.equal(match?.name, "private-topics");
   });
 });

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -15,7 +15,7 @@
  *
  * Pure: no I/O, no globals. Easy to unit test.
  */
-import type { Destination, DestinationMatch } from "./config.js";
+import type { Destination, DestinationMatch, IgnoreRule } from "./config.js";
 
 export interface RoutingInput {
   /** Explicit destination name override. Throws if it doesn't match a destination. */
@@ -44,6 +44,12 @@ export class NoDestinationsConfiguredError extends Error {
     super("No destinations configured. Set top-level qdrant_url or destinations[] in ~/.bikky/config.json.");
     this.name = "NoDestinationsConfiguredError";
   }
+}
+
+export interface IgnoreMatch {
+  rule: IgnoreRule;
+  index: number;
+  name: string;
 }
 
 /** Pre-compile all regexes in a destination's match block. */
@@ -114,6 +120,26 @@ function destinationMatches(compiled: CompiledMatch, input: RoutingInput): boole
   }
 
   return false;
+}
+
+export function routingInputMatches(match: DestinationMatch | undefined, input: RoutingInput): boolean {
+  return destinationMatches(compileMatch(match), input);
+}
+
+export function findMatchingIgnoreRule(
+  input: RoutingInput,
+  ignoreRules: ReadonlyArray<IgnoreRule>,
+): IgnoreMatch | null {
+  for (const [index, rule] of ignoreRules.entries()) {
+    if (routingInputMatches(rule.match, input)) {
+      return {
+        rule,
+        index,
+        name: rule.name?.trim() || `ignore[${index}]`,
+      };
+    }
+  }
+  return null;
 }
 
 function pickFallback(destinations: ReadonlyArray<Destination>): Destination {

--- a/src/search-scope.test.ts
+++ b/src/search-scope.test.ts
@@ -16,6 +16,7 @@ const cfg = (extra: Partial<BikkyConfig> = {}): BikkyConfig => ({
   qdrant_api_key: null,
   collection: "bikky",
   destinations: [],
+  ignore: [],
   default_search_scope: "routed",
   search_scopes: [],
   aws_profile: null,


### PR DESCRIPTION
## Summary
- add configurable top-level ignore rules for memory writes using destination-style match filters
- apply ignore checks before MCP/daemon/telemetry persistence paths
- bump bikky to 0.4.6 and document the release

Fixes #179

## Verification
- npm ci
- npm run check
- npm test
- npm audit --omit=dev --audit-level=high
- cd packages/ui && npm ci && npm run typecheck && npm test && npm audit --omit=dev --audit-level=high && npm run build
- npm run verify:package
- BIKKY_REPO=/Users/saber/code/bikky-pr179-release node /Users/saber/code/agent00/tasks/357-bikky-ignore-routing/artifacts/pr179-ignore-e2e.mjs