### PR TITLE
ci: use npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build-test-core:
@@ -32,8 +33,9 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - run: npm ci
 
@@ -101,8 +103,6 @@ jobs:
           echo "Publishing bikky@${PKG_VERSION}"
 
       - run: npm publish --access public --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-ui:
     needs: build-test-ui
@@ -115,8 +115,9 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - uses: actions/download-artifact@v8
         with:
@@ -136,5 +137,3 @@ jobs:
       - name: Publish bikky-ui
         working-directory: packages/ui
         run: npm publish --access public --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- grant GitHub Actions OIDC permission for the npm publish workflow
- use Node 24/npm 11+ in publish jobs so npm can exchange OIDC credentials
- remove long-lived `NPM_TOKEN` from core and UI publish steps

Refs #181

## npm package settings required
Before running publish, configure npm Trusted Publisher for `bikky`:
- Provider: GitHub Actions
- Organization/user: `bikky-dev`
- Repository: `bikky`
- Workflow filename: `publish.yml`
- Environment: blank
- Allowed actions: `npm publish`

Configure the same for `bikky-ui` before publishing UI releases.

## Verification
- `git diff --check`
- Ruby YAML parse for `.github/workflows/publish.yml`
