### PR TITLE
docs: remove resume ignore examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,11 @@ Most installs use one Qdrant destination. If you need clean separation later, re
   "default_search_scope": "routed",
   "ignore": [
     {
-      "name": "personal-topics",
-      "description": "Never persist personal-topic memories.",
+      "name": "do-not-store",
+      "description": "Never persist memories explicitly marked do-not-store.",
       "match": {
-        "entity": ["^[Rr]esume$"],
-        "content": ["\\b[Rr]esume\\b"]
+        "entity": ["^do-not-store$"],
+        "content": ["\\bdo-not-store\\b"]
       }
     }
   ]

--- a/docs/config/fully-hosted.md
+++ b/docs/config/fully-hosted.md
@@ -70,11 +70,11 @@ If you need separate stores for teams, clients, or environments, replace the top
   "default_search_scope": "routed",
   "ignore": [
     {
-      "name": "personal-topics",
-      "description": "Never persist personal-topic memories.",
+      "name": "do-not-store",
+      "description": "Never persist memories explicitly marked do-not-store.",
       "match": {
-        "entity": ["^[Rr]esume$"],
-        "content": ["\\b[Rr]esume\\b"]
+        "entity": ["^do-not-store$"],
+        "content": ["\\bdo-not-store\\b"]
       }
     }
   ]

--- a/docs/config/hosted-models.md
+++ b/docs/config/hosted-models.md
@@ -69,11 +69,11 @@ If you need separate stores for teams, clients, or environments, replace the top
   "default_search_scope": "routed",
   "ignore": [
     {
-      "name": "personal-topics",
-      "description": "Never persist personal-topic memories.",
+      "name": "do-not-store",
+      "description": "Never persist memories explicitly marked do-not-store.",
       "match": {
-        "entity": ["^[Rr]esume$"],
-        "content": ["\\b[Rr]esume\\b"]
+        "entity": ["^do-not-store$"],
+        "content": ["\\bdo-not-store\\b"]
       }
     }
   ]

--- a/docs/config/hosted-qdrant-local-models.md
+++ b/docs/config/hosted-qdrant-local-models.md
@@ -55,11 +55,11 @@ If you need separate stores for teams, clients, or environments, replace the top
   "default_search_scope": "routed",
   "ignore": [
     {
-      "name": "personal-topics",
-      "description": "Never persist personal-topic memories.",
+      "name": "do-not-store",
+      "description": "Never persist memories explicitly marked do-not-store.",
       "match": {
-        "entity": ["^[Rr]esume$"],
-        "content": ["\\b[Rr]esume\\b"]
+        "entity": ["^do-not-store$"],
+        "content": ["\\bdo-not-store\\b"]
       }
     }
   ]

--- a/docs/config/local.md
+++ b/docs/config/local.md
@@ -56,11 +56,11 @@ If you need separate stores for teams, clients, or environments, replace the top
   "default_search_scope": "routed",
   "ignore": [
     {
-      "name": "personal-topics",
-      "description": "Never persist personal-topic memories.",
+      "name": "do-not-store",
+      "description": "Never persist memories explicitly marked do-not-store.",
       "match": {
-        "entity": ["^[Rr]esume$"],
-        "content": ["\\b[Rr]esume\\b"]
+        "entity": ["^do-not-store$"],
+        "content": ["\\bdo-not-store\\b"]
       }
     }
   ]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -372,12 +372,12 @@ Ignore rules run before destination resolution, embedding, deduplication, supers
 {
   "ignore": [
     {
-      "name": "personal-topics",
-      "description": "Do not persist personal-topic memories.",
+      "name": "do-not-store",
+      "description": "Do not persist memories explicitly marked do-not-store.",
       "match": {
-        "entity": ["^[Rr]esume$"],
-        "content": ["\\b[Rr]esume\\b"],
-        "metadata": { "repo": ["^private/"] }
+        "entity": ["^do-not-store$"],
+        "content": ["\\bdo-not-store\\b"],
+        "metadata": { "classification": ["^ephemeral$"] }
       }
     }
   ]
@@ -391,7 +391,7 @@ When an MCP write tool is ignored, it returns a structured non-error response su
   "action": "ignored",
   "status": "ignored",
   "ignored": true,
-  "rule": "personal-topics"
+  "rule": "do-not-store"
 }
 ```
 


### PR DESCRIPTION
## Summary
- replace the README ignore-rule example with a neutral `do-not-store` marker
- update all config guide examples and the full configuration guide to remove the resume-specific example

## Validation
- rg `[Rr]esume|personal-topics|personal-topic` README.md docs/
- git diff --check
- npm run verify:package