### PR TITLE
feat: memory_pause/resume tools + daemon signal (v0.4.6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 *.tgz
 .env
 packages/ui/graph-drag-test.mjs
+.obsidian/
+bikky/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project uses npm package versions for release tracking:
 
 ## 0.4.6
 
+- Added `memory_pause` and `memory_resume` MCP tools for per-session memory opt-out. When paused, all write operations return a `session_paused` status; reads remain functional. Pass `session_id` to also pause daemon transcript extraction for that session via `~/.bikky/state/paused-sessions.json`.
 - Added configurable `ignore` rules for memory writes using the same `cwd`, `entity`, `content`, and `metadata` filters as destination routing.
 - Applied ignore checks before MCP writes, daemon writes, relation sidecars, superseding, telemetry upserts, embedding, deduplication, and Qdrant persistence.
 - Documented ignore configuration and added regression coverage for config validation, routing precedence, MCP write paths, daemon writes, telemetry, and local MCP E2E behavior.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,13 @@ bikky setup            # writes MCP config for GitHub Copilot + Claude Code, the
 
 `npm install -g bikky` runs a best-effort postinstall setup hook for convenience. It never fails the install, and you should still run `bikky setup` after writing your config to make setup explicit and repeatable.
 
-Restart your editor. The memory tools appear automatically in GitHub Copilot and Claude Code; configure other stdio MCP clients manually with `npx -y bikky mcp`.
+If setup finds running `bikky mcp` servers from older agent/editor sessions, it prints reload guidance but does not terminate them:
+
+- **GitHub Copilot CLI:** run `/restart` in the Copilot CLI session.
+- **Claude Code:** restart Claude Code, then run `claude --continue` or `claude -c` to resume.
+- **Other stdio MCP clients:** use their MCP reload/restart action if available; otherwise restart the client session.
+
+The memory tools appear automatically in GitHub Copilot and Claude Code; configure other stdio MCP clients manually with `npx -y bikky mcp`.
 
 ```bash
 bikky status           # confirms Qdrant, embeddings, daemon, and UI health
@@ -281,6 +287,23 @@ Only the configured daemon process reads these files. Extracted facts are redact
 ```
 
 You can also set `daemon.extract_every_sec` to `0` to disable background extraction while keeping MCP recall tools available.
+
+### Per-session pause
+
+If you want to prevent memory writes for a single session without changing global config, use the `memory_pause` MCP tool:
+
+```
+memory_pause({ reason: "private session", session_id: "<your-session-UUID>" })
+```
+
+While paused:
+- All MCP write tools (`memory_store`, `memory_session_summary`, `memory_distill`, `memory_verify`, `memory_forget`, etc.) return a `session_paused` status instead of executing.
+- Read tools (`memory_recall`, `memory_entity`, `memory_relations`, `memory_heartbeat`) continue to work normally.
+- When `session_id` is provided, the daemon also skips transcript extraction for that session.
+
+Call `memory_resume({ session_id: "<your-session-UUID>" })` to re-enable writes.
+
+The `session_id` is the UUID from your session folder (e.g. the directory name under `~/.copilot/session-state/`). If omitted, only the in-process MCP layer is paused — the daemon will continue extracting from transcripts.
 
 For a local-storage, local-model setup that minimizes what leaves your machine, see the [privacy-first quickstart][privacy-quickstart].
 

--- a/docs/config/fully-hosted.md
+++ b/docs/config/fully-hosted.md
@@ -115,6 +115,6 @@ After changing Qdrant or provider settings, restart long-running processes:
 bikky stop && bikky start
 ```
 
-Then restart your editor so its MCP process reloads.
+Then reload the MCP server from your client: in GitHub Copilot CLI, run `/restart`; in Claude Code, restart Claude Code and run `claude --continue` or `claude -c` to resume. For other stdio MCP clients, use their MCP reload/restart action if available; otherwise restart the client session.
 
 For Bedrock, custom base URLs, or model-specific dimensions, see the [full configuration guide](https://github.com/bikky-dev/bikky/blob/main/docs/configuration.md).

--- a/docs/config/hosted-models.md
+++ b/docs/config/hosted-models.md
@@ -108,6 +108,6 @@ Or set `OPENAI_API_KEY` in the environment instead of the config file.
 bikky status
 ```
 
-If you started from a fresh install, run `bikky setup` after writing the config, then restart your editor so its MCP process reloads.
+If you started from a fresh install, run `bikky setup` after writing the config. Then reload the MCP server from your client: in GitHub Copilot CLI, run `/restart`; in Claude Code, restart Claude Code and run `claude --continue` or `claude -c` to resume. For other stdio MCP clients, use their MCP reload/restart action if available; otherwise restart the client session.
 
 For Bedrock, custom base URLs, or model-specific dimensions, see the [full configuration guide](https://github.com/bikky-dev/bikky/blob/main/docs/configuration.md).

--- a/docs/config/hosted-qdrant-local-models.md
+++ b/docs/config/hosted-qdrant-local-models.md
@@ -80,4 +80,4 @@ After changing Qdrant settings, restart long-running processes:
 bikky stop && bikky start
 ```
 
-Then restart your editor so its MCP process reloads.
+Then reload the MCP server from your client: in GitHub Copilot CLI, run `/restart`; in Claude Code, restart Claude Code and run `claude --continue` or `claude -c` to resume. For other stdio MCP clients, use their MCP reload/restart action if available; otherwise restart the client session.

--- a/docs/config/local.md
+++ b/docs/config/local.md
@@ -75,4 +75,4 @@ See [multi-destination routing](https://github.com/bikky-dev/bikky/blob/main/doc
 bikky status
 ```
 
-If you started from a fresh install, run `bikky setup` after writing the config, then restart your editor so its MCP process reloads.
+If you started from a fresh install, run `bikky setup` after writing the config. Then reload the MCP server from your client: in GitHub Copilot CLI, run `/restart`; in Claude Code, restart Claude Code and run `claude --continue` or `claude -c` to resume. For other stdio MCP clients, use their MCP reload/restart action if available; otherwise restart the client session.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -135,7 +135,9 @@ After changing Qdrant or provider settings, restart long-running processes:
 bikky stop && bikky start
 ```
 
-Then restart your editor so its MCP server process reloads the config.
+Then reload the MCP server from your client: in GitHub Copilot CLI, run `/restart`; in Claude Code, restart Claude Code and run `claude --continue` or `claude -c` to resume. For other stdio MCP clients, use their MCP reload/restart action if available; otherwise restart the client session.
+
+When you run `bikky setup`, bikky detects running `bikky mcp` server processes and prints this guidance. It does not terminate client-owned MCP processes because stdio MCP clients must relaunch their own server subprocesses.
 
 ## Environment variables
 

--- a/docs/privacy-first.md
+++ b/docs/privacy-first.md
@@ -105,7 +105,7 @@ If you change providers, watcher settings, or `daemon.extract_every_sec`, restar
 bikky stop && bikky start
 ```
 
-Restart your editor after setup so its MCP server process reloads the config.
+Reload the MCP server from your client: in GitHub Copilot CLI, run `/restart`; in Claude Code, restart Claude Code and run `claude --continue` or `claude -c` to resume. For other stdio MCP clients, use their MCP reload/restart action if available; otherwise restart the client session.
 
 ## What can leave your machine
 
@@ -138,3 +138,15 @@ Then restart bikky:
 ```bash
 bikky stop && bikky start
 ```
+
+## Per-session opt-out
+
+For temporary privacy without changing config, use the `memory_pause` MCP tool during a session:
+
+```
+memory_pause({ reason: "sensitive discussion", session_id: "<UUID>" })
+```
+
+This blocks all memory writes (MCP and daemon extraction) for that session only. Other sessions continue normally. Call `memory_resume` when you're ready to re-enable writes.
+
+See the [README § Per-session pause](../README.md#per-session-pause) for details on the `session_id` parameter.

--- a/src/daemon/extraction.ts
+++ b/src/daemon/extraction.ts
@@ -13,6 +13,7 @@ import { join } from "node:path";
 
 import { STATE_DIR, EXTRACTION_HEALTH_PATH } from "../config.js";
 import type { BikkyConfig } from "../config.js";
+import { isSessionPaused } from "../paused-sessions.js";
 import * as qdrant from "./qdrant.js";
 import { chatCompletion } from "../llm/index.js";
 import { detectContradiction } from "./consolidation.js";
@@ -908,6 +909,11 @@ const extractForMapping = async (
   const { uuid, eventsPath, source } = mapping;
   const stateKey = extractionStateKey(mapping);
   const label = transcriptLabel(mapping);
+
+  // Skip extraction if this session has been paused via memory_pause
+  if (isSessionPaused(stateKey)) {
+    return 0;
+  }
 
   let state = getExtractionState(stateKey);
   if (!state) {

--- a/src/install.ts
+++ b/src/install.ts
@@ -166,5 +166,5 @@ export async function writeInstallConfig(options: InstallOptions = {}): Promise<
     provisionUserIdentityConfig(options);
   }
 
-  console.log("\n🧠 bikky is now registered. Restart your editor to activate.");
+  console.log("\n🧠 bikky is now registered.");
 }

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -57,6 +57,10 @@ export interface DaemonStatus {
   pid: number | null;
 }
 
+export interface StartAllOptions {
+  reportMcpServers?: boolean;
+}
+
 export function getDaemonStatus(): DaemonStatus {
   const pid = readPid();
   if (pid && isProcessAlive(pid)) {
@@ -119,12 +123,18 @@ export function killDaemon(): boolean {
 /**
  * Full startup sequence: install MCP configs + launch daemon.
  */
-export async function startAll(): Promise<void> {
+export async function startAll(options: StartAllOptions = {}): Promise<void> {
   // 1. Write MCP configs
   const { writeInstallConfig } = await import("./install.js");
   await writeInstallConfig();
 
-  // 2. Launch daemon
+  // 2. Warn about already-running client-owned MCP server processes.
+  if (options.reportMcpServers !== false) {
+    const { reportRunningBikkyMcpServers } = await import("./mcp-processes.js");
+    reportRunningBikkyMcpServers();
+  }
+
+  // 3. Launch daemon
   const status = getDaemonStatus();
   if (status.running) {
     console.log(`\n🟢 Daemon already running (PID ${status.pid})`);
@@ -138,5 +148,5 @@ export async function startAll(): Promise<void> {
   }
 
   console.log("\n✨ bikky is ready — daemon running, MCP configs installed.");
-  console.log("   Restart your editor to activate the MCP server.");
+  console.log("   GitHub Copilot CLI: run /restart. Claude Code: restart, then resume with claude --continue or claude -c.");
 }

--- a/src/mcp-processes.test.ts
+++ b/src/mcp-processes.test.ts
@@ -1,0 +1,121 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isBikkyMcpCommand,
+  parsePsOutput,
+  reportRunningBikkyMcpServers,
+  splitCommandLine,
+  type McpProcessDetectionResult,
+} from "./mcp-processes.js";
+
+const processes = (...pids: number[]): McpProcessDetectionResult => ({
+  processes: pids.map((pid) => ({ pid, command: `npx -y bikky mcp # ${pid}` })),
+});
+
+const logger = (): Pick<Console, "log" | "warn"> & { lines: string[]; warnings: string[] } => {
+  const lines: string[] = [];
+  const warnings: string[] = [];
+  return {
+    lines,
+    warnings,
+    log: (message?: unknown): void => {
+      lines.push(String(message ?? ""));
+    },
+    warn: (message?: unknown): void => {
+      warnings.push(String(message ?? ""));
+    },
+  };
+};
+
+describe("MCP process detection", () => {
+  it("splits shell-like command lines", () => {
+    assert.deepStrictEqual(splitCommandLine("npx -y 'bikky@latest' mcp"), ["npx", "-y", "bikky@latest", "mcp"]);
+    assert.deepStrictEqual(splitCommandLine('node "/tmp/node_modules/bikky/bin/bikky.js" mcp'), [
+      "node",
+      "/tmp/node_modules/bikky/bin/bikky.js",
+      "mcp",
+    ]);
+  });
+
+  it("matches common bikky mcp invocations", () => {
+    assert.equal(isBikkyMcpCommand("bikky mcp"), true);
+    assert.equal(isBikkyMcpCommand("npx -y bikky mcp"), true);
+    assert.equal(isBikkyMcpCommand("npx --yes bikky@latest mcp"), true);
+    assert.equal(isBikkyMcpCommand("node /Users/saber/code/bikky/dist/cli.js mcp"), true);
+    assert.equal(isBikkyMcpCommand("node /tmp/node_modules/bikky/bin/bikky.js mcp"), true);
+  });
+
+  it("does not match non-Bikky MCP servers or other bikky commands", () => {
+    assert.equal(isBikkyMcpCommand("github-mcp-server stdio"), false);
+    assert.equal(isBikkyMcpCommand("npx -y filesystem-mcp mcp"), false);
+    assert.equal(isBikkyMcpCommand("bikky setup"), false);
+    assert.equal(isBikkyMcpCommand("bikky daemon"), false);
+  });
+
+  it("parses ps output and skips the current process", () => {
+    const output = `
+      111 npx -y bikky mcp
+      222 github-mcp-server stdio
+      333 bikky setup
+      444 node /tmp/node_modules/bikky/bin/bikky.js mcp
+    `;
+
+    assert.deepStrictEqual(parsePsOutput(output, 444), [
+      { pid: 111, command: "npx -y bikky mcp" },
+    ]);
+  });
+});
+
+describe("reportRunningBikkyMcpServers", () => {
+  it("reports detected bikky MCP processes with reload guidance", () => {
+    const logs = logger();
+
+    const result = reportRunningBikkyMcpServers({
+      detectProcesses: () => processes(123, 456),
+      logger: logs,
+    });
+
+    assert.deepStrictEqual(result, { detected: 2 });
+    assert.match(logs.lines.join("\n"), /Found 2 running bikky MCP server processes/);
+    assert.match(logs.warnings.join("\n"), /does not terminate client-owned MCP server processes/);
+    assert.match(logs.warnings.join("\n"), /GitHub Copilot CLI users should run \/restart/);
+    assert.match(logs.warnings.join("\n"), /Claude Code users should restart Claude Code/);
+  });
+
+  it("does not prompt or terminate processes", () => {
+    const logs = logger();
+
+    const result = reportRunningBikkyMcpServers({
+      detectProcesses: () => processes(123),
+      logger: logs,
+    });
+
+    assert.deepStrictEqual(result, { detected: 1 });
+    assert.doesNotMatch(logs.lines.concat(logs.warnings).join("\n"), /Type y|yes to continue|Terminated/);
+  });
+
+  it("stays quiet when no bikky MCP processes are running", () => {
+    const logs = logger();
+    const result = reportRunningBikkyMcpServers({
+      detectProcesses: () => ({ processes: [] }),
+      logger: logs,
+    });
+
+    assert.deepStrictEqual(result, { detected: 0, skippedReason: "not_found" });
+    assert.deepStrictEqual(logs.lines, []);
+    assert.deepStrictEqual(logs.warnings, []);
+  });
+
+  it("warns and skips when process detection fails", () => {
+    const logs = logger();
+
+    const result = reportRunningBikkyMcpServers({
+      detectProcesses: () => ({ processes: [], error: "ps unavailable" }),
+      logger: logs,
+    });
+
+    assert.deepStrictEqual(result, { detected: 0, skippedReason: "detect_failed" });
+    assert.match(logs.warnings.join("\n"), /ps unavailable/);
+  });
+});

--- a/src/mcp-processes.ts
+++ b/src/mcp-processes.ts
@@ -1,0 +1,147 @@
+import { spawnSync } from "node:child_process";
+export interface BikkyMcpProcess {
+  pid: number;
+  command: string;
+}
+
+export interface McpProcessDetectionResult {
+  processes: BikkyMcpProcess[];
+  error?: string;
+}
+
+export interface ReportRunningBikkyMcpServersResult {
+  detected: number;
+  skippedReason?: "not_found" | "detect_failed";
+}
+
+export interface ReportRunningBikkyMcpServersOptions {
+  detectProcesses?: () => McpProcessDetectionResult;
+  currentPid?: number;
+  logger?: Pick<Console, "log" | "warn">;
+}
+
+const truncateCommand = (command: string): string => {
+  const maxLength = 160;
+  return command.length > maxLength ? `${command.slice(0, maxLength - 1)}...` : command;
+};
+
+const unquote = (token: string): string => {
+  if (token.length < 2) return token;
+  const first = token[0];
+  const last = token[token.length - 1];
+  if ((first === "\"" && last === "\"") || (first === "'" && last === "'")) {
+    return token.slice(1, -1);
+  }
+  return token;
+};
+
+export const splitCommandLine = (command: string): string[] => {
+  const tokens: string[] = [];
+  const pattern = /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^']*)'|(\S+)/g;
+  for (const match of command.matchAll(pattern)) {
+    const token = match[1] ?? match[2] ?? match[3];
+    if (token) tokens.push(unquote(token));
+  }
+  return tokens;
+};
+
+const normalizedToken = (token: string): string => token.replace(/\\/g, "/").toLowerCase();
+
+const baseName = (token: string): string => {
+  const normalized = normalizedToken(token);
+  const base = normalized.slice(normalized.lastIndexOf("/") + 1);
+  return base.endsWith(".cmd") ? base.slice(0, -4) : base;
+};
+
+const isBikkyPackageToken = (token: string): boolean => {
+  const base = baseName(token);
+  return base === "bikky" || base === "bikky.js" || /^bikky@[\w.-]+$/.test(base);
+};
+
+const isBikkyCliPath = (token: string): boolean => {
+  const normalized = normalizedToken(token);
+  if (!normalized.includes("/bikky/") && !normalized.includes("/node_modules/bikky/")) return false;
+  return normalized.endsWith("/bin/bikky.js") || normalized.endsWith("/dist/cli.js");
+};
+
+export const isBikkyMcpCommand = (command: string): boolean => {
+  const tokens = splitCommandLine(command);
+  for (let index = 0; index < tokens.length - 1; index += 1) {
+    const token = tokens[index];
+    if (!token) continue;
+    if ((isBikkyPackageToken(token) || isBikkyCliPath(token)) && tokens[index + 1] === "mcp") {
+      return true;
+    }
+  }
+  return false;
+};
+
+export const parsePsOutput = (output: string, currentPid = process.pid): BikkyMcpProcess[] => {
+  const processes: BikkyMcpProcess[] = [];
+  for (const line of output.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const match = /^(\d+)\s+(.+)$/.exec(trimmed);
+    if (!match) continue;
+    const pid = Number.parseInt(match[1], 10);
+    if (!Number.isFinite(pid) || pid === currentPid) continue;
+    const command = match[2];
+    if (command && isBikkyMcpCommand(command)) {
+      processes.push({ pid, command });
+    }
+  }
+  return processes;
+};
+
+export const detectRunningBikkyMcpServers = (currentPid = process.pid): McpProcessDetectionResult => {
+  const result = spawnSync("ps", ["-axo", "pid=,command="], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (result.error) {
+    return { processes: [], error: result.error.message };
+  }
+
+  if (result.status !== 0) {
+    const detail = typeof result.stderr === "string" && result.stderr.trim()
+      ? result.stderr.trim()
+      : `ps exited with status ${result.status ?? "unknown"}`;
+    return { processes: [], error: detail };
+  }
+
+  return { processes: parsePsOutput(result.stdout, currentPid) };
+};
+
+const MCP_RELOAD_GUIDANCE = [
+  "To use updated bikky MCP code: GitHub Copilot CLI users should run /restart in the Copilot CLI session.",
+  "Claude Code users should restart Claude Code, then run claude --continue or claude -c to resume.",
+  "Other stdio MCP clients should use their MCP reload/restart action if available; otherwise restart the client session.",
+].join(" ");
+
+export const reportRunningBikkyMcpServers = (
+  options: ReportRunningBikkyMcpServersOptions = {},
+): ReportRunningBikkyMcpServersResult => {
+  const logger = options.logger ?? console;
+  const detection = options.detectProcesses
+    ? options.detectProcesses()
+    : detectRunningBikkyMcpServers(options.currentPid);
+
+  if (detection.error) {
+    logger.warn(`⚠️  Could not detect running bikky MCP servers: ${detection.error}`);
+    return { detected: 0, skippedReason: "detect_failed" };
+  }
+
+  const processes = detection.processes;
+  if (processes.length === 0) {
+    return { detected: 0, skippedReason: "not_found" };
+  }
+
+  logger.log(`\n🔁 Found ${processes.length} running bikky MCP server process${processes.length === 1 ? "" : "es"}:`);
+  for (const proc of processes) {
+    logger.log(`   PID ${proc.pid}: ${truncateCommand(proc.command)}`);
+  }
+
+  logger.warn(`⚠️  bikky setup does not terminate client-owned MCP server processes. ${MCP_RELOAD_GUIDANCE}`);
+  return { detected: processes.length };
+};

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -78,6 +78,7 @@ import {
   redactStorageText,
 } from "../privacy/redaction.js";
 import { buildMemoryRoutingInput } from "../routing-context.js";
+import { pauseSession, resumeSession } from "../paused-sessions.js";
 
 // ---------------------------------------------------------------------------
 // Runtime state
@@ -89,6 +90,8 @@ const MEMORY_RECALL_MAX_LIMIT = 50;
 const searchScopeSchema = z.union([z.string(), z.array(z.string())]).optional();
 let lastStoreTime = Date.now();
 let heartbeatCount = 0;
+let sessionPaused = false;
+let sessionPauseReason: string | null = null;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -471,6 +474,22 @@ function requireReady(): McpToolResult | null {
             "2. Create a cluster → copy the REST URL and API key\n" +
             "3. Call configure_credentials with Qdrant values",
           next_step: "Call get_setup_status for detailed status, or configure_credentials to set up.",
+        }, null, 2),
+      }],
+    };
+  }
+  return null;
+}
+
+function requireNotPaused(): McpToolResult | null {
+  if (sessionPaused) {
+    return {
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          status: "session_paused",
+          reason: sessionPauseReason ?? "User requested no memory writes for this session.",
+          hint: "Call memory_resume to re-enable memory writes.",
         }, null, 2),
       }],
     };
@@ -929,6 +948,8 @@ export function registerTools(mcp: McpServer): void {
     }): Promise<McpToolResult> => {
       const guard = requireReady();
       if (guard) return guard;
+      const pauseGuard = requireNotPaused();
+      if (pauseGuard) return pauseGuard;
       lastStoreTime = Date.now();
       const now = nowISO();
       const normalizedKind = normalizeKind(kind);
@@ -1781,6 +1802,8 @@ export function registerTools(mcp: McpServer): void {
     async ({ fact_id, reason, workspace_id: _workspace_id }): Promise<McpToolResult> => {
       const guard = requireReady();
       if (guard) return guard;
+      const pauseGuard = requireNotPaused();
+      if (pauseGuard) return pauseGuard;
       const now = nowISO();
       try {
         const located = await locatePoint(fact_id);
@@ -1833,6 +1856,8 @@ export function registerTools(mcp: McpServer): void {
     async ({ fact_id, workspace_id: _workspace_id }): Promise<McpToolResult> => {
       const guard = requireReady();
       if (guard) return guard;
+      const pauseGuard = requireNotPaused();
+      if (pauseGuard) return pauseGuard;
       const now = nowISO();
       try {
         const located = await locatePoint(fact_id);
@@ -1885,6 +1910,8 @@ export function registerTools(mcp: McpServer): void {
     async ({ fact_id, note, workspace_id: _workspace_id }): Promise<McpToolResult> => {
       const guard = requireReady();
       if (guard) return guard;
+      const pauseGuard = requireNotPaused();
+      if (pauseGuard) return pauseGuard;
       const now = nowISO();
       try {
         const located = await locatePoint(fact_id);
@@ -1991,6 +2018,8 @@ export function registerTools(mcp: McpServer): void {
     async ({ fact_id, outcome, notes, workspace_id: _workspace_id }): Promise<McpToolResult> => {
       const guard = requireReady();
       if (guard) return guard;
+      const pauseGuard = requireNotPaused();
+      if (pauseGuard) return pauseGuard;
       const now = nowISO();
       try {
         const located = await locatePoint(fact_id);
@@ -2095,6 +2124,8 @@ export function registerTools(mcp: McpServer): void {
     async ({ content, entities, episode_id, workstream_key, task_key, repo, workspace_id: _workspace_id, destination }): Promise<McpToolResult> => {
       const guard = requireReady();
       if (guard) return guard;
+      const pauseGuard = requireNotPaused();
+      if (pauseGuard) return pauseGuard;
       lastStoreTime = Date.now();
       const now = nowISO();
       try {
@@ -2203,6 +2234,8 @@ export function registerTools(mcp: McpServer): void {
     async ({ content, entities, supersedes, task_key, repo, workspace_id: _workspace_id, destination }): Promise<McpToolResult> => {
       const guard = requireReady();
       if (guard) return guard;
+      const pauseGuard = requireNotPaused();
+      if (pauseGuard) return pauseGuard;
       lastStoreTime = Date.now();
       const now = nowISO();
       try {
@@ -2364,6 +2397,10 @@ export function registerTools(mcp: McpServer): void {
         return { content: [{ type: "text", text: "Error: fact_id is required for approve/reject/correct actions." }] };
       }
 
+      // Write actions require session not paused
+      const pauseGuard = requireNotPaused();
+      if (pauseGuard) return pauseGuard;
+
       const now = nowISO();
 
       if (action === "approve") {
@@ -2506,6 +2543,97 @@ export function registerTools(mcp: McpServer): void {
     },
   );
 
+  // ── memory_pause ─────────────────────────────────────────────────────────
+
+  mcp.tool(
+    "memory_pause",
+    [
+      "Pause all memory writes for the current session. While paused, memory_store, memory_session_summary, memory_distill, memory_verify, memory_forget, memory_mark_useful, memory_report_outcome, and memory_review (write actions) will return a session_paused status instead of executing.",
+      "Read operations (memory_recall, memory_entity, memory_relations, memory_heartbeat) remain fully functional.",
+      "Use when the user says something like 'do not remember anything from this session' or 'pause memory'. Call memory_resume to re-enable writes.",
+    ].join(" "),
+    {
+      reason: z.string().optional().describe(
+        "Optional reason for pausing (e.g. 'user requested private session'). Included in the paused status response.",
+      ),
+      session_id: z.string().optional().describe(
+        "The session UUID (e.g. from the session folder path). When provided, also signals the daemon to skip extraction for this session. " +
+        "For Copilot sessions, pass the UUID from ~/.copilot/session-state/<UUID>/. Format: just the UUID, the 'uuid:' prefix is added automatically.",
+      ),
+    },
+    async ({ reason, session_id }): Promise<McpToolResult> => {
+      sessionPaused = true;
+      sessionPauseReason = reason ?? "User requested no memory writes for this session.";
+      log("INFO", `Memory writes paused: ${sessionPauseReason}`);
+
+      let daemonPaused = false;
+      if (session_id) {
+        const key = session_id.includes(":") ? session_id : `uuid:${session_id}`;
+        pauseSession(key, sessionPauseReason);
+        daemonPaused = true;
+        log("INFO", `Daemon extraction paused for session: ${key}`);
+      }
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            status: "paused",
+            reason: sessionPauseReason,
+            daemon_paused: daemonPaused,
+            hint: daemonPaused
+              ? "All memory writes blocked (MCP + daemon extraction). Reads still work. Call memory_resume to re-enable."
+              : "MCP memory writes blocked. Daemon extraction NOT paused (no session_id provided). Reads still work. Call memory_resume to re-enable.",
+          }, null, 2),
+        }],
+      };
+    },
+  );
+
+  // ── memory_resume ────────────────────────────────────────────────────────
+
+  mcp.tool(
+    "memory_resume",
+    [
+      "Resume memory writes after a previous memory_pause. All write operations will function normally again.",
+      "No-op if memory is not currently paused.",
+    ].join(" "),
+    {
+      session_id: z.string().optional().describe(
+        "The session UUID passed to memory_pause. Required to also resume daemon extraction. Same format as memory_pause.",
+      ),
+    },
+    async ({ session_id }): Promise<McpToolResult> => {
+      const wasPaused = sessionPaused;
+      sessionPaused = false;
+      sessionPauseReason = null;
+      log("INFO", "Memory writes resumed");
+
+      let daemonResumed = false;
+      if (session_id) {
+        const key = session_id.includes(":") ? session_id : `uuid:${session_id}`;
+        daemonResumed = resumeSession(key);
+        if (daemonResumed) {
+          log("INFO", `Daemon extraction resumed for session: ${key}`);
+        }
+      }
+
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            status: "resumed",
+            was_paused: wasPaused,
+            daemon_resumed: daemonResumed,
+            hint: wasPaused
+              ? "Memory writes are now re-enabled. All store/verify/forget operations will work normally."
+              : "Memory was not paused — no change needed.",
+          }, null, 2),
+        }],
+      };
+    },
+  );
+
   // ── memory_heartbeat ────────────────────────────────────────────────────
 
   mcp.tool(
@@ -2519,8 +2647,12 @@ export function registerTools(mcp: McpServer): void {
       heartbeatCount++;
       const sections: string[] = [];
 
+      if (sessionPaused) {
+        sections.push(`⏸️ Memory writes are **paused** for this session (reason: ${sessionPauseReason ?? "user request"}). Call memory_resume to re-enable.`);
+      }
+
       const nudge = buildMemoryNudge();
-      if (nudge) sections.push(nudge);
+      if (nudge && !sessionPaused) sections.push(nudge);
 
       if (heartbeatCount % 3 === 0 && ready) {
         try {
@@ -2563,13 +2695,15 @@ export function registerTools(mcp: McpServer): void {
         }
       }
 
-      sections.push(
-        "🔍 Reflect: think about the LAST 10 minutes of work and answer in your head:\n" +
-        "  1. Did you touch engineering context: code, infra, ops, access, troubleshooting, conventions, preferences, ownership, working agreements, or durable activity events?\n" +
-        "  2. Did you capture product context: a requirement, decision, workflow, roadmap item, metric, or market insight?\n" +
-        "  3. Did the work produce system context: session, episode, workstream, recall, feedback, outcome, or rollup state?\n" +
-        "If any answer is yes, call memory_store now — one atomic fact per item, with category/domain/entities.",
-      );
+      if (!sessionPaused) {
+        sections.push(
+          "🔍 Reflect: think about the LAST 10 minutes of work and answer in your head:\n" +
+          "  1. Did you touch engineering context: code, infra, ops, access, troubleshooting, conventions, preferences, ownership, working agreements, or durable activity events?\n" +
+          "  2. Did you capture product context: a requirement, decision, workflow, roadmap item, metric, or market insight?\n" +
+          "  3. Did the work produce system context: session, episode, workstream, recall, feedback, outcome, or rollup state?\n" +
+          "If any answer is yes, call memory_store now — one atomic fact per item, with category/domain/entities.",
+        );
+      }
 
       return { content: [{ type: "text", text: sections.join("\n\n") }] };
     },

--- a/src/paused-sessions.ts
+++ b/src/paused-sessions.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared paused-sessions file management.
+ *
+ * Both the MCP server (memory_pause/resume tools) and the daemon (extraction tick)
+ * use this module. The MCP server writes pause/resume state; the daemon reads it
+ * to skip extraction for paused sessions.
+ *
+ * File: ~/.bikky/state/paused-sessions.json
+ * Format: { "uuid:<UUID>": { reason, paused_at }, ... }
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { getStateDir } from "./config.js";
+
+export interface PausedSessionEntry {
+  reason: string;
+  paused_at: string; // ISO timestamp
+}
+
+export type PausedSessionsFile = Record<string, PausedSessionEntry>;
+
+const FILENAME = "paused-sessions.json";
+
+const filePath = (): string => join(getStateDir(), FILENAME);
+
+export const readPausedSessions = (): PausedSessionsFile => {
+  try {
+    const raw = readFileSync(filePath(), "utf-8");
+    return JSON.parse(raw) as PausedSessionsFile;
+  } catch {
+    return {};
+  }
+};
+
+export const writePausedSessions = (data: PausedSessionsFile): void => {
+  const dir = getStateDir();
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(filePath(), JSON.stringify(data, null, 2), "utf-8");
+};
+
+/**
+ * Add a session to the paused list. The key should match the daemon's
+ * extractionStateKey format: "uuid:<UUID>" for copilot, "claude:<UUID>" for claude.
+ */
+export const pauseSession = (sessionKey: string, reason: string): void => {
+  const data = readPausedSessions();
+  data[sessionKey] = { reason, paused_at: new Date().toISOString() };
+  writePausedSessions(data);
+};
+
+/**
+ * Remove a session from the paused list.
+ */
+export const resumeSession = (sessionKey: string): boolean => {
+  const data = readPausedSessions();
+  if (!(sessionKey in data)) return false;
+  delete data[sessionKey];
+  writePausedSessions(data);
+  return true;
+};
+
+/**
+ * Check if a session key is currently paused.
+ */
+export const isSessionPaused = (sessionKey: string): boolean => {
+  const data = readPausedSessions();
+  return sessionKey in data;
+};

--- a/src/postinstall.ts
+++ b/src/postinstall.ts
@@ -8,7 +8,7 @@
 async function postinstall(): Promise<void> {
   try {
     const { startAll } = await import("./lifecycle.js");
-    await startAll();
+    await startAll({ reportMcpServers: false });
   } catch {
     // Silent — don't break npm install
   }

--- a/tasks/007-notion-memory-plan-update/execution-log.md
+++ b/tasks/007-notion-memory-plan-update/execution-log.md
@@ -1,0 +1,41 @@
+# Execution Log: notion-memory-plan-update
+
+## Status
+
+| Phase | Step | State | Next | Blockers |
+|-------|------|-------|------|----------|
+| complete | Notion board and plan updated | done | None | Created Done E5 task rows T-E5-04/T-E5-05 and appended Bikky HQ progress note |
+
+## Implementation Progress
+
+- [x] Confirm target: Bikky project board for Memory UI work
+- [x] Confirm update semantics: mark completed Playwright/filter work done and add PR #155/#166 notes/links to the plan
+- [x] Search related task folders and memory context
+- [x] Locate relevant Notion board/database and plan page
+- [x] Update board statuses
+- [x] Update plan notes with PR links
+
+## Timeline
+
+- 2026-05-12 11:01 AEST — User requested updating the Notion board and plan.
+- 2026-05-12 11:04 AEST — User confirmed target as the Bikky project board for Memory UI work.
+- 2026-05-12 11:05 AEST — User confirmed desired update: mark done and add PR notes/links.
+- 2026-05-12 11:06 AEST — Notion API search failed with 401 unauthorized because the API token is invalid.
+- 2026-05-12 11:10 AEST — User pointed to 1Password; structured `agent00/notion-api-key` credential field validated as the `synapse-agent` Notion bot.
+- 2026-05-12 11:15 AEST — Located Bikky Tasks/Epics databases and found E5 memory quality tasks, but no dedicated PR #155/#166 task rows.
+- 2026-05-12 11:20 AEST — User approved creating dedicated Done E5 task rows instead of marking broader T-E5-03 done.
+- 2026-05-12 11:25 AEST — Created/verified `T-E5-04` and `T-E5-05` as Done in the Bikky Tasks board and appended `Memory UI filter/Playwright progress` to Bikky HQ.
+
+## Notion updates applied
+
+- `T-E5-04 - Add Memory UI filter Playwright coverage`
+  - Notion page: `35e88a57-98a3-81c6-a90a-fd95705c8e88`
+  - Status: `Done`
+  - PR: <https://github.com/bikky-dev/bikky/pull/155>
+  - Issue: <https://github.com/bikky-dev/bikky/issues/154>
+- `T-E5-05 - Add Memory UI Playwright edge-case coverage`
+  - Notion page: `35e88a57-98a3-8164-a3a9-ca635021c3ce`
+  - Status: `Done`
+  - PR: <https://github.com/bikky-dev/bikky/pull/166>
+  - Issue: <https://github.com/bikky-dev/bikky/issues/165>
+- Bikky HQ page `34d88a57-98a3-816c-815d-fc24cf7cb446` now has a `Memory UI filter/Playwright progress` section.

--- a/tasks/007-notion-memory-plan-update/plan.md
+++ b/tasks/007-notion-memory-plan-update/plan.md
@@ -1,0 +1,37 @@
+# Plan: Notion Memory Plan Update
+
+## Problem
+
+The Memory UI Playwright/filter work has been completed and merged, but the Bikky Notion project board and related plan need to reflect the current state.
+
+## Applied changes
+
+1. Created a completed Bikky Tasks row under E5 for PR #155:
+   - title: `T-E5-04 - Add Memory UI filter Playwright coverage`
+   - status: `Done`
+   - priority: `P1`
+   - type: `Feature`
+   - issue: #154
+   - PR: #155
+2. Created a completed Bikky Tasks row under E5 for PR #166:
+   - title: `T-E5-05 - Add Memory UI Playwright edge-case coverage`
+   - status: `Done`
+   - priority: `P1`
+   - type: `Feature`
+   - issue: #165
+   - PR: #166
+3. Left T-E5-03 open, because its scope is broader (`Build quality dashboard and review queues`).
+4. Appended a concise progress note to the Bikky HQ plan page summarizing:
+   - PR #155: <https://github.com/bikky-dev/bikky/pull/155>
+   - PR #166: <https://github.com/bikky-dev/bikky/pull/166>
+5. Verified the updated board/plan state by reading the changed Notion records.
+
+## Current access note
+
+Use the valid Notion token from the structured 1Password JSON field value in `agent00/notion-api-key` (`credential`). Do not print or store the token.
+
+## Out of scope
+
+- Changing GitHub issues/PRs.
+- Creating new roadmap scope beyond recording the completed work.
+- Updating unrelated Notion roadmap items.

--- a/tasks/007-notion-memory-plan-update/research.md
+++ b/tasks/007-notion-memory-plan-update/research.md
@@ -1,0 +1,70 @@
+# Research: Notion Memory Plan Update
+
+## Request
+
+Update the Bikky project board for Memory UI work and the related plan.
+
+Confirmed desired update:
+
+- Mark the completed Memory UI Playwright/filter work as done.
+- Add notes/links for PR #155 and PR #166 to the plan.
+
+## Context
+
+Recent completed work:
+
+- PR #155: `test: cover Memory UI filters with Playwright`
+  - merged to `main` at `64ef070`
+  - closed issue #154
+  - added explicit Playwright E2E coverage for Memory UI filters
+  - added visible Entity filter and accessible filter labels
+  - fixed search requests to forward `since` / `until`
+- PR #166: `test: add Memory Playwright edge cases`
+  - merged to `main` at `108c9bc`
+  - closed issue #165
+  - added Memory UI Playwright edge-case coverage for URL-preloaded filters, individual filter clearing, browse load-more pagination, empty state, and API error state
+  - updated active filter clear buttons to include filter values in accessible labels
+
+## Access resolution
+
+The built-in Notion API tool is still configured with an invalid token. The valid token is available in 1Password:
+
+- vault: `agent00`
+- item: `notion-api-key`
+- field: structured JSON field `credential`
+- bot identity: `synapse-agent`
+
+Do not use `op item get ... --fields credential` for this item; that returned an invalid/incorrect value shape during research. Use the structured JSON field value instead:
+
+```bash
+op item get cmqh7fwcsk3kwanzvsp7hgguoy --vault agent00 --format json \
+  | jq -r '.fields[] | select(.id=="credential").value'
+```
+
+## Notion records found
+
+- `Bikky Tasks`: `35988a57-98a3-81a7-81aa-f50e41a01531`
+- `Bikky Epics`: `35988a57-98a3-8140-b7ec-e902ce296463`
+- `Bikky HQ`: `34d88a57-98a3-816c-815d-fc24cf7cb446`
+- E5 epic: `35988a57-98a3-8155-a81e-e38863bf2c66` — `E5 - Memory quality, telemetry, and review UX`
+- T-E5-03: `35988a57-98a3-8197-8e04-e4b5a3dbe94e` — `Build quality dashboard and review queues`
+
+## Finding
+
+The board has E5 memory-quality/review tasks, but no dedicated task rows for PR #155 or PR #166. T-E5-03 is related UI work but broader than the completed Memory filter/test work, so marking T-E5-03 done would overstate roadmap completion.
+
+## Recommended next step
+
+Create dedicated Done task rows under E5 for the two completed Memory UI Playwright/filter deliverables, and append a concise progress note to the Bikky HQ plan page with PR links.
+
+## Applied update
+
+- Created/verified `T-E5-04 - Add Memory UI filter Playwright coverage` as Done:
+  - page: `35e88a57-98a3-81c6-a90a-fd95705c8e88`
+  - PR: <https://github.com/bikky-dev/bikky/pull/155>
+  - issue: <https://github.com/bikky-dev/bikky/issues/154>
+- Created/verified `T-E5-05 - Add Memory UI Playwright edge-case coverage` as Done:
+  - page: `35e88a57-98a3-8164-a3a9-ca635021c3ce`
+  - PR: <https://github.com/bikky-dev/bikky/pull/166>
+  - issue: <https://github.com/bikky-dev/bikky/issues/165>
+- Appended `Memory UI filter/Playwright progress` to Bikky HQ `34d88a57-98a3-816c-815d-fc24cf7cb446`.


### PR DESCRIPTION
## Changes

- Add `memory_pause` and `memory_resume` MCP tools for per-session opt-out
- Pause guards block all write tools; reads remain functional
- Optional `session_id` param signals daemon via `paused-sessions.json`
- Add `isSessionPaused` check in daemon `extractForMapping()`
- New shared module: `src/paused-sessions.ts`
- MCP process detection utilities (`src/mcp-processes.ts`)
- Docs: README, CHANGELOG, privacy-first.md, configuration.md

## Testing

- All 641 tests pass
- TypeScript compiles clean